### PR TITLE
Add controller & agent unit tests; fix honker ack/retry worker-id bug

### DIFF
--- a/agent/tests/test_cli.py
+++ b/agent/tests/test_cli.py
@@ -1,0 +1,126 @@
+from types import SimpleNamespace
+
+import pytest
+
+from lab_agent import cli
+from lab_agent.config import AgentConfig
+
+
+def test_build_parser_registers_subcommands():
+    parser = cli.build_parser()
+    args = parser.parse_args(["doctor"])
+    assert args.command == "doctor"
+    assert args.func is cli._cmd_doctor
+
+
+def test_no_subcommand_exits():
+    with pytest.raises(SystemExit):
+        cli.main([])
+
+
+def test_run_loads_config_and_starts_agent(monkeypatch):
+    import lab_agent.client as client
+
+    cfg = AgentConfig(controller_url="ws://x", token="t")
+    monkeypatch.setattr(cli, "load_config", lambda path: cfg)
+    started = {}
+    monkeypatch.setattr(client, "run_agent", lambda c: started.setdefault("cfg", c))
+    assert cli.main(["run"]) == 0
+    assert started["cfg"] is cfg
+
+
+def test_install_builds_config_from_flags_and_calls_installer(monkeypatch, capsys):
+    import lab_agent.installer as installer
+
+    captured = {}
+
+    def fake_install(cfg, config_path, *, enable):
+        captured["cfg"] = cfg
+        captured["enable"] = enable
+        return {"config": str(config_path), "status": "written (not enabled)"}
+
+    monkeypatch.setattr(installer, "install", fake_install)
+    rc = cli.main([
+        "install",
+        "--controller", "wss://ctl:8443",
+        "--token", "secret",
+        "--node-name", "node-7",
+        "--slow-backend", "smb",
+        "--slow-path", "/mnt/cold",
+        "--slow-shared",
+        "--no-verify-tls",
+        "--no-enable",
+    ])
+    assert rc == 0
+    cfg = captured["cfg"]
+    assert cfg.controller_url == "wss://ctl:8443"
+    assert cfg.token == "secret"
+    assert cfg.node_name == "node-7"
+    assert cfg.slow_backend == "smb"
+    assert cfg.slow_path == "/mnt/cold"
+    assert cfg.slow_shared is True
+    assert cfg.tls_verify is False
+    assert captured["enable"] is False
+    assert "status:" in capsys.readouterr().out
+
+
+def test_install_enables_by_default(monkeypatch):
+    import lab_agent.installer as installer
+
+    captured = {}
+
+    def fake_install(cfg, path, *, enable):
+        captured["enable"] = enable
+        return {}
+
+    monkeypatch.setattr(installer, "install", fake_install)
+    cli.main(["install", "--controller", "ws://c", "--token", "t"])
+    assert captured["enable"] is True
+
+
+def _caps(issues):
+    fields = dict(
+        zfs=True, docker=True, docker_zfs_driver=True, nvidia_runtime=False, nvidia_gpu=False,
+        gpu_count=0, fast_pool_present=True, slow_pool_present=True, slow_backend="zfs",
+        slow_shared=False, issues=issues,
+    )
+    return SimpleNamespace(issues=issues, to_dict=lambda: fields)
+
+
+def test_doctor_returns_zero_when_healthy(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "load_config", lambda path: AgentConfig(controller_url="w", token="t",
+                                                                     node_name="n1"))
+    monkeypatch.setattr(cli, "detect_capabilities", lambda cfg: _caps([]))
+    rc = cli.main(["doctor"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "node: n1" in out
+    assert "all checks passed" in out
+    assert "issues:" not in out
+
+
+def test_doctor_returns_one_when_issues(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "load_config", lambda path: AgentConfig(controller_url="w", token="t"))
+    monkeypatch.setattr(cli, "detect_capabilities", lambda cfg: _caps(["zfs command not found"]))
+    rc = cli.main(["doctor"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "issues:" in out
+    assert "zfs command not found" in out
+
+
+def test_doctor_synthesizes_config_when_missing(monkeypatch):
+    def raise_missing(path):
+        raise FileNotFoundError("nope")
+
+    monkeypatch.setattr(cli, "load_config", raise_missing)
+    seen = {}
+
+    def fake_detect(cfg):
+        seen["cfg"] = cfg
+        return _caps([])
+
+    monkeypatch.setattr(cli, "detect_capabilities", fake_detect)
+    assert cli.main(["doctor"]) == 0
+    # Falls back to a placeholder config rather than crashing.
+    assert seen["cfg"].controller_url == "(none)"

--- a/agent/tests/test_coldfs.py
+++ b/agent/tests/test_coldfs.py
@@ -1,0 +1,77 @@
+import os
+
+import pytest
+
+from lab_agent.executors import coldfs
+
+
+def test_ensure_dir_creates_nested(tmp_path):
+    target = tmp_path / "labs" / "bio" / "users" / "alice"
+    coldfs.ensure_dir(str(target))
+    assert target.is_dir()
+
+
+def test_ensure_dir_is_idempotent(tmp_path):
+    target = tmp_path / "labs" / "bio"
+    coldfs.ensure_dir(str(target))
+    coldfs.ensure_dir(str(target))  # no raise on existing
+    assert target.is_dir()
+
+
+def test_remove_tree_deletes_subtree_inside_guard(tmp_path):
+    guard = tmp_path / "cold"
+    lab = guard / "labs" / "bio"
+    coldfs.ensure_dir(str(lab))
+    (lab / "f.txt").write_text("x")
+    coldfs.remove_tree(str(lab), guard=str(guard))
+    assert not lab.exists()
+    assert guard.exists()  # root untouched
+
+
+def test_remove_tree_refuses_to_delete_the_guard_itself(tmp_path):
+    guard = tmp_path / "cold"
+    coldfs.ensure_dir(str(guard))
+    with pytest.raises(coldfs.ColdFsError):
+        coldfs.remove_tree(str(guard), guard=str(guard))
+    assert guard.exists()
+
+
+def test_remove_tree_refuses_path_outside_guard(tmp_path):
+    guard = tmp_path / "cold"
+    outside = tmp_path / "elsewhere"
+    coldfs.ensure_dir(str(guard))
+    coldfs.ensure_dir(str(outside))
+    with pytest.raises(coldfs.ColdFsError):
+        coldfs.remove_tree(str(outside), guard=str(guard))
+    assert outside.exists()
+
+
+def test_remove_tree_refuses_sibling_prefix_collision(tmp_path):
+    # "/x/cold-evil" must not be considered inside guard "/x/cold" despite the string prefix.
+    guard = tmp_path / "cold"
+    sibling = tmp_path / "cold-evil"
+    coldfs.ensure_dir(str(guard))
+    coldfs.ensure_dir(str(sibling))
+    with pytest.raises(coldfs.ColdFsError):
+        coldfs.remove_tree(str(sibling), guard=str(guard))
+    assert sibling.exists()
+
+
+def test_remove_tree_noop_when_path_missing(tmp_path):
+    guard = tmp_path / "cold"
+    coldfs.ensure_dir(str(guard))
+    # Absent path inside guard: returns quietly before the guard check.
+    coldfs.remove_tree(str(guard / "labs" / "ghost"), guard=str(guard))
+
+
+def test_remove_tree_resolves_symlink_escape(tmp_path):
+    # A symlink living inside the guard but pointing outside must not allow escape.
+    guard = tmp_path / "cold"
+    coldfs.ensure_dir(str(guard))
+    outside = tmp_path / "secret"
+    coldfs.ensure_dir(str(outside))
+    link = guard / "labs"
+    os.symlink(str(outside), str(link))
+    with pytest.raises(coldfs.ColdFsError):
+        coldfs.remove_tree(str(link), guard=str(guard))
+    assert outside.exists()

--- a/agent/tests/test_containerops.py
+++ b/agent/tests/test_containerops.py
@@ -1,0 +1,81 @@
+from types import SimpleNamespace
+
+from lab_agent import containerops
+from lab_agent.config import AgentConfig
+
+
+def _cfg():
+    return AgentConfig(controller_url="ws://x", token="t", node_name="n")
+
+
+def _patch_common(monkeypatch, *, nvidia_runtime=True, nvidia_gpu=True):
+    monkeypatch.setattr(containerops.zfs, "get_mountpoint",
+                        lambda ds: f"/mnt/{ds.replace('/', '_')}")
+    monkeypatch.setattr(containerops.coldstore, "shared_mount", lambda cfg, lab: f"/cold/{lab}/shared")
+    monkeypatch.setattr(containerops.coldstore, "users_mount", lambda cfg, lab: f"/cold/{lab}/users")
+    monkeypatch.setattr(containerops, "detect_capabilities",
+                        lambda cfg: SimpleNamespace(nvidia_runtime=nvidia_runtime, nvidia_gpu=nvidia_gpu))
+
+
+def test_mounts_built_from_paths_and_coldstore(monkeypatch):
+    _patch_common(monkeypatch)
+    mounts = containerops._mounts(_cfg(), "bio")
+    assert mounts.fast_shared == "/mnt/fast_labs_bio_shared"
+    assert mounts.fast_users == "/mnt/fast_labs_bio_users"
+    assert mounts.slow_shared == "/cold/bio/shared"
+    assert mounts.slow_users == "/cold/bio/users"
+
+
+def test_ensure_container_removes_old_then_creates(monkeypatch):
+    _patch_common(monkeypatch)
+    events = []
+    monkeypatch.setattr(containerops.docker, "remove_container",
+                        lambda name: events.append(("remove", name)))
+
+    def fake_create(name, opts, mounts, *, gpus):
+        events.append(("create", name, gpus))
+        return "cid123"
+
+    monkeypatch.setattr(containerops.docker, "create_container", fake_create)
+
+    cid = containerops.ensure_container(_cfg(), "bio", {"image": "custom-ssh"})
+    assert cid == "cid123"
+    # Remove must happen before create.
+    assert events == [("remove", "lab-bio"), ("create", "lab-bio", True)]
+
+
+def test_ensure_container_disables_gpus_without_runtime(monkeypatch):
+    _patch_common(monkeypatch, nvidia_runtime=False, nvidia_gpu=True)
+    captured = {}
+    monkeypatch.setattr(containerops.docker, "remove_container", lambda name: None)
+    monkeypatch.setattr(containerops.docker, "create_container",
+                        lambda name, opts, mounts, *, gpus: captured.update(gpus=gpus) or "id")
+    containerops.ensure_container(_cfg(), "bio", {})
+    assert captured["gpus"] is False
+
+
+def test_ensure_container_passes_options_from_params(monkeypatch):
+    _patch_common(monkeypatch)
+    captured = {}
+    monkeypatch.setattr(containerops.docker, "remove_container", lambda name: None)
+
+    def fake_create(name, opts, mounts, *, gpus):
+        captured["opts"] = opts
+        captured["mounts"] = mounts
+        return "id"
+
+    monkeypatch.setattr(containerops.docker, "create_container", fake_create)
+    containerops.ensure_container(_cfg(), "bio", {"image": "myimg", "ssh_port": 2222})
+    assert captured["opts"].image == "myimg"
+    assert captured["opts"].ssh_port == 2222
+    assert captured["mounts"].slow_users == "/cold/bio/users"
+
+
+def test_recreate_container_handler_returns_result_and_log(monkeypatch):
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(containerops.docker, "remove_container", lambda name: None)
+    monkeypatch.setattr(containerops.docker, "create_container",
+                        lambda name, opts, mounts, *, gpus: "cid999")
+    result, log = containerops.recreate_container(_cfg(), {"lab": "bio"})
+    assert result == {"lab": "bio", "container": "cid999"}
+    assert "recreated container for lab 'bio'" in log

--- a/agent/tests/test_gpu_policy.py
+++ b/agent/tests/test_gpu_policy.py
@@ -1,0 +1,84 @@
+import pytest
+
+from lab_agent.config import AgentConfig
+from lab_agent.gpu import policy as gpu_policy
+from lab_agent.gpu.policy import GpuPolicy
+
+
+@pytest.fixture(autouse=True)
+def _restore_global():
+    # set_policy mutates module-global state; restore it after each test.
+    saved = gpu_policy._current
+    yield
+    gpu_policy._current = saved
+
+
+def test_defaults_are_conservative():
+    p = GpuPolicy()
+    assert p.enabled is False
+    assert p.util_threshold == 5.0
+    assert p.idle_minutes == 20.0
+    assert p.grace_minutes == 10.0
+    assert p.immediate is False
+    assert p.interval_s == 30
+    assert p.whitelist_users == set()
+    assert p.whitelist_labs == set()
+
+
+def test_from_dict_full():
+    p = GpuPolicy.from_dict({
+        "enabled": 1,
+        "immediate": True,
+        "util_threshold": "12.5",
+        "idle_minutes": 5,
+        "grace_minutes": 2,
+        "interval_s": "60",
+        "whitelist_users": ["root", "admin"],
+        "whitelist_labs": ["bio"],
+    })
+    assert p.enabled is True
+    assert p.immediate is True
+    assert p.util_threshold == 12.5
+    assert p.idle_minutes == 5.0
+    assert p.grace_minutes == 2.0
+    assert p.interval_s == 60
+    assert p.whitelist_users == {"root", "admin"}
+    assert p.whitelist_labs == {"bio"}
+
+
+def test_from_dict_empty_keeps_defaults():
+    p = GpuPolicy.from_dict({})
+    assert p == GpuPolicy()
+
+
+def test_from_dict_none_floats_ignored():
+    p = GpuPolicy.from_dict({"util_threshold": None, "idle_minutes": None})
+    assert p.util_threshold == 5.0
+    assert p.idle_minutes == 20.0
+
+
+def test_from_dict_zero_interval_falls_back_to_default():
+    # interval_s uses truthiness, so 0 keeps the default.
+    p = GpuPolicy.from_dict({"interval_s": 0})
+    assert p.interval_s == 30
+
+
+def test_from_dict_null_whitelists_become_empty_sets():
+    p = GpuPolicy.from_dict({"whitelist_users": None, "whitelist_labs": None})
+    assert p.whitelist_users == set()
+    assert p.whitelist_labs == set()
+
+
+def test_set_policy_updates_global_and_get_policy_reflects_it():
+    p = gpu_policy.set_policy({"enabled": True, "idle_minutes": 7})
+    assert p.enabled is True
+    assert gpu_policy.get_policy() is p
+    assert gpu_policy.get_policy().idle_minutes == 7.0
+
+
+def test_update_policy_handler_sets_policy_and_returns_summary():
+    cfg = AgentConfig(controller_url="ws://x", token="t")
+    result, log = gpu_policy.update_policy_handler(cfg, {"enabled": True, "idle_minutes": 15})
+    assert result == {"enabled": True, "idle_minutes": 15.0}
+    assert "gpu policy updated" in log
+    assert gpu_policy.get_policy().enabled is True

--- a/agent/tests/test_installer.py
+++ b/agent/tests/test_installer.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+import pytest
+
+from lab_agent import installer
+from lab_agent.config import AgentConfig
+
+
+def _cfg():
+    return AgentConfig(controller_url="wss://ctl:8443", token="secret", node_name="node-1")
+
+
+def test_resolve_executable_prefers_path_binary(monkeypatch):
+    monkeypatch.setattr(installer.shutil, "which", lambda _: "/usr/local/bin/lab-agent")
+    assert installer._resolve_executable() == "/usr/local/bin/lab-agent"
+
+
+def test_resolve_executable_falls_back_to_python_module(monkeypatch):
+    monkeypatch.setattr(installer.shutil, "which", lambda _: None)
+    monkeypatch.setattr(installer.sys, "executable", "/opt/py/bin/python")
+    assert installer._resolve_executable() == "/opt/py/bin/python -m lab_agent.cli"
+
+
+def test_render_unit_contains_exec_start_and_config(monkeypatch):
+    monkeypatch.setattr(installer.shutil, "which", lambda _: "/usr/bin/lab-agent")
+    unit = installer.render_unit(Path("/etc/lab-agent/config.toml"))
+    assert "ExecStart=/usr/bin/lab-agent run" in unit
+    assert "Environment=LAB_AGENT_CONFIG=/etc/lab-agent/config.toml" in unit
+    assert "Restart=always" in unit
+    assert "User=root" in unit
+    assert "WantedBy=multi-user.target" in unit
+
+
+def test_install_requires_root(monkeypatch, tmp_path):
+    monkeypatch.setattr(installer.os, "geteuid", lambda: 1000)
+    with pytest.raises(PermissionError):
+        installer.install(_cfg(), tmp_path / "config.toml")
+
+
+def test_install_writes_config_and_unit_and_enables(monkeypatch, tmp_path):
+    monkeypatch.setattr(installer.os, "geteuid", lambda: 0)
+    monkeypatch.setattr(installer.shutil, "which", lambda _: "/usr/bin/lab-agent")
+    monkeypatch.setattr(installer, "STATE_DIR", tmp_path / "state")
+    unit_path = tmp_path / "lab-agent.service"
+    monkeypatch.setattr(installer, "SYSTEMD_UNIT_PATH", unit_path)
+    calls: list[str] = []
+    monkeypatch.setattr(installer.os, "system", lambda cmd: calls.append(cmd) or 0)
+
+    config_path = tmp_path / "config.toml"
+    result = installer.install(_cfg(), config_path, enable=True)
+
+    assert config_path.exists()
+    assert 'controller_url = "wss://ctl:8443"' in config_path.read_text()
+    assert (tmp_path / "state").is_dir()
+    assert "ExecStart=/usr/bin/lab-agent run" in unit_path.read_text()
+    assert result["status"] == "enabled and started"
+    assert any("daemon-reload" in c for c in calls)
+    assert any("enable --now lab-agent.service" in c for c in calls)
+
+
+def test_install_no_enable_skips_systemctl(monkeypatch, tmp_path):
+    monkeypatch.setattr(installer.os, "geteuid", lambda: 0)
+    monkeypatch.setattr(installer.shutil, "which", lambda _: "/usr/bin/lab-agent")
+    monkeypatch.setattr(installer, "STATE_DIR", tmp_path / "state")
+    monkeypatch.setattr(installer, "SYSTEMD_UNIT_PATH", tmp_path / "lab-agent.service")
+    calls: list[str] = []
+    monkeypatch.setattr(installer.os, "system", lambda cmd: calls.append(cmd) or 0)
+
+    result = installer.install(_cfg(), tmp_path / "config.toml", enable=False)
+    assert result["status"] == "written (not enabled)"
+    assert calls == []

--- a/agent/tests/test_localq.py
+++ b/agent/tests/test_localq.py
@@ -1,0 +1,80 @@
+from lab_agent.localq import OUTBOX_QUEUE, TASKS_QUEUE, LocalQueues
+
+
+def test_init_creates_parent_dir_and_queues(tmp_path):
+    db = tmp_path / "nested" / "state.db"
+    q = LocalQueues(str(db))
+    try:
+        assert db.parent.is_dir()
+        assert q.worker_id.startswith("agent-")
+    finally:
+        q.close()
+
+
+def test_task_roundtrip_enqueue_then_claim(tmp_path):
+    q = LocalQueues(str(tmp_path / "state.db"))
+    try:
+        frame = {"type": "task", "id": "t1", "action": "lab.create"}
+        q.enqueue_task(frame)
+        job = q.claim_task()
+        assert job is not None
+        assert job.payload == frame
+        job.ack()
+    finally:
+        q.close()
+
+
+def test_claim_task_returns_none_when_empty(tmp_path):
+    q = LocalQueues(str(tmp_path / "state.db"))
+    try:
+        assert q.claim_task() is None
+    finally:
+        q.close()
+
+
+def test_outbound_roundtrip(tmp_path):
+    q = LocalQueues(str(tmp_path / "state.db"))
+    try:
+        frame = {"type": "result", "id": "r1", "ok": True}
+        q.enqueue_outbound(frame)
+        job = q.claim_outbound()
+        assert job is not None
+        assert job.payload == frame
+        job.ack()
+        assert q.claim_outbound() is None
+    finally:
+        q.close()
+
+
+def test_tasks_and_outbox_are_independent(tmp_path):
+    q = LocalQueues(str(tmp_path / "state.db"))
+    try:
+        q.enqueue_task({"id": "task"})
+        # An outbound claim must not see the task frame.
+        assert q.claim_outbound() is None
+        job = q.claim_task()
+        assert job.payload == {"id": "task"}
+        job.ack()
+    finally:
+        q.close()
+
+
+def test_durable_across_reopen(tmp_path):
+    path = str(tmp_path / "state.db")
+    q1 = LocalQueues(path)
+    q1.enqueue_task({"id": "survivor"})
+    q1.close()
+
+    q2 = LocalQueues(path)
+    try:
+        job = q2.claim_task()
+        assert job is not None
+        assert job.payload == {"id": "survivor"}
+        job.ack()
+    finally:
+        q2.close()
+
+
+def test_queue_name_constants():
+    assert TASKS_QUEUE == "tasks"
+    assert OUTBOX_QUEUE == "outbox"

--- a/agent/tests/test_logbus.py
+++ b/agent/tests/test_logbus.py
@@ -1,0 +1,67 @@
+from lab_agent import protocol as P
+from lab_agent.logbus import LogBus
+
+
+def _bus():
+    frames: list[dict] = []
+    return LogBus("node-1", sink=frames.append, echo=False), frames
+
+
+def test_log_emits_log_frame_to_sink():
+    bus, frames = _bus()
+    bus.log("INFO", "src", "hello", lab="bio", user="al", task_id="7", detail="d")
+    assert len(frames) == 1
+    f = frames[0]
+    assert f["type"] == P.T_LOG
+    assert f["node"] == "node-1"
+    assert f["level"] == "INFO"
+    assert f["source"] == "src"
+    assert f["msg"] == "hello"
+    assert f["lab"] == "bio" and f["user"] == "al" and f["task_id"] == "7" and f["detail"] == "d"
+
+
+def test_level_helpers_set_level():
+    bus, frames = _bus()
+    bus.debug("s", "d")
+    bus.info("s", "i")
+    bus.warn("s", "w")
+    bus.error("s", "e")
+    assert [f["level"] for f in frames] == ["DEBUG", "INFO", "WARN", "ERROR"]
+
+
+def test_helpers_forward_kwargs():
+    bus, frames = _bus()
+    bus.warn("zfs", "quota near", lab="bio", task_id="3")
+    assert frames[0]["lab"] == "bio"
+    assert frames[0]["task_id"] == "3"
+
+
+def test_event_emits_event_frame():
+    bus, frames = _bus()
+    bus.event("gpu.warn", {"pid": 42})
+    assert frames[0]["type"] == P.T_EVENT
+    assert frames[0]["kind"] == "gpu.warn"
+    assert frames[0]["payload"] == {"pid": 42}
+
+
+def test_telemetry_emits_telemetry_frame():
+    bus, frames = _bus()
+    bus.telemetry({"pools": [1]})
+    assert frames[0]["type"] == P.T_TELEMETRY
+    assert frames[0]["payload"] == {"pools": [1]}
+
+
+def test_echo_writes_to_stderr(capsys):
+    frames: list[dict] = []
+    bus = LogBus("n", sink=frames.append, echo=True)
+    bus.info("src", "visible")
+    captured = capsys.readouterr()
+    assert "[INFO] src: visible" in captured.err
+    # Still delivered to the sink.
+    assert frames[0]["msg"] == "visible"
+
+
+def test_echo_disabled_is_silent(capsys):
+    bus, _ = _bus()
+    bus.info("src", "quiet")
+    assert capsys.readouterr().err == ""

--- a/agent/tests/test_paths.py
+++ b/agent/tests/test_paths.py
@@ -1,0 +1,45 @@
+from lab_agent import paths
+from lab_agent.config import AgentConfig
+
+
+def _cfg(**kw):
+    base = dict(controller_url="ws://x", token="t", node_name="n")
+    base.update(kw)
+    return AgentConfig(**base)
+
+
+def test_zfs_dataset_names_use_pool_roots():
+    cfg = _cfg(fast_pool="fast", slow_pool="slow")
+    assert paths.lab_fast(cfg, "bio") == "fast/labs/bio"
+    assert paths.lab_slow(cfg, "bio") == "slow/labs/bio"
+    assert paths.lab_fast_shared(cfg, "bio") == "fast/labs/bio/shared"
+    assert paths.lab_slow_shared(cfg, "bio") == "slow/labs/bio/shared"
+    assert paths.lab_fast_users(cfg, "bio") == "fast/labs/bio/users"
+    assert paths.lab_slow_users(cfg, "bio") == "slow/labs/bio/users"
+
+
+def test_user_dataset_names():
+    cfg = _cfg(fast_pool="fast", slow_pool="slow")
+    assert paths.user_scratch(cfg, "bio", "alice") == "fast/labs/bio/users/alice"
+    assert paths.user_cold(cfg, "bio", "alice") == "slow/labs/bio/users/alice"
+
+
+def test_custom_pool_names_propagate():
+    cfg = _cfg(fast_pool="nvme0", slow_pool="rust1")
+    assert paths.lab_fast(cfg, "ml") == "nvme0/labs/ml"
+    assert paths.user_cold(cfg, "ml", "bob") == "rust1/labs/ml/users/bob"
+
+
+def test_cold_paths_are_filesystem_paths_under_cold_root():
+    cfg = _cfg(slow_backend="smb", slow_path="/mnt/cold")
+    assert paths.cold_lab(cfg, "bio") == "/mnt/cold/labs/bio"
+    assert paths.cold_lab_shared(cfg, "bio") == "/mnt/cold/labs/bio/shared"
+    assert paths.cold_lab_users(cfg, "bio") == "/mnt/cold/labs/bio/users"
+    assert paths.cold_user(cfg, "bio", "alice") == "/mnt/cold/labs/bio/users/alice"
+
+
+def test_cold_paths_mirror_zfs_layout_so_controller_parser_works():
+    # The controller parses "…/labs/<lab>[/users/<u>]"; the SMB layout must match.
+    cfg = _cfg(slow_backend="smb", slow_path="/srv/share/")  # trailing slash stripped via cold_root
+    assert paths.cold_lab(cfg, "bio") == "/srv/share/labs/bio"
+    assert paths.cold_user(cfg, "bio", "u") == "/srv/share/labs/bio/users/u"

--- a/agent/tests/test_protocol.py
+++ b/agent/tests/test_protocol.py
@@ -1,0 +1,104 @@
+from lab_agent import protocol as P
+
+
+def test_now_ms_is_milliseconds(monkeypatch):
+    monkeypatch.setattr(P.time, "time", lambda: 1_700_000_000.5)
+    assert P.now_ms() == 1_700_000_000_500
+
+
+def test_task_from_frame_full():
+    frame = {
+        "id": "abc",
+        "action": P.A_LAB_CREATE,
+        "params": {"lab": "bio"},
+        "requested_by": "admin",
+        "ts": 42,
+    }
+    task = P.Task.from_frame(frame)
+    assert task.id == "abc"
+    assert task.action == "lab.create"
+    assert task.params == {"lab": "bio"}
+    assert task.requested_by == "admin"
+    assert task.ts == 42
+
+
+def test_task_from_frame_defaults_missing_optionals():
+    task = P.Task.from_frame({"id": "1", "action": "x"})
+    assert task.params == {}
+    assert task.requested_by is None
+    assert isinstance(task.ts, int) and task.ts > 0
+
+
+def test_task_from_frame_coerces_null_params_to_empty_dict():
+    task = P.Task.from_frame({"id": "1", "action": "x", "params": None})
+    assert task.params == {}
+
+
+def test_result_frame_shape():
+    f = P.result_frame("t1", ok=True, result={"lab": "bio"}, logs="done")
+    assert f["type"] == P.T_RESULT
+    assert f["id"] == "t1"
+    assert f["ok"] is True
+    assert f["result"] == {"lab": "bio"}
+    assert f["error"] is None
+    assert f["logs"] == "done"
+    assert isinstance(f["ts"], int)
+
+
+def test_result_frame_error_defaults():
+    f = P.result_frame("t2", ok=False, error="boom")
+    assert f["ok"] is False
+    assert f["error"] == "boom"
+    assert f["result"] is None
+    assert f["logs"] is None
+
+
+def test_hello_frame_carries_identity_and_caps():
+    f = P.hello_frame("node-1", "secret", {"zfs": True})
+    assert f["type"] == P.T_HELLO
+    assert f["node"] == "node-1"
+    assert f["token"] == "secret"
+    assert f["capabilities"] == {"zfs": True}
+
+
+def test_log_frame_optional_fields_default_none():
+    f = P.log_frame("n", "INFO", "src", "hello")
+    assert f["type"] == P.T_LOG
+    assert f["level"] == "INFO"
+    assert f["source"] == "src"
+    assert f["msg"] == "hello"
+    assert f["lab"] is None and f["user"] is None
+    assert f["task_id"] is None and f["detail"] is None
+
+
+def test_log_frame_with_context():
+    f = P.log_frame("n", "ERROR", "zfs", "fail", lab="bio", user="al", task_id="9", detail="tb")
+    assert f["lab"] == "bio"
+    assert f["user"] == "al"
+    assert f["task_id"] == "9"
+    assert f["detail"] == "tb"
+
+
+def test_event_frame_shape():
+    f = P.event_frame("n", "gpu.kill", {"pid": 5})
+    assert f["type"] == P.T_EVENT
+    assert f["kind"] == "gpu.kill"
+    assert f["payload"] == {"pid": 5}
+
+
+def test_telemetry_frame_shape():
+    f = P.telemetry_frame("n", {"pools": []})
+    assert f["type"] == P.T_TELEMETRY
+    assert f["payload"] == {"pools": []}
+
+
+def test_frame_type_and_action_constants_are_distinct():
+    types = {P.T_HELLO, P.T_TASK, P.T_RESULT, P.T_LOG, P.T_EVENT, P.T_TELEMETRY, P.T_ACK}
+    assert len(types) == 7
+    actions = {
+        P.A_LAB_CREATE, P.A_LAB_SET_QUOTA, P.A_LAB_DESTROY,
+        P.A_STUDENT_ADD, P.A_STUDENT_REMOVE, P.A_CONTAINER_RECREATE,
+        P.A_GPU_POLICY_UPDATE, P.A_NODE_REPORT_STATE, P.A_NODE_BACKUP,
+        P.A_NODE_SCRUB, P.A_OLDFILES_SCAN,
+    }
+    assert len(actions) == 11

--- a/agent/tests/test_system.py
+++ b/agent/tests/test_system.py
@@ -1,0 +1,170 @@
+import os
+
+from lab_agent import system
+from lab_agent.config import AgentConfig
+from lab_agent.executors.base import CommandResult
+
+
+def _cfg(**kw):
+    base = dict(controller_url="ws://x", token="t", node_name="n", fast_pool="fast", slow_pool="slow")
+    base.update(kw)
+    return AgentConfig(**base)
+
+
+class FakeRunner:
+    """Returns canned CommandResults keyed by a prefix of the joined command."""
+
+    def __init__(self, responses=None, default_ok=True):
+        self.responses = responses or {}
+        self.default_ok = default_ok
+        self.calls: list[list[str]] = []
+
+    def __call__(self, args, **kwargs):
+        argv = [str(a) for a in args]
+        self.calls.append(argv)
+        joined = " ".join(argv)
+        for prefix, res in self.responses.items():
+            if joined.startswith(prefix):
+                return res
+        return CommandResult(self.default_ok, argv, 0 if self.default_ok else 1, "", "")
+
+
+def _ok(stdout=""):
+    return CommandResult(True, [], 0, stdout, "")
+
+
+def _fail(stderr="err"):
+    return CommandResult(False, [], 1, "", stderr)
+
+
+def test_healthy_zfs_node(monkeypatch):
+    runner = FakeRunner({
+        "zfs version": _ok("zfs-2.2.0"),
+        "docker version": _ok("24.0"),
+        "docker info --format {{.Driver}}": _ok("zfs"),
+        "docker info --format {{.Runtimes}}": _ok("map[nvidia:... runc:...]"),
+        "nvidia-smi -L": _ok("GPU 0: NVIDIA A100\nGPU 1: NVIDIA A100\n"),
+        "zpool list -H -o name fast": _ok("fast"),
+        "zpool list -H -o name slow": _ok("slow"),
+    })
+    monkeypatch.setattr(system, "run", runner)
+    caps = system.detect_capabilities(_cfg())
+    assert caps.zfs is True
+    assert caps.docker is True
+    assert caps.docker_zfs_driver is True
+    assert caps.nvidia_runtime is True
+    assert caps.nvidia_gpu is True
+    assert caps.gpu_count == 2
+    assert caps.fast_pool_present is True
+    assert caps.slow_pool_present is True
+    assert caps.slow_backend == "zfs"
+    assert caps.issues == []
+
+
+def test_missing_zfs_records_issue_and_skips_pool_checks(monkeypatch):
+    runner = FakeRunner({
+        "zfs version": _fail(),
+        "docker version": _ok("24.0"),
+        "docker info --format {{.Driver}}": _ok("zfs"),
+        "docker info --format {{.Runtimes}}": _ok("runc"),
+        "nvidia-smi -L": _fail(),
+    })
+    monkeypatch.setattr(system, "run", runner)
+    caps = system.detect_capabilities(_cfg())
+    assert caps.zfs is False
+    assert caps.fast_pool_present is False
+    assert caps.slow_pool_present is False
+    assert "zfs command not found" in caps.issues
+
+
+def test_wrong_docker_storage_driver_is_flagged(monkeypatch):
+    runner = FakeRunner({
+        "zfs version": _ok(),
+        "docker version": _ok(),
+        "docker info --format {{.Driver}}": _ok("overlay2"),
+        "docker info --format {{.Runtimes}}": _ok("runc"),
+        "nvidia-smi -L": _fail(),
+        "zpool list -H -o name fast": _ok("fast"),
+        "zpool list -H -o name slow": _ok("slow"),
+    })
+    monkeypatch.setattr(system, "run", runner)
+    caps = system.detect_capabilities(_cfg())
+    assert caps.docker_zfs_driver is False
+    assert any("storage driver is 'overlay2'" in i for i in caps.issues)
+
+
+def test_missing_fast_pool_is_flagged(monkeypatch):
+    runner = FakeRunner({
+        "zfs version": _ok(),
+        "docker version": _fail(),
+        "nvidia-smi -L": _fail(),
+        "zpool list -H -o name fast": _fail(),
+        "zpool list -H -o name slow": _ok("slow"),
+    })
+    monkeypatch.setattr(system, "run", runner)
+    caps = system.detect_capabilities(_cfg())
+    assert caps.fast_pool_present is False
+    assert any("fast pool 'fast' not found" in i for i in caps.issues)
+    assert "docker not reachable" in caps.issues
+
+
+def test_docker_unreachable_skips_driver_and_runtime(monkeypatch):
+    runner = FakeRunner({
+        "zfs version": _ok(),
+        "docker version": _fail(),
+        "nvidia-smi -L": _fail(),
+        "zpool list -H -o name fast": _ok("fast"),
+        "zpool list -H -o name slow": _ok("slow"),
+    })
+    monkeypatch.setattr(system, "run", runner)
+    caps = system.detect_capabilities(_cfg())
+    assert caps.docker is False
+    assert caps.docker_zfs_driver is False
+    assert caps.nvidia_runtime is False
+
+
+def test_smb_backend_checks_mountpoint_not_pool(monkeypatch):
+    runner = FakeRunner({
+        "zfs version": _ok(),
+        "docker version": _ok(),
+        "docker info --format {{.Driver}}": _ok("zfs"),
+        "docker info --format {{.Runtimes}}": _ok("nvidia"),
+        "nvidia-smi -L": _ok("GPU 0: X\n"),
+        "zpool list -H -o name fast": _ok("fast"),
+    })
+    monkeypatch.setattr(system, "run", runner)
+    monkeypatch.setattr(os.path, "ismount", lambda p: True)
+    cfg = _cfg(slow_backend="smb", slow_path="/mnt/cold", slow_shared=True)
+    caps = system.detect_capabilities(cfg)
+    assert caps.slow_backend == "smb"
+    assert caps.slow_shared is True
+    assert caps.slow_pool_present is True
+    # The slow pool name must never be probed on the SMB backend.
+    assert ["zpool", "list", "-H", "-o", "name", "slow"] not in runner.calls
+
+
+def test_smb_backend_unmounted_is_flagged(monkeypatch):
+    runner = FakeRunner({
+        "zfs version": _ok(),
+        "docker version": _fail(),
+        "nvidia-smi -L": _fail(),
+        "zpool list -H -o name fast": _ok("fast"),
+    })
+    monkeypatch.setattr(system, "run", runner)
+    monkeypatch.setattr(os.path, "ismount", lambda p: False)
+    cfg = _cfg(slow_backend="smb", slow_path="/mnt/cold")
+    caps = system.detect_capabilities(cfg)
+    assert caps.slow_pool_present is False
+    assert any("SMB mount '/mnt/cold' is not mounted" in i for i in caps.issues)
+
+
+def test_to_dict_roundtrips_fields():
+    caps = system.Capabilities(
+        zfs=True, docker=True, docker_zfs_driver=True, nvidia_runtime=False,
+        nvidia_gpu=False, gpu_count=0, fast_pool_present=True, slow_pool_present=True,
+        slow_backend="zfs", slow_shared=False, issues=["x"],
+    )
+    d = caps.to_dict()
+    assert d["zfs"] is True
+    assert d["gpu_count"] == 0
+    assert d["issues"] == ["x"]

--- a/agent/tests/test_telemetry.py
+++ b/agent/tests/test_telemetry.py
@@ -1,0 +1,96 @@
+from types import SimpleNamespace
+
+from lab_agent import telemetry
+from lab_agent.config import AgentConfig
+from lab_agent.executors.base import CommandResult
+
+
+def _cfg(**kw):
+    base = dict(controller_url="ws://x", token="t", node_name="n", fast_pool="fast", slow_pool="slow")
+    base.update(kw)
+    return AgentConfig(**base)
+
+
+def test_pool_free_parses_zpool_output(monkeypatch):
+    monkeypatch.setattr(
+        telemetry, "run",
+        lambda args, **kw: CommandResult(True, [], 0, "fast\t1000\t400\t600\n", ""),
+    )
+    info = telemetry._pool_free("fast")
+    assert info == {"name": "fast", "size": 1000, "alloc": 400, "free": 600}
+
+
+def test_pool_free_none_on_command_failure(monkeypatch):
+    monkeypatch.setattr(telemetry, "run", lambda args, **kw: CommandResult(False, [], 1, "", "no pool"))
+    assert telemetry._pool_free("gone") is None
+
+
+def test_pool_free_none_on_empty_output(monkeypatch):
+    monkeypatch.setattr(telemetry, "run", lambda args, **kw: CommandResult(True, [], 0, "  \n", ""))
+    assert telemetry._pool_free("fast") is None
+
+
+def test_pool_free_none_on_short_output(monkeypatch):
+    monkeypatch.setattr(telemetry, "run", lambda args, **kw: CommandResult(True, [], 0, "fast 1 2\n", ""))
+    assert telemetry._pool_free("fast") is None
+
+
+def test_pools_excludes_slow_on_smb_backend(monkeypatch):
+    seen: list[str] = []
+
+    def fake_run(args, **kw):
+        pool = str(args[-1])
+        seen.append(pool)
+        return CommandResult(True, [], 0, f"{pool}\t10\t1\t9\n", "")
+
+    monkeypatch.setattr(telemetry, "run", fake_run)
+    cfg = _cfg(slow_backend="smb", slow_path="/mnt/cold")
+    pools = telemetry._pools(cfg)
+    assert [p["name"] for p in pools] == ["fast"]
+    assert seen == ["fast"]
+
+
+def test_pools_includes_both_on_zfs_backend(monkeypatch):
+    monkeypatch.setattr(
+        telemetry, "run",
+        lambda args, **kw: CommandResult(True, [], 0, f"{args[-1]}\t10\t1\t9\n", ""),
+    )
+    pools = telemetry._pools(_cfg())
+    assert {p["name"] for p in pools} == {"fast", "slow"}
+
+
+def test_pools_drops_unavailable_pool(monkeypatch):
+    def fake_run(args, **kw):
+        pool = str(args[-1])
+        if pool == "slow":
+            return CommandResult(False, [], 1, "", "missing")
+        return CommandResult(True, [], 0, f"{pool}\t10\t1\t9\n", "")
+
+    monkeypatch.setattr(telemetry, "run", fake_run)
+    pools = telemetry._pools(_cfg())
+    assert [p["name"] for p in pools] == ["fast"]
+
+
+def test_collect_heartbeat_assembles_all_sections(monkeypatch):
+    cfg = _cfg()
+    monkeypatch.setattr(
+        telemetry, "run",
+        lambda args, **kw: CommandResult(True, [], 0, f"{args[-1]}\t10\t1\t9\n", ""),
+    )
+    monkeypatch.setattr(telemetry.zfs, "list_usage", lambda root: [
+        SimpleNamespace(dataset="fast/labs/bio", used_bytes=100, quota_bytes=200, available_bytes=100),
+    ])
+    monkeypatch.setattr(telemetry.coldstore, "list_usage", lambda cfg: [
+        {"pool": "slow", "dataset": "slow/labs/bio", "used_bytes": 5, "quota_bytes": None,
+         "available_bytes": None},
+    ])
+    monkeypatch.setattr(telemetry.zfs, "scrub_status",
+                        lambda p: SimpleNamespace(to_dict=lambda: {"pool": p, "healthy": True}))
+    monkeypatch.setattr(telemetry, "list_gpu_processes", lambda: [{"pid": 1, "vram_bytes": 1024}])
+
+    hb = telemetry.collect_heartbeat(cfg)
+    assert {p["name"] for p in hb["pools"]} == {"fast", "slow"}
+    datasets = {d["dataset"] for d in hb["datasets"]}
+    assert datasets == {"fast/labs/bio", "slow/labs/bio"}
+    assert {s["pool"] for s in hb["scrub"]} == {"fast", "slow"}
+    assert hb["gpu_processes"] == [{"pid": 1, "vram_bytes": 1024}]

--- a/controller/src/lib/hub.ts
+++ b/controller/src/lib/hub.ts
@@ -105,10 +105,10 @@ function drainNode(node: string, ws: WebSocket): void {
     if (!claimed) break;
     try {
       ws.send(JSON.stringify(claimed.frame));
-      ackTask(node, claimed.jobId);
+      ackTask(node, claimed.jobId, workerId);
       markTaskState(claimed.frame.id, "sent");
     } catch {
-      retryTask(node, claimed.jobId, "send failed");
+      retryTask(node, claimed.jobId, workerId, "send failed");
       break;
     }
   }

--- a/controller/src/lib/queue.ts
+++ b/controller/src/lib/queue.ts
@@ -76,14 +76,15 @@ export function claimTask(node: string, workerId: string): { jobId: number; fram
   return { jobId: job.id, frame: job.payload as TaskFrame };
 }
 
-export function ackTask(node: string, jobId: number): void {
-  nodeQueue(node).ackBatch([jobId]);
+export function ackTask(node: string, jobId: number, workerId: string): void {
+  // honker_ack only releases the job for the worker that claimed it, so the worker id is required.
+  nodeQueue(node).ackBatch([jobId], workerId);
 }
 
-export function retryTask(node: string, jobId: number, error: string): void {
-  // honker exposes per-job retry; claim again then retry. Simpler: re-enqueue via internal _retry.
+export function retryTask(node: string, jobId: number, workerId: string, error: string): void {
+  // honker exposes per-job retry; signature is _retry(jobId, workerId, delaySeconds, error).
   try {
-    nodeQueue(node)._retry(jobId, 5, error);
+    nodeQueue(node)._retry(jobId, workerId, 5, error);
   } catch {
     /* if the job already expired it will be redelivered anyway */
   }

--- a/controller/tests/db.test.ts
+++ b/controller/tests/db.test.ts
@@ -1,0 +1,66 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const tmp = mkdtempSync(join(tmpdir(), "lab-ctl-db-"));
+process.env.DB_PATH = join(tmp, "controller.db");
+process.env.SIGNUP_TOKEN = "t";
+process.env.AGENT_TOKEN = "t";
+process.env.SESSION_SECRET = "test-session-secret-test-session";
+
+let dbmod: typeof import("../src/lib/db");
+
+beforeAll(async () => {
+  dbmod = await import("../src/lib/db");
+});
+
+describe("db singleton", () => {
+  it("returns the same connection on repeated calls", () => {
+    expect(dbmod.db()).toBe(dbmod.db());
+  });
+
+  it("opens in WAL journal mode with foreign keys enforced", () => {
+    expect(String(dbmod.db().pragma("journal_mode", { simple: true })).toLowerCase()).toBe("wal");
+    expect(dbmod.db().pragma("foreign_keys", { simple: true })).toBe(1);
+  });
+});
+
+describe("migrations", () => {
+  it("records every shipped migration exactly once", () => {
+    const ids = (dbmod.db().prepare("SELECT id FROM _migrations ORDER BY id").all() as any[]).map(
+      (r) => r.id,
+    );
+    expect(ids).toContain("0001_init");
+    expect(ids).toContain("0002_scrub");
+    expect(new Set(ids).size).toBe(ids.length); // no duplicates
+  });
+
+  it("created the core tables", () => {
+    const tables = new Set(
+      (
+        dbmod.db().prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as any[]
+      ).map((r) => r.name),
+    );
+    for (const t of ["admins", "settings", "nodes", "labs", "students", "lab_members", "task_log", "logs"]) {
+      expect(tables.has(t)).toBe(true);
+    }
+  });
+
+  it("applied 0002_scrub columns to nodes", () => {
+    const cols = (dbmod.db().prepare("PRAGMA table_info(nodes)").all() as any[]).map((c) => c.name);
+    expect(cols).toContain("last_scrub");
+    expect(cols).toContain("scrub_status");
+  });
+
+  it("enforces foreign keys (orphan lab insert rejected)", () => {
+    expect(() =>
+      dbmod
+        .db()
+        .prepare(
+          "INSERT INTO labs (name, node_id, fast_quota_bytes, slow_quota_bytes, image, created_at) VALUES ('orphan', 999999, 1, 1, 'i', 0)",
+        )
+        .run(),
+    ).toThrow();
+  });
+});

--- a/controller/tests/env.test.ts
+++ b/controller/tests/env.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { env } from "../src/lib/env";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("env defaults", () => {
+  it("dbPath falls back to ./data/controller.db", () => {
+    vi.stubEnv("DB_PATH", undefined as unknown as string);
+    expect(env.dbPath).toBe("./data/controller.db");
+    vi.stubEnv("DB_PATH", "/custom/path.db");
+    expect(env.dbPath).toBe("/custom/path.db");
+  });
+
+  it("port parses PORT and defaults to 8443", () => {
+    vi.stubEnv("PORT", undefined as unknown as string);
+    expect(env.port).toBe(8443);
+    vi.stubEnv("PORT", "9000");
+    expect(env.port).toBe(9000);
+  });
+
+  it("isProd reflects NODE_ENV", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    expect(env.isProd).toBe(true);
+    vi.stubEnv("NODE_ENV", "development");
+    expect(env.isProd).toBe(false);
+  });
+});
+
+describe("required secrets", () => {
+  it("returns the explicit value when set", () => {
+    vi.stubEnv("SESSION_SECRET", "explicit-secret");
+    expect(env.sessionSecret).toBe("explicit-secret");
+  });
+
+  it("uses the dev fallback outside production", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("SIGNUP_TOKEN", undefined as unknown as string);
+    expect(env.signupToken).toBe("dev-signup-token");
+    vi.stubEnv("AGENT_TOKEN", undefined as unknown as string);
+    expect(env.agentToken).toBe("dev-agent-token");
+  });
+
+  it("throws in production when a required var is missing", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("SESSION_SECRET", undefined as unknown as string);
+    expect(() => env.sessionSecret).toThrow(/Missing required env var SESSION_SECRET/);
+  });
+
+  it("treats an empty string as missing", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("AGENT_TOKEN", "");
+    expect(() => env.agentToken).toThrow(/AGENT_TOKEN/);
+  });
+});

--- a/controller/tests/format.test.ts
+++ b/controller/tests/format.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { ago, fmtBytes, pct } from "../src/lib/format";
+
+describe("fmtBytes", () => {
+  it("renders an em-dash for null/undefined", () => {
+    expect(fmtBytes(null)).toBe("—");
+    expect(fmtBytes(undefined)).toBe("—");
+  });
+
+  it("renders bytes with no decimal", () => {
+    expect(fmtBytes(0)).toBe("0 B");
+    expect(fmtBytes(512)).toBe("512 B");
+    expect(fmtBytes(1023)).toBe("1023 B");
+  });
+
+  it("steps through units at 1024 boundaries", () => {
+    expect(fmtBytes(1024)).toBe("1.0 KB");
+    expect(fmtBytes(1536)).toBe("1.5 KB");
+    expect(fmtBytes(1024 ** 2)).toBe("1.0 MB");
+    expect(fmtBytes(1024 ** 3)).toBe("1.0 GB");
+    expect(fmtBytes(2 * 1024 ** 4)).toBe("2.0 TB");
+    expect(fmtBytes(1024 ** 5)).toBe("1.0 PB");
+  });
+
+  it("drops the decimal once the value reaches 100 in a unit", () => {
+    expect(fmtBytes(100 * 1024)).toBe("100 KB");
+    expect(fmtBytes(150 * 1024)).toBe("150 KB");
+  });
+
+  it("clamps to the largest unit (PB)", () => {
+    expect(fmtBytes(5000 * 1024 ** 5)).toBe("5000 PB");
+  });
+});
+
+describe("ago", () => {
+  it("returns 'never' for falsy timestamps", () => {
+    expect(ago(null)).toBe("never");
+    expect(ago(undefined)).toBe("never");
+    expect(ago(0)).toBe("never");
+  });
+
+  it("formats seconds, minutes, hours, days", () => {
+    const now = Date.now();
+    expect(ago(now - 5 * 1000)).toBe("5s ago");
+    expect(ago(now - 5 * 60 * 1000)).toBe("5m ago");
+    expect(ago(now - 5 * 3600 * 1000)).toBe("5h ago");
+    expect(ago(now - 5 * 86400 * 1000)).toBe("5d ago");
+  });
+
+  it("uses the largest fitting unit at boundaries", () => {
+    const now = Date.now();
+    expect(ago(now - 59 * 1000)).toBe("59s ago");
+    expect(ago(now - 60 * 1000)).toBe("1m ago");
+    expect(ago(now - 3599 * 1000)).toBe("59m ago");
+    expect(ago(now - 3600 * 1000)).toBe("1h ago");
+  });
+});
+
+describe("pct", () => {
+  it("returns null when quota is missing or non-positive", () => {
+    expect(pct(100, null)).toBeNull();
+    expect(pct(100, undefined)).toBeNull();
+    expect(pct(100, 0)).toBeNull();
+    expect(pct(100, -5)).toBeNull();
+  });
+
+  it("computes a rounded percentage", () => {
+    expect(pct(50, 100)).toBe(50);
+    expect(pct(1, 3)).toBe(33);
+    expect(pct(0, 100)).toBe(0);
+  });
+
+  it("caps at 100 when over quota", () => {
+    expect(pct(150, 100)).toBe(100);
+    expect(pct(1000, 100)).toBe(100);
+  });
+});

--- a/controller/tests/labs.test.ts
+++ b/controller/tests/labs.test.ts
@@ -1,0 +1,136 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const tmp = mkdtempSync(join(tmpdir(), "lab-ctl-labs-"));
+process.env.DB_PATH = join(tmp, "controller.db");
+process.env.SIGNUP_TOKEN = "t";
+process.env.AGENT_TOKEN = "t";
+process.env.SESSION_SECRET = "test-session-secret-test-session";
+
+const enqueueTask = vi.fn((..._args: unknown[]) => ({ id: "x" }));
+vi.mock("../src/lib/queue", () => ({ enqueueTask }));
+
+let dbmod: typeof import("../src/lib/db");
+let labs: typeof import("../src/lib/labs");
+let nodeId: number;
+
+beforeAll(async () => {
+  dbmod = await import("../src/lib/db");
+  labs = await import("../src/lib/labs");
+  dbmod.db().prepare("INSERT INTO nodes (name, online, created_at) VALUES ('gpu-1', 1, 0)").run();
+  nodeId = (dbmod.db().prepare("SELECT id FROM nodes WHERE name='gpu-1'").get() as any).id;
+});
+
+beforeEach(() => {
+  enqueueTask.mockClear();
+});
+
+function makeLab(name: string) {
+  return labs.createLab({
+    name,
+    nodeId,
+    piEmail: "pi@uga.edu",
+    fastQuotaBytes: 1000,
+    slowQuotaBytes: 2000,
+    image: "custom-ssh",
+    sshPort: 50001,
+    containerOptions: { cpus: "4" },
+  });
+}
+
+describe("createLab", () => {
+  it("inserts the lab, enqueues lab.create, and audits", () => {
+    const lab = makeLab("bio");
+    expect(lab.name).toBe("bio");
+    expect(lab.node_name).toBe("gpu-1");
+    expect(lab.status).toBe("provisioning");
+
+    expect(enqueueTask).toHaveBeenCalledWith(
+      "gpu-1",
+      "lab.create",
+      expect.objectContaining({
+        lab: "bio",
+        fast_quota_bytes: 1000,
+        slow_quota_bytes: 2000,
+        image: "custom-ssh",
+        ssh_port: 50001,
+        container_options: { cpus: "4" },
+      }),
+      undefined,
+    );
+
+    const audit = dbmod
+      .db()
+      .prepare("SELECT * FROM audit_log WHERE action='lab.create' AND target='bio'")
+      .get() as any;
+    expect(audit).toBeTruthy();
+    expect(audit.detail).toBe("node=gpu-1");
+  });
+
+  it("throws for an unknown node", () => {
+    expect(() =>
+      labs.createLab({ name: "x", nodeId: 9999, fastQuotaBytes: 1, slowQuotaBytes: 1, image: "i" }),
+    ).toThrow(/Unknown node/);
+  });
+});
+
+describe("getters", () => {
+  it("getLabByName and getLab return the row with node join", () => {
+    makeLab("chem");
+    const byName = labs.getLabByName("chem")!;
+    expect(byName.online).toBe(1);
+    expect(labs.getLab(byName.id)!.name).toBe("chem");
+    expect(labs.getLab(123456)).toBeUndefined();
+  });
+
+  it("listLabs returns all labs ordered by name", () => {
+    const names = labs.listLabs().map((l) => l.name);
+    expect(names).toContain("bio");
+    expect(names).toContain("chem");
+    expect([...names]).toEqual([...names].sort());
+  });
+});
+
+describe("updateQuota", () => {
+  it("updates only provided fields and enqueues lab.set_quota", () => {
+    const lab = makeLab("phys");
+    enqueueTask.mockClear();
+    labs.updateQuota(lab.id, 5000, undefined, "admin");
+    const row = labs.getLab(lab.id)!;
+    expect(row.fast_quota_bytes).toBe(5000);
+    expect(row.slow_quota_bytes).toBe(2000); // unchanged
+    expect(enqueueTask).toHaveBeenCalledWith(
+      "gpu-1",
+      "lab.set_quota",
+      expect.objectContaining({ lab: "phys", fast_quota_bytes: 5000 }),
+      "admin",
+    );
+    expect(enqueueTask.mock.calls[0][2]).not.toHaveProperty("slow_quota_bytes");
+  });
+
+  it("throws for an unknown lab", () => {
+    expect(() => labs.updateQuota(999999, 1, 1)).toThrow(/Unknown lab/);
+  });
+});
+
+describe("destroyLab", () => {
+  it("enqueues lab.destroy, deletes the row, and audits", () => {
+    const lab = makeLab("geo");
+    enqueueTask.mockClear();
+    labs.destroyLab(lab.id, "admin");
+    expect(labs.getLab(lab.id)).toBeUndefined();
+    expect(enqueueTask).toHaveBeenCalledWith("gpu-1", "lab.destroy", { lab: "geo" }, "admin");
+    const audit = dbmod
+      .db()
+      .prepare("SELECT * FROM audit_log WHERE action='lab.destroy' AND target='geo'")
+      .get();
+    expect(audit).toBeTruthy();
+  });
+
+  it("is a no-op for an unknown lab (no enqueue)", () => {
+    labs.destroyLab(999999);
+    expect(enqueueTask).not.toHaveBeenCalled();
+  });
+});

--- a/controller/tests/mailer.test.ts
+++ b/controller/tests/mailer.test.ts
@@ -1,0 +1,124 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const tmp = mkdtempSync(join(tmpdir(), "lab-ctl-mailer-"));
+process.env.DB_PATH = join(tmp, "controller.db");
+process.env.SIGNUP_TOKEN = "t";
+process.env.AGENT_TOKEN = "t";
+process.env.SESSION_SECRET = "test-session-secret-test-session";
+
+// Capture the messages handed to nodemailer instead of opening an SMTP socket.
+const sent: any[] = [];
+let failNext = false;
+const sendMailImpl = vi.fn(async (msg: any) => {
+  if (failNext) throw new Error("smtp down");
+  sent.push(msg);
+  return { messageId: "1" };
+});
+vi.mock("nodemailer", () => ({
+  default: { createTransport: () => ({ sendMail: sendMailImpl }) },
+}));
+
+let dbmod: typeof import("../src/lib/db");
+let settings: typeof import("../src/lib/settings");
+let mailer: typeof import("../src/lib/mailer");
+
+beforeAll(async () => {
+  dbmod = await import("../src/lib/db");
+  settings = await import("../src/lib/settings");
+  mailer = await import("../src/lib/mailer");
+  void dbmod;
+});
+
+beforeEach(() => {
+  sent.length = 0;
+  failNext = false;
+  sendMailImpl.mockClear();
+});
+
+function configureSmtp() {
+  settings.setSetting("smtpHost", "smtp.uga.edu");
+  settings.setSetting("smtpFrom", "labs@uga.edu");
+}
+
+describe("sendMail gating", () => {
+  it("skips when SMTP is not configured", async () => {
+    settings.setSetting("smtpHost", "");
+    settings.setSetting("smtpFrom", "");
+    const res = await mailer.sendMail("a@uga.edu", "s", "b");
+    expect(res).toEqual({ sent: false, skipped: true });
+    expect(sendMailImpl).not.toHaveBeenCalled();
+  });
+
+  it("skips when there is no recipient", async () => {
+    configureSmtp();
+    const res = await mailer.sendMail("", "s", "b");
+    expect(res.skipped).toBe(true);
+  });
+
+  it("sends when configured, using the From setting", async () => {
+    configureSmtp();
+    const res = await mailer.sendMail("a@uga.edu", "Subject", "Body");
+    expect(res).toEqual({ sent: true });
+    expect(sent[0]).toMatchObject({ from: "labs@uga.edu", to: "a@uga.edu", subject: "Subject", text: "Body" });
+  });
+
+  it("returns the error message when the transport throws", async () => {
+    configureSmtp();
+    failNext = true;
+    const res = await mailer.sendMail("a@uga.edu", "s", "b");
+    expect(res.sent).toBe(false);
+    expect(res.error).toBe("smtp down");
+  });
+});
+
+describe("templated emails", () => {
+  beforeEach(configureSmtp);
+
+  it("credential email contains the ssh command, username and password", async () => {
+    const res = await mailer.sendCredentialEmail({
+      to: "a@uga.edu", name: "Alice", username: "alice", password: "pw123",
+      host: "gpu-1", port: 2222, lab: "bio",
+    });
+    expect(res.sent).toBe(true);
+    expect(sent[0].subject).toBe("Your access to lab bio");
+    expect(sent[0].text).toContain("ssh alice@gpu-1 -p 2222");
+    expect(sent[0].text).toContain("Password: pw123");
+  });
+
+  it("quota email lists the per-student breakdown", async () => {
+    await mailer.sendQuotaEmail({
+      to: "pi@uga.edu", lab: "bio", pool: "fast", pct: 92,
+      usedHuman: "1.8 TB", quotaHuman: "2.0 TB",
+      breakdown: [{ username: "alice", usedHuman: "1.0 TB" }],
+    });
+    expect(sent[0].subject).toBe("Lab bio is at 92% of its fast quota");
+    expect(sent[0].text).toContain("alice");
+    expect(sent[0].text).toContain("1.0 TB");
+  });
+
+  it("quota email handles an empty breakdown", async () => {
+    await mailer.sendQuotaEmail({
+      to: "pi@uga.edu", lab: "bio", pool: "slow", pct: 95,
+      usedHuman: "x", quotaHuman: "y", breakdown: [],
+    });
+    expect(sent[0].text).toContain("(no per-student usage reported yet)");
+  });
+
+  it("gpu warning and kill emails mention the pid", async () => {
+    await mailer.sendGpuWarningEmail("a@uga.edu", { lab: "bio", pid: 42, graceMinutes: 10 });
+    expect(sent[0].text).toContain("PID 42");
+    expect(sent[0].text).toContain("10 minutes");
+    await mailer.sendGpuKillEmail("a@uga.edu", { lab: null, pid: 7 });
+    expect(sent[1].text).toContain("PID 7");
+  });
+
+  it("removal email distinguishes deleted vs retained data", async () => {
+    await mailer.sendRemovalEmail("a@uga.edu", "bio", true);
+    expect(sent[0].text).toContain("has been deleted");
+    await mailer.sendRemovalEmail("a@uga.edu", "bio", false);
+    expect(sent[1].text).toContain("retained");
+  });
+});

--- a/controller/tests/maintenance.test.ts
+++ b/controller/tests/maintenance.test.ts
@@ -1,0 +1,73 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const tmp = mkdtempSync(join(tmpdir(), "lab-ctl-maint-"));
+process.env.DB_PATH = join(tmp, "controller.db");
+process.env.SIGNUP_TOKEN = "t";
+process.env.AGENT_TOKEN = "t";
+process.env.SESSION_SECRET = "test-session-secret-test-session";
+
+const enqueueTask = vi.fn(() => ({ id: "x" }));
+vi.mock("../src/lib/queue", () => ({ enqueueTask }));
+
+const backupAll = vi.fn(async () => ({ ok: true }));
+vi.mock("../src/lib/backup", () => ({ backupAll }));
+
+let dbmod: typeof import("../src/lib/db");
+let maintenance: typeof import("../src/lib/maintenance");
+let settings: typeof import("../src/lib/settings");
+
+beforeAll(async () => {
+  dbmod = await import("../src/lib/db");
+  maintenance = await import("../src/lib/maintenance");
+  settings = await import("../src/lib/settings");
+});
+
+beforeEach(() => {
+  enqueueTask.mockClear();
+});
+
+describe("pruneOldData", () => {
+  it("deletes logs and gpu_events older than the retention window, keeping recent rows", () => {
+    settings.setSetting("logRetentionDays", 30);
+    const now = Date.now();
+    const old = now - 40 * 86400 * 1000;
+    const recent = now - 1 * 86400 * 1000;
+
+    const insLog = dbmod
+      .db()
+      .prepare("INSERT INTO logs (node, level, source, msg, ts) VALUES ('n','INFO','s','m',?)");
+    insLog.run(old);
+    insLog.run(old);
+    insLog.run(recent);
+
+    const insGpu = dbmod
+      .db()
+      .prepare("INSERT INTO gpu_events (node, state, ts) VALUES ('n','warned',?)");
+    insGpu.run(old);
+    insGpu.run(recent);
+
+    const result = maintenance.pruneOldData();
+    expect(result.logs).toBe(2);
+    expect(result.gpuEvents).toBe(1);
+
+    const logsLeft = dbmod.db().prepare("SELECT COUNT(*) AS n FROM logs").get() as any;
+    expect(logsLeft.n).toBe(1);
+    const gpuLeft = dbmod.db().prepare("SELECT COUNT(*) AS n FROM gpu_events").get() as any;
+    expect(gpuLeft.n).toBe(1);
+  });
+
+  it("removes nothing when all rows are within retention", () => {
+    dbmod.db().prepare("DELETE FROM logs").run();
+    dbmod.db().prepare("DELETE FROM gpu_events").run();
+    dbmod
+      .db()
+      .prepare("INSERT INTO logs (node, level, source, msg, ts) VALUES ('n','INFO','s','m',?)")
+      .run(Date.now());
+    const result = maintenance.pruneOldData();
+    expect(result.logs).toBe(0);
+    expect(result.gpuEvents).toBe(0);
+  });
+});

--- a/controller/tests/queue.test.ts
+++ b/controller/tests/queue.test.ts
@@ -1,0 +1,92 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const tmp = mkdtempSync(join(tmpdir(), "lab-ctl-queue-"));
+process.env.DB_PATH = join(tmp, "controller.db");
+process.env.SIGNUP_TOKEN = "t";
+process.env.AGENT_TOKEN = "t";
+process.env.SESSION_SECRET = "test-session-secret-test-session";
+
+// Real honker queue (writes queue.db next to controller.db).
+let dbmod: typeof import("../src/lib/db");
+let queue: typeof import("../src/lib/queue");
+
+beforeAll(async () => {
+  dbmod = await import("../src/lib/db");
+  queue = await import("../src/lib/queue");
+});
+
+describe("enqueueTask", () => {
+  it("returns a task frame and mirrors it into task_log as queued", () => {
+    const frame = queue.enqueueTask("gpu-1", "lab.create", { lab: "bio" }, "admin");
+    expect(frame.type).toBe("task");
+    expect(frame.action).toBe("lab.create");
+    expect(frame.params).toEqual({ lab: "bio" });
+    expect(frame.requested_by).toBe("admin");
+    expect(typeof frame.id).toBe("string");
+
+    const row = dbmod.db().prepare("SELECT * FROM task_log WHERE task_uuid = ?").get(frame.id) as any;
+    expect(row.state).toBe("queued");
+    expect(row.node).toBe("gpu-1");
+    expect(row.action).toBe("lab.create");
+    expect(JSON.parse(row.params)).toEqual({ lab: "bio" });
+    expect(row.requested_by).toBe("admin");
+  });
+
+  it("generates a unique id per task", () => {
+    const a = queue.enqueueTask("gpu-1", "node.scrub");
+    const b = queue.enqueueTask("gpu-1", "node.scrub");
+    expect(a.id).not.toBe(b.id);
+  });
+});
+
+describe("claim / ack", () => {
+  it("claims a queued task for the destination node, then acks it (no redelivery)", () => {
+    const frame = queue.enqueueTask("worker-node", "lab.set_quota", { lab: "x" });
+    const claimed = queue.claimTask("worker-node", "w1");
+    expect(claimed).not.toBeNull();
+    expect(claimed!.frame.id).toBe(frame.id);
+    expect(claimed!.frame.params).toEqual({ lab: "x" });
+    expect(typeof claimed!.jobId).toBe("number");
+    // ack must pass the claiming worker id; once acked the task is gone.
+    queue.ackTask("worker-node", claimed!.jobId, "w1");
+    expect(queue.claimTask("worker-node", "w1")).toBeNull();
+  });
+
+  it("does not deliver another node's tasks", () => {
+    queue.enqueueTask("node-a", "lab.create");
+    expect(queue.claimTask("node-b", "w1")).toBeNull();
+  });
+
+  it("returns null when the queue is empty", () => {
+    expect(queue.claimTask("empty-node", "w1")).toBeNull();
+  });
+
+  it("retryTask makes the job claimable again without throwing", () => {
+    queue.enqueueTask("retry-node", "node.scrub");
+    const claimed = queue.claimTask("retry-node", "w1")!;
+    expect(() => queue.retryTask("retry-node", claimed.jobId, "w1", "send failed")).not.toThrow();
+  });
+});
+
+describe("markTaskState", () => {
+  it("transitions task_log state and stores the result", () => {
+    const frame = queue.enqueueTask("gpu-1", "lab.create", { lab: "y" });
+    queue.markTaskState(frame.id, "ok", { container: "abc" });
+    const row = dbmod.db().prepare("SELECT * FROM task_log WHERE task_uuid = ?").get(frame.id) as any;
+    expect(row.state).toBe("ok");
+    expect(JSON.parse(row.result)).toEqual({ container: "abc" });
+    expect(row.error).toBeNull();
+  });
+
+  it("stores an error string on failure", () => {
+    const frame = queue.enqueueTask("gpu-1", "lab.create");
+    queue.markTaskState(frame.id, "failed", undefined, "boom");
+    const row = dbmod.db().prepare("SELECT * FROM task_log WHERE task_uuid = ?").get(frame.id) as any;
+    expect(row.state).toBe("failed");
+    expect(row.result).toBeNull();
+    expect(row.error).toBe("boom");
+  });
+});

--- a/controller/tests/settings.test.ts
+++ b/controller/tests/settings.test.ts
@@ -1,0 +1,145 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const tmp = mkdtempSync(join(tmpdir(), "lab-ctl-settings-"));
+process.env.DB_PATH = join(tmp, "controller.db");
+process.env.SIGNUP_TOKEN = "t";
+process.env.AGENT_TOKEN = "t";
+process.env.SESSION_SECRET = "test-session-secret-test-session";
+
+const enqueueTask = vi.fn((..._args: unknown[]) => ({ id: "x" }));
+vi.mock("../src/lib/queue", () => ({ enqueueTask }));
+
+let dbmod: typeof import("../src/lib/db");
+let settings: typeof import("../src/lib/settings");
+
+beforeAll(async () => {
+  dbmod = await import("../src/lib/db");
+  settings = await import("../src/lib/settings");
+});
+
+beforeEach(() => {
+  enqueueTask.mockClear();
+});
+
+describe("getSetting / setSetting", () => {
+  it("returns the typed default when unset", () => {
+    expect(settings.getSetting("fastQuotaDefaultBytes")).toBe(2 * settings.TIB);
+    expect(settings.getSetting("alertLevel")).toBe("ERROR");
+  });
+
+  it("roundtrips a value through JSON", () => {
+    settings.setSetting("quotaAlertPct", 75);
+    expect(settings.getSetting("quotaAlertPct")).toBe(75);
+    settings.setSetting("gpuEnabled", true);
+    expect(settings.getSetting("gpuEnabled")).toBe(true);
+  });
+
+  it("falls back to default when the stored value is corrupt JSON", () => {
+    dbmod
+      .db()
+      .prepare(
+        "INSERT INTO settings (key, value) VALUES ('oldFileThresholdDays', 'not json') ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+      )
+      .run();
+    expect(settings.getSetting("oldFileThresholdDays")).toBe(30);
+  });
+});
+
+describe("getSettings", () => {
+  it("returns every key, merging stored values over defaults", () => {
+    settings.setSetting("sshPortStart", 40000);
+    const all = settings.getSettings();
+    expect(Object.keys(all).length).toBe(Object.keys(settings.DEFAULT_SETTINGS).length);
+    expect(all.sshPortStart).toBe(40000);
+    expect(all.smtpPort).toBe(587); // default preserved
+  });
+});
+
+describe("configuration helpers", () => {
+  it("isSmtpConfigured needs both host and from", () => {
+    settings.setSetting("smtpHost", "");
+    settings.setSetting("smtpFrom", "");
+    expect(settings.isSmtpConfigured()).toBe(false);
+    settings.setSetting("smtpHost", "smtp.uga.edu");
+    expect(settings.isSmtpConfigured()).toBe(false);
+    settings.setSetting("smtpFrom", "labs@uga.edu");
+    expect(settings.isSmtpConfigured()).toBe(true);
+  });
+
+  it("isWebdavConfigured + webdavConfig strip the trailing slash", () => {
+    settings.setSetting("webdavUrl", "");
+    expect(settings.isWebdavConfigured()).toBe(false);
+    settings.setSetting("webdavUrl", "https://dav.example/labmgr/");
+    settings.setSetting("webdavUser", "bob");
+    settings.setSetting("webdavPass", "pw");
+    expect(settings.isWebdavConfigured()).toBe(true);
+    expect(settings.webdavConfig()).toEqual({
+      url: "https://dav.example/labmgr",
+      user: "bob",
+      pass: "pw",
+    });
+  });
+});
+
+describe("gpuPolicyPayload", () => {
+  it("parses comma-separated whitelists, trimming and dropping blanks", () => {
+    settings.setSetting("gpuEnabled", true);
+    settings.setSetting("gpuUtilThreshold", 8);
+    settings.setSetting("gpuIdleMinutes", 15);
+    settings.setSetting("gpuWhitelistUsers", " root , admin ,, ");
+    settings.setSetting("gpuWhitelistLabs", "bio");
+    const payload = settings.gpuPolicyPayload();
+    expect(payload).toMatchObject({
+      enabled: true,
+      util_threshold: 8,
+      idle_minutes: 15,
+      whitelist_users: ["root", "admin"],
+      whitelist_labs: ["bio"],
+    });
+  });
+});
+
+describe("broadcastGpuPolicy", () => {
+  it("enqueues gpu.policy.update to every known node", () => {
+    dbmod.db().prepare("INSERT INTO nodes (name, online, created_at) VALUES ('n1', 1, 0)").run();
+    dbmod.db().prepare("INSERT INTO nodes (name, online, created_at) VALUES ('n2', 0, 0)").run();
+    settings.broadcastGpuPolicy("admin");
+    expect(enqueueTask).toHaveBeenCalledTimes(2);
+    const nodes = enqueueTask.mock.calls.map((c) => c[0]).sort();
+    expect(nodes).toEqual(["n1", "n2"]);
+    expect(enqueueTask.mock.calls[0][1]).toBe("gpu.policy.update");
+    expect(enqueueTask.mock.calls[0][3]).toBe("admin");
+  });
+});
+
+describe("nextSshPort", () => {
+  it("returns the lowest free port, skipping assigned ones", () => {
+    dbmod.db().prepare("DELETE FROM labs").run();
+    settings.setSetting("sshPortStart", 50000);
+    settings.setSetting("sshPortEnd", 50005);
+    const nodeId = (dbmod.db().prepare("SELECT id FROM nodes WHERE name='n1'").get() as any).id;
+    dbmod
+      .db()
+      .prepare(
+        "INSERT INTO labs (name, node_id, fast_quota_bytes, slow_quota_bytes, image, ssh_port, created_at) VALUES ('l1', ?, 1, 1, 'i', 50000, 0)",
+      )
+      .run(nodeId);
+    expect(settings.nextSshPort()).toBe(50001);
+  });
+
+  it("throws when the whole range is exhausted", () => {
+    settings.setSetting("sshPortStart", 60000);
+    settings.setSetting("sshPortEnd", 60000);
+    const nodeId = (dbmod.db().prepare("SELECT id FROM nodes WHERE name='n1'").get() as any).id;
+    dbmod
+      .db()
+      .prepare(
+        "INSERT INTO labs (name, node_id, fast_quota_bytes, slow_quota_bytes, image, ssh_port, created_at) VALUES ('l2', ?, 1, 1, 'i', 60000, 0)",
+      )
+      .run(nodeId);
+    expect(() => settings.nextSshPort()).toThrow(/No free SSH port/);
+  });
+});

--- a/controller/tests/students.test.ts
+++ b/controller/tests/students.test.ts
@@ -1,0 +1,133 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const tmp = mkdtempSync(join(tmpdir(), "lab-ctl-students-"));
+process.env.DB_PATH = join(tmp, "controller.db");
+process.env.SIGNUP_TOKEN = "t";
+process.env.AGENT_TOKEN = "t";
+process.env.SESSION_SECRET = "test-session-secret-test-session";
+
+const enqueueTask = vi.fn(() => ({ id: "x" }));
+vi.mock("../src/lib/queue", () => ({ enqueueTask }));
+
+const sendCredentialEmail = vi.fn(async (..._args: unknown[]) => ({ sent: true }));
+const sendRemovalEmail = vi.fn(async () => ({ sent: true }));
+vi.mock("../src/lib/mailer", () => ({ sendCredentialEmail, sendRemovalEmail }));
+
+let dbmod: typeof import("../src/lib/db");
+let students: typeof import("../src/lib/students");
+let labs: typeof import("../src/lib/labs");
+let labId: number;
+
+beforeAll(async () => {
+  dbmod = await import("../src/lib/db");
+  students = await import("../src/lib/students");
+  labs = await import("../src/lib/labs");
+  dbmod.db().prepare("INSERT INTO nodes (name, online, created_at) VALUES ('gpu-1', 1, 0)").run();
+  const nodeId = (dbmod.db().prepare("SELECT id FROM nodes WHERE name='gpu-1'").get() as any).id;
+  const lab = labs.createLab({
+    name: "bio",
+    nodeId,
+    fastQuotaBytes: 1000,
+    slowQuotaBytes: 2000,
+    image: "custom-ssh",
+    sshPort: 2222,
+  });
+  labId = lab.id;
+});
+
+beforeEach(() => {
+  enqueueTask.mockClear();
+  sendCredentialEmail.mockClear();
+  sendRemovalEmail.mockClear();
+});
+
+describe("generatePassword", () => {
+  it("produces the requested length from the safe alphabet", () => {
+    const pw = students.generatePassword(16);
+    expect(pw).toHaveLength(16);
+    expect(pw).toMatch(/^[a-zA-Z0-9]+$/);
+    // Avoids visually ambiguous characters (l, o, I, O, 0, 1).
+    expect(pw).not.toMatch(/[loIO01]/);
+  });
+
+  it("defaults to length 12 and is non-deterministic", () => {
+    expect(students.generatePassword()).toHaveLength(12);
+    expect(students.generatePassword()).not.toBe(students.generatePassword());
+  });
+});
+
+describe("findOrCreateStudent", () => {
+  it("creates a student then returns the same row on repeat", () => {
+    const a = students.findOrCreateStudent({ username: "newbie", email: "n@uga.edu" });
+    const b = students.findOrCreateStudent({ username: "newbie" });
+    expect(a.id).toBe(b.id);
+    expect(b.email).toBe("n@uga.edu");
+  });
+});
+
+describe("addStudentToLab", () => {
+  it("creates membership, enqueues student.add, and emails credentials", async () => {
+    const res = await students.addStudentToLab(labId, { username: "alice", email: "a@uga.edu" }, "admin");
+    expect(res.student.username).toBe("alice");
+    expect(res.password).toHaveLength(12);
+    expect(res.emailed).toBe(true);
+
+    const member = dbmod
+      .db()
+      .prepare(
+        "SELECT * FROM lab_members WHERE lab_id=? AND student_id=(SELECT id FROM students WHERE username='alice')",
+      )
+      .get(labId);
+    expect(member).toBeTruthy();
+
+    expect(enqueueTask).toHaveBeenCalledWith(
+      "gpu-1",
+      "student.add",
+      expect.objectContaining({ lab: "bio", username: "alice", password: res.password }),
+      "admin",
+    );
+    const cred = sendCredentialEmail.mock.calls[0][0] as any;
+    expect(cred).toMatchObject({ to: "a@uga.edu", username: "alice", port: 2222, lab: "bio" });
+  });
+
+  it("does not email when the student has no address", async () => {
+    const res = await students.addStudentToLab(labId, { username: "bob" });
+    expect(res.emailed).toBe(false);
+    expect(sendCredentialEmail).not.toHaveBeenCalled();
+  });
+
+  it("rejects a duplicate membership", async () => {
+    await students.addStudentToLab(labId, { username: "carol", email: "c@uga.edu" });
+    await expect(students.addStudentToLab(labId, { username: "carol" })).rejects.toThrow(
+      /already a member/,
+    );
+  });
+
+  it("throws for an unknown lab", async () => {
+    await expect(students.addStudentToLab(999999, { username: "x" })).rejects.toThrow(/Unknown lab/);
+  });
+});
+
+describe("listMembers / removeStudentFromLab", () => {
+  it("lists members and removes one, enqueuing student.remove + removal email", async () => {
+    await students.addStudentToLab(labId, { username: "dave", email: "d@uga.edu" });
+    const before = students.listMembers(labId);
+    const dave = before.find((m) => m.username === "dave")!;
+    expect(dave).toBeTruthy();
+
+    enqueueTask.mockClear();
+    students.removeStudentFromLab(labId, dave.id, true, "admin");
+
+    expect(enqueueTask).toHaveBeenCalledWith(
+      "gpu-1",
+      "student.remove",
+      { lab: "bio", username: "dave", delete_data: true },
+      "admin",
+    );
+    expect(sendRemovalEmail).toHaveBeenCalledWith("d@uga.edu", "bio", true);
+    expect(students.listMembers(labId).find((m) => m.username === "dave")).toBeUndefined();
+  });
+});

--- a/controller/tests/webdav.test.ts
+++ b/controller/tests/webdav.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as webdav from "../src/lib/webdav";
+
+const cfg = { url: "https://dav.example/labmgr", user: "bob", pass: "s3cret" };
+
+type Call = { url: string; init: any };
+let calls: Call[];
+
+function mockFetch(make: (call: Call) => Partial<Response> & { _text?: string; _buf?: Buffer }) {
+  return vi.fn(async (url: string, init: any) => {
+    const call = { url, init };
+    calls.push(call);
+    const r = make(call);
+    return {
+      ok: r.ok ?? true,
+      status: r.status ?? 200,
+      statusText: (r as any).statusText ?? "OK",
+      text: async () => r._text ?? "",
+      arrayBuffer: async () => {
+        const b = r._buf ?? Buffer.alloc(0);
+        return b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength);
+      },
+    } as unknown as Response;
+  });
+}
+
+beforeEach(() => {
+  calls = [];
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("auth header", () => {
+  it("sends HTTP basic auth derived from user:pass", async () => {
+    vi.stubGlobal("fetch", mockFetch(() => ({ ok: true })));
+    await webdav.put(cfg, "f.db", Buffer.from("x"));
+    const expected = "Basic " + Buffer.from("bob:s3cret").toString("base64");
+    expect(calls[0].init.headers.Authorization).toBe(expected);
+  });
+
+  it("omits auth when no user is configured", async () => {
+    vi.stubGlobal("fetch", mockFetch(() => ({ ok: true })));
+    await webdav.put({ ...cfg, user: "" }, "f.db", Buffer.from("x"));
+    expect(calls[0].init.headers.Authorization).toBeUndefined();
+  });
+});
+
+describe("put", () => {
+  it("PUTs to url/name and resolves on success", async () => {
+    vi.stubGlobal("fetch", mockFetch(() => ({ ok: true, status: 201 })));
+    await webdav.put(cfg, "controller-1.db", Buffer.from("data"));
+    expect(calls[0].url).toBe("https://dav.example/labmgr/controller-1.db");
+    expect(calls[0].init.method).toBe("PUT");
+  });
+
+  it("throws on a non-ok status", async () => {
+    vi.stubGlobal("fetch", mockFetch(() => ({ ok: false, status: 507, statusText: "Insufficient Storage" })));
+    await expect(webdav.put(cfg, "f.db", Buffer.from("x"))).rejects.toThrow(/507 Insufficient Storage/);
+  });
+});
+
+describe("get", () => {
+  it("returns the body as a Buffer", async () => {
+    const payload = Buffer.from("SQLite format 3\0");
+    vi.stubGlobal("fetch", mockFetch(() => ({ ok: true, _buf: payload })));
+    const out = await webdav.get(cfg, "controller-latest.db");
+    expect(Buffer.isBuffer(out)).toBe(true);
+    expect(out.equals(payload)).toBe(true);
+  });
+
+  it("throws on a non-ok status", async () => {
+    vi.stubGlobal("fetch", mockFetch(() => ({ ok: false, status: 404 })));
+    await expect(webdav.get(cfg, "missing.db")).rejects.toThrow(/404/);
+  });
+});
+
+describe("del", () => {
+  it("issues a DELETE to url/name", async () => {
+    vi.stubGlobal("fetch", mockFetch(() => ({ ok: true })));
+    await webdav.del(cfg, "old.db");
+    expect(calls[0].init.method).toBe("DELETE");
+    expect(calls[0].url).toBe("https://dav.example/labmgr/old.db");
+  });
+});
+
+describe("list", () => {
+  it("parses PROPFIND hrefs into basenames, excluding the collection itself", async () => {
+    const xml = `<?xml version="1.0"?>
+    <d:multistatus xmlns:d="DAV:">
+      <d:response><d:href>/labmgr/</d:href></d:response>
+      <d:response><d:href>/labmgr/controller-1000.db</d:href></d:response>
+      <d:response><d:href>/labmgr/controller-2000.db</d:href></d:response>
+    </d:multistatus>`;
+    vi.stubGlobal("fetch", mockFetch(() => ({ ok: true, _text: xml })));
+    const names = await webdav.list(cfg);
+    expect(names).toEqual(["controller-1000.db", "controller-2000.db"]);
+    expect(calls[0].init.method).toBe("PROPFIND");
+    expect(calls[0].init.headers.Depth).toBe("1");
+  });
+
+  it("URL-decodes hrefs", async () => {
+    const xml = `<d:multistatus xmlns:d="DAV:"><d:response><d:href>/labmgr/back%20up.db</d:href></d:response></d:multistatus>`;
+    vi.stubGlobal("fetch", mockFetch(() => ({ ok: true, _text: xml })));
+    expect(await webdav.list(cfg)).toEqual(["back up.db"]);
+  });
+
+  it("returns an empty list on a non-ok status", async () => {
+    vi.stubGlobal("fetch", mockFetch(() => ({ ok: false, status: 500 })));
+    expect(await webdav.list(cfg)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add controller unit tests; fix honker ack/retry worker-id bug
- Add agent unit tests for 11 previously-untested modules

## Test plan
- CI runs the controller and agent test suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)