### PR TITLE
Security remediation: fix all 32 findings from the 2026-06-20 audit

### DIFF
--- a/.github/workflows/build-controller.yml
+++ b/.github/workflows/build-controller.yml
@@ -17,10 +17,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -28,7 +28,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE }}
           tags: |
@@ -37,10 +37,10 @@ jobs:
             type=sha
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: ./controller
           push: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
       run:
         working-directory: agent
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: "3.12"
       - name: Install
@@ -32,8 +32,8 @@ jobs:
       run:
         working-directory: controller
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: npm

--- a/README.md
+++ b/README.md
@@ -94,12 +94,24 @@ docker info | grep -i runtimes   # should list: nvidia
 
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh        # if uv is not present
-sudo uvx --from git+https://github.com/EC061/docker-mass-deployment#subdirectory=agent \
-    lab-agent install --controller wss://CONTROLLER_HOST:8443/agent --token AGENT_TOKEN
+# Pin to a released tag (not #main) and install with the shipped uv.lock so every node runs the same
+# audited code + dependency set (I-02). Replace v1.0.0 with the tag you intend to deploy.
+sudo uvx --locked --from "git+https://github.com/EC061/docker-mass-deployment@v1.0.0#subdirectory=agent" \
+    lab-agent install --controller wss://CONTROLLER_HOST:8443/agent
 ```
 
 `lab-agent install` writes `/etc/lab-agent/config.toml` and a systemd unit (`lab-agent.service`) that
-starts on boot and reconnects automatically. Check readiness any time with `lab-agent doctor`.
+starts on boot and reconnects automatically.
+
+**Provision the node's token:** in the controller UI go to **Nodes → Provision token**, then run the
+printed command on the node to apply it and restart the agent:
+
+```bash
+sudo lab-agent set-token <TOKEN-FROM-UI>
+```
+
+Each node has its own token; the controller only accepts allow-listed nodes (so a stolen token can't
+impersonate another node). Check readiness any time with `lab-agent doctor`.
 
 ### 1.6 Sharing cold storage between two nodes over SMB (optional)
 
@@ -113,9 +125,10 @@ and the other mounts it over SMB:
   agent with the SMB cold-storage backend so its containers bind-mount the shared data:
 
 ```bash
-sudo uvx --from git+https://github.com/EC061/docker-mass-deployment#subdirectory=agent \
-    lab-agent install --controller wss://CONTROLLER_HOST:8443/agent --token AGENT_TOKEN \
+sudo uvx --locked --from "git+https://github.com/EC061/docker-mass-deployment@v1.0.0#subdirectory=agent" \
+    lab-agent install --controller wss://CONTROLLER_HOST:8443/agent \
     --slow-backend smb --slow-path /mnt/cold --slow-shared
+# then provision + apply the token as above: sudo lab-agent set-token <TOKEN-FROM-UI>
 ```
 
 - `--slow-path` is where the share is mounted; labs live under `<slow-path>/labs/...`.

--- a/README.md
+++ b/README.md
@@ -133,12 +133,13 @@ The controller is a long-lived Node process (Next.js + WebSocket hub); it cannot
 
 ```bash
 cd controller
-cp .env.example .env     # set SIGNUP_TOKEN, AGENT_TOKEN, SESSION_SECRET
-# Then either:
-docker compose up -d                     # from the repo root (uses controller/Dockerfile)
-# ...or run from source for development:
-npm install && npm run dev
+cp .env.example .env     # set SIGNUP_TOKEN, AGENT_TOKEN, SESSION_SECRET (no defaults — required)
+docker compose up -d     # from the repo root (uses controller/Dockerfile); the supported deploy
 ```
+
+`npm run dev` (below, under Development) is for local hacking only — never a production deploy.
+All three secrets are mandatory in every environment and `SESSION_SECRET` must be ≥ 32 characters;
+generate them with `openssl rand -hex 32`.
 
 Env vars (controller bootstrap only — everything else is set in the UI):
 

--- a/STUDENT_GUIDE.md
+++ b/STUDENT_GUIDE.md
@@ -52,7 +52,8 @@ the GPU active while you need it. If you have a legitimate long idle job, ask an
 
 - Check your GPU usage with `nvidia-smi`.
 - Put large data in `~/scratch` (fast) while training; move finished results to `~/cold-storage`.
-- Files you create are group-writable by default (`umask 000`) so teammates in shared folders can edit
-  them.
+- Files you create default to `umask 027` — readable/writable by you, not by other students. To
+  share a file with a teammate, grant access explicitly (e.g. `chmod g+rw <file>` within a shared
+  group folder) rather than making everything world-writable.
 
 If something isn't working, contact your lab admin.

--- a/agent/src/lab_agent/cli.py
+++ b/agent/src/lab_agent/cli.py
@@ -22,7 +22,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
 def _cmd_install(args: argparse.Namespace) -> int:
     from .installer import install
 
-    cfg = AgentConfig(controller_url=args.controller, token=args.token)
+    cfg = AgentConfig(controller_url=args.controller, token=args.token or "")
     if args.node_name:
         cfg.node_name = args.node_name
     if args.fast_pool:
@@ -41,6 +41,31 @@ def _cmd_install(args: argparse.Namespace) -> int:
     result = install(cfg, config_path, enable=not args.no_enable)
     for key, value in result.items():
         print(f"{key}: {value}")
+    if not cfg.token:
+        print(
+            "note: no token set yet. Provision this node in the controller UI (Nodes -> "
+            "Provision token), then run: sudo lab-agent set-token <TOKEN>"
+        )
+    return 0
+
+
+def _cmd_set_token(args: argparse.Namespace) -> int:
+    """Write a controller-issued per-node token into the existing config and restart the service."""
+    import os
+
+    from .config import save_config
+
+    config_path = Path(args.config) if args.config else DEFAULT_CONFIG_PATH
+    cfg = load_config(config_path)
+    cfg.token = args.token
+    saved = save_config(cfg, config_path)
+    print(f"token written: {saved}")
+    if args.no_restart:
+        print("restart skipped; run `systemctl restart lab-agent` to apply.")
+        return 0
+    rc = os.system("systemctl restart lab-agent.service")
+    print("restarted lab-agent.service" if rc == 0 else
+          "could not restart automatically; run `systemctl restart lab-agent` manually.")
     return 0
 
 
@@ -76,7 +101,8 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_install = sub.add_parser("install", help="write config + systemd unit")
     p_install.add_argument("--controller", required=True, help="controller URL, e.g. wss://host:port")
-    p_install.add_argument("--token", required=True, help="agent auth token")
+    p_install.add_argument("--token", help="per-node token from the controller UI (or set it later "
+                                          "with `lab-agent set-token`)")
     p_install.add_argument("--node-name", help="override node name (default: hostname)")
     p_install.add_argument("--fast-pool", help="fast ZFS pool name (default: fast)")
     p_install.add_argument("--slow-pool", help="slow ZFS pool name (default: slow)")
@@ -91,6 +117,12 @@ def build_parser() -> argparse.ArgumentParser:
     p_install.add_argument("--no-enable", action="store_true",
                            help="write files but do not enable/start the service")
     p_install.set_defaults(func=_cmd_install)
+
+    p_set_token = sub.add_parser("set-token", help="write a controller-issued token and restart")
+    p_set_token.add_argument("token", help="the per-node token shown in the controller UI")
+    p_set_token.add_argument("--no-restart", action="store_true",
+                             help="write the token but do not restart the service")
+    p_set_token.set_defaults(func=_cmd_set_token)
 
     p_doctor = sub.add_parser("doctor", help="check zfs/docker/nvidia/pools")
     p_doctor.set_defaults(func=_cmd_doctor)

--- a/agent/src/lab_agent/client.py
+++ b/agent/src/lab_agent/client.py
@@ -75,6 +75,19 @@ class Agent:
                     await self._on_connected(ws)
             except asyncio.CancelledError:
                 raise
+            except websockets.exceptions.ConnectionClosed as exc:
+                # The hub closes with a 40xx code + reason when it rejects our identity. Surface it
+                # clearly so operators know to (re)provision rather than chase a network ghost.
+                code = getattr(exc, "code", None)
+                reason = getattr(exc, "reason", "") or ""
+                if code in (4001, 4003):
+                    self.log.error(
+                        "client",
+                        f"controller rejected this node (code {code}: {reason}). "
+                        "Provision/rotate its token in the UI and run `lab-agent set-token`.",
+                    )
+                else:
+                    self.log.warn("client", f"connection closed (code {code}: {reason})")
             except Exception as exc:  # connection refused/dropped/etc.
                 self.log.warn("client", f"controller connection failed: {exc}")
             self._connected.clear()

--- a/agent/src/lab_agent/client.py
+++ b/agent/src/lab_agent/client.py
@@ -44,6 +44,14 @@ class Agent:
             return None
         ctx = ssl.create_default_context()
         if not self.cfg.tls_verify:
+            # The agent then sends AGENT_TOKEN over a link with no server authentication, so a MITM
+            # can harvest the fleet token. Loudly flag it (L-08); prefer pinning a CA instead.
+            self.log.warn(
+                "client",
+                "TLS verification is DISABLED (tls_verify=false): the controller is not "
+                "authenticated and the agent token can be intercepted by a man-in-the-middle. "
+                "Use a trusted/pinned CA instead for anything beyond a closed lab network.",
+            )
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE
         return ctx
@@ -183,7 +191,15 @@ class Agent:
                         "state": "killed" if d.action == "kill" else "warned",
                     }
                     if d.action == "kill":
-                        await asyncio.to_thread(monitor.kill_pid, d.pid)
+                        # Re-verify the PID identity right before killing (M-06): if the original
+                        # process already exited and the PID was recycled, skip the kill.
+                        killed = await asyncio.to_thread(
+                            monitor.kill_pid, d.pid, d.proc.get("start_time")
+                        )
+                        if not killed:
+                            self.log.info("gpu", f"skipped kill of pid {d.pid}: process gone",
+                                          lab=d.lab, user=d.user)
+                            continue
                         self.log.warn("gpu", f"killed idle GPU pid {d.pid} (user={d.user})",
                                       lab=d.lab, user=d.user)
                     else:

--- a/agent/src/lab_agent/executors/docker.py
+++ b/agent/src/lab_agent/executors/docker.py
@@ -14,13 +14,39 @@ The container mounts, fixed at creation:
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 
 from .base import CommandResult, run
 
+# A docker image reference: optional registry/host, repo path, optional :tag and/or @sha256 digest.
+# Crucially it must not start with '-' (which docker would read as a flag) and contains no spaces.
+IMAGE_RE = re.compile(
+    r"^[a-zA-Z0-9][a-zA-Z0-9._/-]*(:[a-zA-Z0-9._-]+)?(@sha256:[a-f0-9]{64})?$"
+)
+# Environment variable names: conventional shell identifiers only.
+ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
 
 class DockerError(RuntimeError):
     pass
+
+
+def validate_image(image: str) -> str:
+    if not IMAGE_RE.match(image) or len(image) > 256:
+        raise DockerError(f"invalid image reference '{image}'")
+    return image
+
+
+def sanitize_env(env: dict) -> dict[str, str]:
+    """Keep only well-formed env keys with bounded, newline-free values (L-10)."""
+    out: dict[str, str] = {}
+    for key, value in env.items():
+        if not isinstance(key, str) or not ENV_KEY_RE.match(key):
+            continue
+        sval = str(value).replace("\n", "").replace("\r", "")[:1024]
+        out[key] = sval
+    return out
 
 
 def container_name(lab: str) -> str:
@@ -79,6 +105,7 @@ def build_run_args(
     if storage_quota_supported and opts.image_quota:
         args += ["--storage-opt", f"size={opts.image_quota}"]
     args += ["--restart", opts.restart]
+    validate_image(opts.image)
     # Shared lab data.
     args += ["-v", f"{mounts.fast_shared}:/labdata/fast"]
     args += ["-v", f"{mounts.slow_shared}:/labdata/slow"]
@@ -87,7 +114,7 @@ def build_run_args(
              f"type=bind,source={mounts.fast_users},target=/labusers/fast,bind-propagation=rshared"]
     args += ["--mount",
              f"type=bind,source={mounts.slow_users},target=/labusers/slow,bind-propagation=rshared"]
-    for key, value in opts.extra_env.items():
+    for key, value in sanitize_env(opts.extra_env).items():
         args += ["-e", f"{key}={value}"]
     args.append(opts.image)
     return args

--- a/agent/src/lab_agent/executors/users.py
+++ b/agent/src/lab_agent/executors/users.py
@@ -39,16 +39,18 @@ def _run_script(container: str, script: str) -> CommandResult:
 def add_user(container: str, username: str, password: str) -> CommandResult:
     validate_username(username)
     # Password is embedded in the stdin-piped script body, never in argv.
+    # Students are NOT added to sudo (H-05): a brute-forced/shared student password would otherwise
+    # grant container root and a host-escalation foothold. umask 027 keeps each student's files
+    # private to themselves instead of world-writable.
     script = f"""set -e
 u={username}
 if ! id "$u" >/dev/null 2>&1; then useradd -m -s /bin/bash "$u"; fi
-usermod -aG sudo "$u" 2>/dev/null || true
 mkdir -p /labusers/fast/"$u" /labusers/slow/"$u"
 chown "$u":"$u" /labusers/fast/"$u" /labusers/slow/"$u"
 ln -sfn /labusers/fast/"$u" /home/"$u"/scratch
 ln -sfn /labusers/slow/"$u" /home/"$u"/cold-storage
 chown -h "$u":"$u" /home/"$u"/scratch /home/"$u"/cold-storage
-grep -q 'umask 000' /home/"$u"/.bashrc 2>/dev/null || echo 'umask 000' >> /home/"$u"/.bashrc
+grep -q '^umask ' /home/"$u"/.bashrc 2>/dev/null || echo 'umask 027' >> /home/"$u"/.bashrc
 printf '%s:%s' "$u" {_shell_quote(password)} | chpasswd
 """
     return _run_script(container, script)

--- a/agent/src/lab_agent/gpu/monitor.py
+++ b/agent/src/lab_agent/gpu/monitor.py
@@ -26,6 +26,7 @@ class GpuProcess:
     util: float | None  # SM utilization %, None if unknown
     container: str | None
     user: str | None
+    start_time: int | None = None  # /proc/<pid>/stat field 22; identifies the PID across reuse
 
 
 def _query_compute_apps() -> dict[int, int]:
@@ -115,11 +116,43 @@ def _student_user(container: str | None, pid: int) -> str | None:
     return res.stdout.split(":", 1)[0].strip() or None
 
 
-def kill_pid(pid: int) -> bool:
-    """Kill a host process (the agent runs as root). Returns True if the signal was sent."""
+def pid_start_time(pid: int) -> int | None:
+    """Process start time (clock ticks since boot) from /proc/<pid>/stat field 22.
+
+    Together with the PID this uniquely identifies a process: the kernel reuses PIDs, but a reused
+    PID is a *new* process with a different start time.
+    """
+    try:
+        with open(f"/proc/{pid}/stat", encoding="utf-8") as fh:
+            data = fh.read()
+    except OSError:
+        return None
+    # comm (field 2) may contain spaces/parens; split after the closing ')'.
+    rparen = data.rfind(")")
+    if rparen == -1:
+        return None
+    fields = data[rparen + 2:].split()
+    # After comm, field 3 is state; starttime is field 22 overall => index 19 of this slice.
+    try:
+        return int(fields[19])
+    except (IndexError, ValueError):
+        return None
+
+
+def kill_pid(pid: int, expected_start_time: int | None = None) -> bool:
+    """Kill a host process (the agent runs as root). Returns True if the signal was sent.
+
+    When expected_start_time is given, re-verify the PID still refers to the same process right
+    before signalling (M-06): the kill decision was made minutes earlier and Linux recycles PIDs, so
+    a mismatch means the original process already exited and we must NOT kill the impostor.
+    """
     import os
     import signal
 
+    if expected_start_time is not None:
+        current = pid_start_time(pid)
+        if current is None or current != expected_start_time:
+            return False
     try:
         os.kill(pid, signal.SIGKILL)
         return True
@@ -141,6 +174,7 @@ def list_gpu_processes() -> list[dict]:
                     util=util.get(pid),
                     container=container,
                     user=_student_user(container, pid),
+                    start_time=pid_start_time(pid),
                 )
             )
         )

--- a/agent/src/lab_agent/paths.py
+++ b/agent/src/lab_agent/paths.py
@@ -12,15 +12,28 @@ Layout (per node), rooted on the configured pools:
 
 from __future__ import annotations
 
+import re
+
 from .config import AgentConfig
+
+# Defense-in-depth: the controller already allow-lists lab names (lib/labs.ts), but the agent runs
+# as root, so it re-validates before a name is ever interpolated into a dataset/container argument
+# (M-04). Same shape as the controller's LAB_NAME_RE.
+LAB_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,39}$")
+
+
+def validate_lab_name(lab: str) -> str:
+    if not LAB_NAME_RE.match(lab):
+        raise ValueError(f"invalid lab name '{lab}'")
+    return lab
 
 
 def lab_fast(cfg: AgentConfig, lab: str) -> str:
-    return f"{cfg.labs_fast_root}/{lab}"
+    return f"{cfg.labs_fast_root}/{validate_lab_name(lab)}"
 
 
 def lab_slow(cfg: AgentConfig, lab: str) -> str:
-    return f"{cfg.labs_slow_root}/{lab}"
+    return f"{cfg.labs_slow_root}/{validate_lab_name(lab)}"
 
 
 def lab_fast_shared(cfg: AgentConfig, lab: str) -> str:
@@ -55,7 +68,7 @@ def user_cold(cfg: AgentConfig, lab: str, user: str) -> str:
 
 
 def cold_lab(cfg: AgentConfig, lab: str) -> str:
-    return f"{cfg.cold_root}/{lab}"
+    return f"{cfg.cold_root}/{validate_lab_name(lab)}"
 
 
 def cold_lab_shared(cfg: AgentConfig, lab: str) -> str:

--- a/agent/tests/test_cli.py
+++ b/agent/tests/test_cli.py
@@ -78,6 +78,51 @@ def test_install_enables_by_default(monkeypatch):
     assert captured["enable"] is True
 
 
+def test_install_allows_no_token(monkeypatch, capsys):
+    """Token may be supplied later via set-token; install must not require it."""
+    import lab_agent.installer as installer
+
+    captured = {}
+
+    def fake_install(cfg, path, *, enable):
+        captured["cfg"] = cfg
+        return {"status": "written (not enabled)"}
+
+    monkeypatch.setattr(installer, "install", fake_install)
+    rc = cli.main(["install", "--controller", "wss://ctl:8443", "--no-enable"])
+    assert rc == 0
+    assert captured["cfg"].token == ""
+    assert "set-token" in capsys.readouterr().out
+
+
+def test_set_token_writes_config_and_restarts(monkeypatch, tmp_path):
+    from lab_agent.config import render_config
+
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(render_config(AgentConfig(controller_url="wss://ctl:8443", token="old")))
+
+    calls = {}
+    monkeypatch.setattr("os.system", lambda cmd: calls.__setitem__("cmd", cmd) or 0)
+
+    rc = cli.main(["--config", str(config_path), "set-token", "new-token-value"])
+    assert rc == 0
+    assert 'token = "new-token-value"' in config_path.read_text()
+    assert "restart" in calls["cmd"] and "lab-agent" in calls["cmd"]
+
+
+def test_set_token_no_restart(monkeypatch, tmp_path, capsys):
+    from lab_agent.config import render_config
+
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(render_config(AgentConfig(controller_url="wss://ctl:8443", token="old")))
+
+    monkeypatch.setattr("os.system", lambda cmd: (_ for _ in ()).throw(AssertionError("should not restart")))
+    rc = cli.main(["--config", str(config_path), "set-token", "new-token", "--no-restart"])
+    assert rc == 0
+    assert 'token = "new-token"' in config_path.read_text()
+    assert "restart skipped" in capsys.readouterr().out
+
+
 def _caps(issues):
     fields = dict(
         zfs=True, docker=True, docker_zfs_driver=True, nvidia_runtime=False, nvidia_gpu=False,

--- a/agent/tests/test_docker.py
+++ b/agent/tests/test_docker.py
@@ -1,4 +1,14 @@
-from lab_agent.executors.docker import ContainerOptions, Mounts, build_run_args, container_name
+import pytest
+
+from lab_agent.executors.docker import (
+    ContainerOptions,
+    DockerError,
+    Mounts,
+    build_run_args,
+    container_name,
+    sanitize_env,
+    validate_image,
+)
 
 
 def _mounts():
@@ -60,3 +70,28 @@ def test_options_from_params():
     assert opts.memory == "4g"
     assert opts.ssh_port == 50001
     assert opts.image_quota == "30g"
+
+
+def test_validate_image_rejects_flag_injection_and_junk():
+    assert validate_image("custom-ssh") == "custom-ssh"
+    assert validate_image("ghcr.io/org/img:1.2") == "ghcr.io/org/img:1.2"
+    for bad in ["-v", "--privileged", "img name", "img;rm", ""]:
+        with pytest.raises(DockerError):
+            validate_image(bad)
+
+
+def test_build_run_args_rejects_bad_image():
+    with pytest.raises(DockerError):
+        build_run_args("lab-bio", ContainerOptions(image="--privileged"), _mounts(), gpus=False)
+
+
+def test_sanitize_env_drops_bad_keys_and_clamps_values():
+    out = sanitize_env({"OK_VAR": "v", "bad key": "x", "WITH_NL": "a\nb", "1BAD": "y"})
+    assert out == {"OK_VAR": "v", "WITH_NL": "ab"}
+
+
+def test_build_run_args_only_emits_sanitized_env():
+    opts = ContainerOptions(ssh_port=1, extra_env={"GOOD": "1", "bad-key": "2"})
+    args = build_run_args("lab-bio", opts, _mounts(), gpus=False)
+    assert "GOOD=1" in args
+    assert all("bad-key" not in a for a in args)

--- a/agent/tests/test_gpu_monitor.py
+++ b/agent/tests/test_gpu_monitor.py
@@ -36,3 +36,20 @@ def test_list_gpu_processes_merges_vram_and_util(monkeypatch):
 def test_list_gpu_processes_empty_without_nvidia(monkeypatch):
     monkeypatch.setattr(monitor, "run", lambda args, **kw: CommandResult(False, [], 127, "", "not found"))
     assert monitor.list_gpu_processes() == []
+
+
+def test_kill_pid_skips_on_start_time_mismatch(monkeypatch):
+    killed = {}
+    monkeypatch.setattr(monitor, "pid_start_time", lambda pid: 9999)  # current != expected
+    monkeypatch.setattr("os.kill", lambda pid, sig: killed.setdefault("hit", True))
+    # expected_start_time differs from current -> must NOT kill (PID was recycled).
+    assert monitor.kill_pid(4242, expected_start_time=1234) is False
+    assert "hit" not in killed
+
+
+def test_kill_pid_proceeds_on_start_time_match(monkeypatch):
+    killed = {}
+    monkeypatch.setattr(monitor, "pid_start_time", lambda pid: 1234)
+    monkeypatch.setattr("os.kill", lambda pid, sig: killed.setdefault("pid", pid))
+    assert monitor.kill_pid(4242, expected_start_time=1234) is True
+    assert killed["pid"] == 4242

--- a/agent/tests/test_users.py
+++ b/agent/tests/test_users.py
@@ -29,7 +29,9 @@ def test_add_user_script_creates_user_and_links(cap):
     assert "useradd -m -s /bin/bash" in script
     assert "ln -sfn /labusers/fast/" in script
     assert "ln -sfn /labusers/slow/" in script
-    assert "umask 000" in script
+    assert "umask 027" in script
+    # Students must NOT be granted sudo (H-05).
+    assert "sudo" not in script
     assert "chpasswd" in script
     # Password is in the piped script body, not in argv.
     assert "s3cret" in script

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -1,0 +1,208 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "honker"
+version = "0.2.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/a2/ce5fce973ca620d78cb7595a07b64d0a5498b240b14d6bb6a011ff501f26/honker-0.2.6-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:feca2473e2bab1c86d512f4ad0ae48490000842412bf15e6df115220fad12dc6", size = 935503, upload-time = "2026-06-05T07:52:46.305Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/34ba2389d68e03e21c5c1bf12f7ae6ac0e686c0615b2a593d5388a4c5559/honker-0.2.6-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:d601701862d245eb33a7036a0357e20d2b63fecc379278d280c7eb152572fc67", size = 915749, upload-time = "2026-06-05T07:53:57.243Z" },
+    { url = "https://files.pythonhosted.org/packages/96/08/22d47229061803120601ad8e64c47ebef52b1cdd282453a323b3a8ffd051/honker-0.2.6-cp311-abi3-manylinux_2_38_aarch64.whl", hash = "sha256:e2ba9d2c32590e08db47d1e3209d96ebaa0b6372dd500b0510d10c1d81e7a3d6", size = 1806143, upload-time = "2026-06-05T07:50:36.244Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/2c/5c8849695811f737242c79840d655914638afe522255a91627c6755e41c7/honker-0.2.6-cp311-abi3-manylinux_2_38_x86_64.whl", hash = "sha256:bc632296b727e591d9dc10087b5bb13e35d1307bb55737107d18de32791ac6c6", size = 1814082, upload-time = "2026-06-05T07:50:32.361Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/a5/c06a39fd3ea545da254278982be3d529d505688a2bd1fe1a40df1b548a70/honker-0.2.6-cp311-abi3-win_amd64.whl", hash = "sha256:49d05bb7ea270ac3a6377269863c5d825f25118b909b65cb1b542d2445290ea6", size = 1609580, upload-time = "2026-06-05T07:51:50.061Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "lab-agent"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "honker" },
+    { name = "websockets" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "honker", specifier = ">=0.2.6" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
+    { name = "websockets", specifier = ">=12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/98/1295ad5a5aa9bc85bdcdfa5d82fe7b49c61af5657df4f227637ff9de0da6/ruff-0.15.18.tar.gz", hash = "sha256:2698a964c70e8bf402dcb99c8810472d270d141e7aa8c4e13599fd52033a2f33", size = 4761437, upload-time = "2026-06-18T18:25:39.224Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/d0/686e984941269621e2be72612d5c1e461f8f7b38415a2a7d7a81c8ae6715/ruff-0.15.18-py3-none-linux_armv6l.whl", hash = "sha256:8b6850172348c8381b8b3084c5915a4393c2373b9b54cd5b5e1ea15812bc10df", size = 10887308, upload-time = "2026-06-18T18:25:03.062Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/21/bc4123e3f5515ee99f8ce1eb93a14a0628fe4d1678663cd08f933ac16931/ruff-0.15.18-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3fccc153a85417dcd976883160cacce486997b0a0058dd18f54b8aaaac7d1ce2", size = 11281305, upload-time = "2026-06-18T18:25:30.026Z" },
+    { url = "https://files.pythonhosted.org/packages/51/93/4769464c25cf7ab2acb3c7dda9cad3d867eb41c59565b3e2a9d17249c90c/ruff-0.15.18-py3-none-macosx_11_0_arm64.whl", hash = "sha256:08d4c86a68f2c3ec2c9d56380a71fb4a4f65373055cbb8caabd645e9102f38d4", size = 10641215, upload-time = "2026-06-18T18:25:15.802Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/42/56926d17120db2c208d76bf60a1a019644dd9e91dc27f0f95c9caddb1366/ruff-0.15.18-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37e5108745c2c0705da916d7d4de533ddf547051ef45f62888c31bae73f66318", size = 10957224, upload-time = "2026-06-18T18:25:36.955Z" },
+    { url = "https://files.pythonhosted.org/packages/22/4f/d43fab8d8189afde803103022d000a8ef9f230616d436d52a8b2b8d63b50/ruff-0.15.18-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56949a6ce8b3abde54c0bcb22cebfe57e8771cadc84b407ae8b8eaf67ebdcd43", size = 10699024, upload-time = "2026-06-18T18:25:05.707Z" },
+    { url = "https://files.pythonhosted.org/packages/63/42/1e3e4c68bd408b9768cf3e439acbe2c78245225faef253f7028a0cdb63e0/ruff-0.15.18-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:01a754cd6a1b630d3f97e33eb452cf7a98040482318e870f8bc52a5a30e62657", size = 11491458, upload-time = "2026-06-18T18:25:20.275Z" },
+    { url = "https://files.pythonhosted.org/packages/20/77/47a3484bea8521e14a203d98c389c5c97846675e4f02734672da4a69b52a/ruff-0.15.18-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6ba7a07e03a44dbf10bb086ee06705b173625014ec99f73a7e6836a5e5590a0c", size = 12383752, upload-time = "2026-06-18T18:25:22.535Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ca/054159590787023d83b658a1a1819c4c8910114e7015069340b71c0961cb/ruff-0.15.18-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5a2c40a41a4cadbcf5897b548ab29dfe248b20c540961c0247d98a3973c70403", size = 11577923, upload-time = "2026-06-18T18:25:10.702Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ff/d353d6b7bbd73cc0ec37f4463d7540e45e894338abdd9964eee0de332708/ruff-0.15.18-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f0480ce690cbb6c4db6e5d08f19fce98e10ba131a8b60c1bcdac42771e3ae2d", size = 11583925, upload-time = "2026-06-18T18:25:32.391Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4a/891f89b9c296ed3e5f3ece1a5629badc989d9a8fdaa30431aaf4774bc1c2/ruff-0.15.18-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2330215f1f393fa8733f55edce04fcf94c36a2c460fcde31f78cc84e4951e9b1", size = 11582834, upload-time = "2026-06-18T18:25:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a3/ed9e370154bf85de360b93c03026157f02d4943b2d01ff4945f4429f8e8a/ruff-0.15.18-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6aa6a3d979e48ae617578183674bf264fbe7d0114a796a26bd678d67963c7ff", size = 10927328, upload-time = "2026-06-18T18:25:34.676Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d1/5cf5909329fedb5d39d555ee818ba5cf4638e1a301b89785d34f2905bfcb/ruff-0.15.18-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a81beadbbff2c9c245561ae3f77b16709d87f35eec650d0501679239d3449b22", size = 10693187, upload-time = "2026-06-18T18:25:08.245Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/44/ff6c635cf2c4f4e7b618b6640da057376baa36014695487d88aed4794268/ruff-0.15.18-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2186d9e940ae332ab293623a75b5f4fe49565f449954d50a72a046683aa6b809", size = 11208721, upload-time = "2026-06-18T18:25:41.327Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d9/5baa2a30861adfb7022cf33c1e35b2fc18085b08c16f83eff4c7b99a5f48/ruff-0.15.18-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5c2abf140438032bc77b2284a6c9944ecd8a19e5f1c7b52b1b8e4a0a80d19a7a", size = 11678599, upload-time = "2026-06-18T18:25:13.607Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1a/0725a7cfdc32ff769efb96ee782bec882e16448c5d9e3be947ec4c04ce27/ruff-0.15.18-py3-none-win32.whl", hash = "sha256:02299e6e9fa5b297a3f6d5d10d7bcd655c925b028bb8b9d4588214549c6b9ec4", size = 10901903, upload-time = "2026-06-18T18:25:24.755Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/51/805d9f6fb7970505c3504794a5ec350f605361b807fef4dcf214ebd35e72/ruff-0.15.18-py3-none-win_amd64.whl", hash = "sha256:dac80dc8d26b2257dbefabed62f5d255c3937b4ccb122da1fc634794fa3578b3", size = 12041189, upload-time = "2026-06-18T18:25:17.915Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4c/67bb45e41609eb4726f1bfeb59e083cf91d14c696d4bd14c234a980be93d/ruff-0.15.18-py3-none-win_arm64.whl", hash = "sha256:b2c9257fcbd4a3e5b977a1904e6facca016bafe2edc17df24db67cfaee03b4e4", size = 11329958, upload-time = "2026-06-18T18:25:43.686Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/db/de907251b4ff46ae804ad0409809504153b3f30984daf82a1d84a9875830/websockets-16.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:31a52addea25187bde0797a97d6fc3d2f92b6f72a9370792d65a6e84615ac8a8", size = 177340, upload-time = "2026-01-10T09:22:34.539Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fa/abe89019d8d8815c8781e90d697dec52523fb8ebe308bf11664e8de1877e/websockets-16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:417b28978cdccab24f46400586d128366313e8a96312e4b9362a4af504f3bbad", size = 175022, upload-time = "2026-01-10T09:22:36.332Z" },
+    { url = "https://files.pythonhosted.org/packages/58/5d/88ea17ed1ded2079358b40d31d48abe90a73c9e5819dbcde1606e991e2ad/websockets-16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:af80d74d4edfa3cb9ed973a0a5ba2b2a549371f8a741e0800cb07becdd20f23d", size = 175319, upload-time = "2026-01-10T09:22:37.602Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ae/0ee92b33087a33632f37a635e11e1d99d429d3d323329675a6022312aac2/websockets-16.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:08d7af67b64d29823fed316505a89b86705f2b7981c07848fb5e3ea3020c1abe", size = 184631, upload-time = "2026-01-10T09:22:38.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c5/27178df583b6c5b31b29f526ba2da5e2f864ecc79c99dae630a85d68c304/websockets-16.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7be95cfb0a4dae143eaed2bcba8ac23f4892d8971311f1b06f3c6b78952ee70b", size = 185870, upload-time = "2026-01-10T09:22:39.893Z" },
+    { url = "https://files.pythonhosted.org/packages/87/05/536652aa84ddc1c018dbb7e2c4cbcd0db884580bf8e95aece7593fde526f/websockets-16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d6297ce39ce5c2e6feb13c1a996a2ded3b6832155fcfc920265c76f24c7cceb5", size = 185361, upload-time = "2026-01-10T09:22:41.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e2/d5332c90da12b1e01f06fb1b85c50cfc489783076547415bf9f0a659ec19/websockets-16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1c1b30e4f497b0b354057f3467f56244c603a79c0d1dafce1d16c283c25f6e64", size = 184615, upload-time = "2026-01-10T09:22:42.442Z" },
+    { url = "https://files.pythonhosted.org/packages/77/fb/d3f9576691cae9253b51555f841bc6600bf0a983a461c79500ace5a5b364/websockets-16.0-cp311-cp311-win32.whl", hash = "sha256:5f451484aeb5cafee1ccf789b1b66f535409d038c56966d6101740c1614b86c6", size = 178246, upload-time = "2026-01-10T09:22:43.654Z" },
+    { url = "https://files.pythonhosted.org/packages/54/67/eaff76b3dbaf18dcddabc3b8c1dba50b483761cccff67793897945b37408/websockets-16.0-cp311-cp311-win_amd64.whl", hash = "sha256:8d7f0659570eefb578dacde98e24fb60af35350193e4f56e11190787bee77dac", size = 178684, upload-time = "2026-01-10T09:22:44.941Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/72/07/c98a68571dcf256e74f1f816b8cc5eae6eb2d3d5cfa44d37f801619d9166/websockets-16.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:349f83cd6c9a415428ee1005cadb5c2c56f4389bc06a9af16103c3bc3dcc8b7d", size = 174947, upload-time = "2026-01-10T09:23:36.166Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/52/93e166a81e0305b33fe416338be92ae863563fe7bce446b0f687b9df5aea/websockets-16.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:4a1aba3340a8dca8db6eb5a7986157f52eb9e436b74813764241981ca4888f03", size = 175260, upload-time = "2026-01-10T09:23:37.409Z" },
+    { url = "https://files.pythonhosted.org/packages/56/0c/2dbf513bafd24889d33de2ff0368190a0e69f37bcfa19009ef819fe4d507/websockets-16.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f4a32d1bd841d4bcbffdcb3d2ce50c09c3909fbead375ab28d0181af89fd04da", size = 176071, upload-time = "2026-01-10T09:23:39.158Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]

--- a/controller/.env.example
+++ b/controller/.env.example
@@ -6,11 +6,15 @@ DB_PATH=./data/controller.db
 # HTTP + agent-WebSocket port.
 PORT=8443
 
+# These three secrets are REQUIRED in every environment (dev included) — there are no built-in
+# defaults. The app refuses to start without them. Generate real values, e.g.:
+#   openssl rand -hex 32
+
 # Required to register an admin on the signup page. Give this only to people allowed to create accounts.
-SIGNUP_TOKEN=change-me-signup
+SIGNUP_TOKEN=REPLACE_WITH_RANDOM_SIGNUP_TOKEN
 
 # Shared token every agent must present in its hello frame.
-AGENT_TOKEN=change-me-agent
+AGENT_TOKEN=REPLACE_WITH_RANDOM_AGENT_TOKEN
 
-# Secret used to sign admin session cookies. Use a long random string.
-SESSION_SECRET=change-me-session-secret
+# Secret used to sign admin session cookies. Must be at least 32 characters.
+SESSION_SECRET=REPLACE_WITH_openssl_rand_hex_32_value

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,7 +1,9 @@
 # Controller image: builds the Next.js app and runs the long-lived custom server (Next + WS hub).
 # Multi-stage to keep the runtime image lean while still compiling native modules during build.
 
-FROM node:26-bookworm-slim AS deps
+# Base image pinned by digest for reproducible, tamper-evident builds (M-09). Dependabot bumps the
+# digest; the tag comment keeps it readable.
+FROM node:26-bookworm-slim@sha256:4e2e85a824f938e41a61e9e819f0c7c11432f7d60f470b96214d3ead2f0dd63e AS deps
 WORKDIR /app
 # Build tools for native modules (better-sqlite3 / honker-node) if no prebuild is available.
 RUN apt-get update && apt-get install -y --no-install-recommends python3 make g++ \
@@ -9,13 +11,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends python3 make g+
 COPY package.json package-lock.json* ./
 RUN npm ci
 
-FROM node:26-bookworm-slim AS build
+FROM node:26-bookworm-slim@sha256:4e2e85a824f938e41a61e9e819f0c7c11432f7d60f470b96214d3ead2f0dd63e AS build
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN npm run build
 
-FROM node:26-bookworm-slim AS runtime
+FROM node:26-bookworm-slim@sha256:4e2e85a824f938e41a61e9e819f0c7c11432f7d60f470b96214d3ead2f0dd63e AS runtime
 WORKDIR /app
 ENV NODE_ENV=production
 # Non-root runtime user.

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -34,4 +34,6 @@ COPY --from=build /app/src ./src
 RUN mkdir -p /app/data && chown -R app:app /app
 USER app
 EXPOSE 8443
-CMD ["npx", "tsx", "server.ts"]
+# Invoke the tsx binary that's already in node_modules rather than `npx tsx`, which can reach out to
+# the network to fetch a missing package at boot (L-07).
+CMD ["node_modules/.bin/tsx", "server.ts"]

--- a/controller/src/app/(app)/labs/[id]/page.tsx
+++ b/controller/src/app/(app)/labs/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import { db } from "@/lib/db";
+import { takeFlash } from "@/lib/flash";
 import { ago, fmtBytes, pct } from "@/lib/format";
 import { getLab } from "@/lib/labs";
 import { listMembers } from "@/lib/students";
@@ -44,10 +45,12 @@ export default async function LabDetail({
   searchParams,
 }: {
   params: Promise<{ id: string }>;
-  searchParams: Promise<{ newuser?: string; pw?: string; emailed?: string }>;
+  searchParams: Promise<{ newuser?: string; pwid?: string; emailed?: string }>;
 }) {
   const { id } = await params;
-  const { newuser, pw, emailed } = await searchParams;
+  const { newuser, pwid, emailed } = await searchParams;
+  // The cleartext password is fetched once from the server-side flash store, never the URL (M-07).
+  const pw = pwid ? takeFlash(pwid) : null;
   const labId = Number(id);
   const lab = getLab(labId);
   if (!lab) notFound();

--- a/controller/src/app/(app)/labs/actions.ts
+++ b/controller/src/app/(app)/labs/actions.ts
@@ -2,20 +2,23 @@
 
 import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
-import { currentAdmin } from "@/lib/auth";
+import { requireAdmin } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { createLab, destroyLab, updateQuota } from "@/lib/labs";
 import { enqueueTask } from "@/lib/queue";
 import { getSettings, nextSshPort, TIB } from "@/lib/settings";
 import { addStudentToLab, removeStudentFromLab } from "@/lib/students";
 
-async function actor(): Promise<string | undefined> {
-  return (await currentAdmin())?.email;
+// Enforcing auth gate: throws/redirects when the caller is not a live admin, and returns the
+// verified email used as the audit actor. Call as the first line of every action.
+async function actor(): Promise<string> {
+  return (await requireAdmin()).email;
 }
 
 const tbToBytes = (tb: number) => Math.round(tb * TIB);
 
 export async function createLabAction(formData: FormData) {
+  const who = await actor();
   const name = String(formData.get("name") ?? "").trim();
   const nodeId = Number(formData.get("nodeId"));
   const piEmail = String(formData.get("piEmail") ?? "").trim() || undefined;
@@ -41,12 +44,13 @@ export async function createLabAction(formData: FormData) {
     slowQuotaBytes: tbToBytes(slowTb),
     sshPort: nextSshPort(),
     containerOptions,
-    actor: await actor(),
+    actor: who,
   });
   revalidatePath("/labs");
 }
 
 export async function setQuotaAction(formData: FormData) {
+  const who = await actor();
   const labId = Number(formData.get("labId"));
   const fastTb = formData.get("fastTb");
   const slowTb = formData.get("slowTb");
@@ -54,19 +58,21 @@ export async function setQuotaAction(formData: FormData) {
     labId,
     fastTb !== null && fastTb !== "" ? tbToBytes(Number(fastTb)) : undefined,
     slowTb !== null && slowTb !== "" ? tbToBytes(Number(slowTb)) : undefined,
-    await actor(),
+    who,
   );
   revalidatePath("/labs");
   revalidatePath(`/labs/${labId}`);
 }
 
 export async function destroyLabAction(formData: FormData) {
+  const who = await actor();
   const labId = Number(formData.get("labId"));
-  destroyLab(labId, await actor());
+  destroyLab(labId, who);
   revalidatePath("/labs");
 }
 
 export async function rescanAction(formData: FormData) {
+  const who = await actor();
   const labId = Number(formData.get("labId"));
   const lab = db().prepare("SELECT labs.name AS name, nodes.name AS node FROM labs JOIN nodes ON nodes.id = labs.node_id WHERE labs.id = ?").get(labId) as
     | { name: string; node: string }
@@ -82,12 +88,13 @@ export async function rescanAction(formData: FormData) {
     lab.node,
     "oldfiles.scan",
     { lab: lab.name, users, threshold_days: getSettings().oldFileThresholdDays },
-    await actor(),
+    who,
   );
   revalidatePath(`/labs/${labId}`);
 }
 
 export async function recreateContainerAction(formData: FormData) {
+  const who = await actor();
   const labId = Number(formData.get("labId"));
   const lab = db()
     .prepare(
@@ -104,18 +111,19 @@ export async function recreateContainerAction(formData: FormData) {
       ssh_port: lab.ssh_port,
       container_options: lab.opts ? JSON.parse(lab.opts) : {},
     },
-    await actor(),
+    who,
   );
   revalidatePath(`/labs/${labId}`);
 }
 
 export async function addMemberAction(formData: FormData) {
+  const who = await actor();
   const labId = Number(formData.get("labId"));
   const username = String(formData.get("username") ?? "").trim().toLowerCase();
   const email = String(formData.get("email") ?? "").trim() || undefined;
   const name = String(formData.get("name") ?? "").trim() || undefined;
   if (!username) throw new Error("Username required");
-  const result = await addStudentToLab(labId, { username, email, name }, await actor());
+  const result = await addStudentToLab(labId, { username, email, name }, who);
   revalidatePath(`/labs/${labId}`);
   // Show the generated password once (also emailed when SMTP is configured).
   const flash = result.emailed ? "&emailed=1" : "";
@@ -123,9 +131,10 @@ export async function addMemberAction(formData: FormData) {
 }
 
 export async function removeMemberAction(formData: FormData) {
+  const who = await actor();
   const labId = Number(formData.get("labId"));
   const studentId = Number(formData.get("studentId"));
   const deleteData = formData.get("deleteData") === "on";
-  removeStudentFromLab(labId, studentId, deleteData, await actor());
+  removeStudentFromLab(labId, studentId, deleteData, who);
   revalidatePath(`/labs/${labId}`);
 }

--- a/controller/src/app/(app)/labs/actions.ts
+++ b/controller/src/app/(app)/labs/actions.ts
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
 import { requireAdmin } from "@/lib/auth";
 import { db } from "@/lib/db";
+import { putFlash } from "@/lib/flash";
 import { createLab, destroyLab, updateQuota } from "@/lib/labs";
 import { enqueueTask } from "@/lib/queue";
 import { getSettings, nextSshPort, TIB } from "@/lib/settings";
@@ -125,9 +126,11 @@ export async function addMemberAction(formData: FormData) {
   if (!username) throw new Error("Username required");
   const result = await addStudentToLab(labId, { username, email, name }, who);
   revalidatePath(`/labs/${labId}`);
-  // Show the generated password once (also emailed when SMTP is configured).
-  const flash = result.emailed ? "&emailed=1" : "";
-  redirect(`/labs/${labId}?newuser=${encodeURIComponent(username)}&pw=${encodeURIComponent(result.password)}${flash}`);
+  // Show the generated password once via a one-time server-side flash — never put the cleartext
+  // credential in the redirect URL / history / access logs (M-07).
+  const pwid = putFlash(result.password);
+  const emailed = result.emailed ? "&emailed=1" : "";
+  redirect(`/labs/${labId}?newuser=${encodeURIComponent(username)}&pwid=${pwid}${emailed}`);
 }
 
 export async function removeMemberAction(formData: FormData) {

--- a/controller/src/app/(app)/layout.tsx
+++ b/controller/src/app/(app)/layout.tsx
@@ -1,12 +1,20 @@
 import { redirect } from "next/navigation";
 import type { ReactNode } from "react";
-import { clearSessionCookie, currentAdmin } from "@/lib/auth";
+import { clearSessionCookie, currentAdmin, logoutAllSessions } from "@/lib/auth";
 
 // Authed pages read cookies/DB per request — never statically prerender them.
 export const dynamic = "force-dynamic";
 
 async function logout() {
   "use server";
+  await clearSessionCookie();
+  redirect("/login");
+}
+
+async function logoutEverywhere() {
+  "use server";
+  const admin = await currentAdmin();
+  if (admin) logoutAllSessions(Number(admin.sub));
   await clearSessionCookie();
   redirect("/login");
 }
@@ -38,6 +46,11 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
         <form action={logout} style={{ marginTop: 24 }}>
           <button type="submit" style={{ background: "var(--panel-2)" }}>
             Sign out
+          </button>
+        </form>
+        <form action={logoutEverywhere} style={{ marginTop: 8 }}>
+          <button type="submit" style={{ background: "var(--panel-2)", fontSize: 12 }}>
+            Sign out everywhere
           </button>
         </form>
         <p className="muted" style={{ marginTop: 16, fontSize: 12 }}>{admin.email}</p>

--- a/controller/src/app/(app)/nodes/actions.ts
+++ b/controller/src/app/(app)/nodes/actions.ts
@@ -1,0 +1,35 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { requireAdmin } from "@/lib/auth";
+import { isValidNodeName, provisionNode, revokeNode, rotateNodeToken } from "@/lib/nodes";
+
+// The freshly issued token is shown once on the Nodes page so the admin can paste the printed
+// `lab-agent set-token` command onto the node. It is never stored in plaintext.
+function showToken(name: string, token: string): never {
+  redirect(`/nodes?provisioned=${encodeURIComponent(name)}&token=${encodeURIComponent(token)}`);
+}
+
+export async function provisionNodeAction(formData: FormData) {
+  const admin = await requireAdmin();
+  const name = String(formData.get("name") ?? "").trim().toLowerCase();
+  if (!isValidNodeName(name)) {
+    redirect("/nodes?error=Invalid+node+name+(use+a-z+0-9+and+hyphen)");
+  }
+  const token = provisionNode(name, admin.email);
+  showToken(name, token);
+}
+
+export async function rotateNodeTokenAction(formData: FormData) {
+  const admin = await requireAdmin();
+  const name = String(formData.get("name") ?? "").trim().toLowerCase();
+  const token = rotateNodeToken(name, admin.email);
+  showToken(name, token);
+}
+
+export async function revokeNodeAction(formData: FormData) {
+  const admin = await requireAdmin();
+  const name = String(formData.get("name") ?? "").trim().toLowerCase();
+  revokeNode(name, admin.email);
+  redirect("/nodes?revoked=" + encodeURIComponent(name));
+}

--- a/controller/src/app/(app)/nodes/page.tsx
+++ b/controller/src/app/(app)/nodes/page.tsx
@@ -1,4 +1,5 @@
 import { db } from "@/lib/db";
+import { provisionNodeAction, revokeNodeAction, rotateNodeTokenAction } from "./actions";
 
 export const dynamic = "force-dynamic";
 
@@ -9,6 +10,9 @@ interface NodeRow {
   capabilities: string | null;
   pools: string | null;
   scrub_status: string | null;
+  allowed: number;
+  auth_mode: string;
+  token_pinned_at: number | null;
 }
 
 interface ScrubEntry {
@@ -58,14 +62,63 @@ function ago(ts: number | null): string {
   return `${Math.floor(s / 3600)}h ago`;
 }
 
-export default function NodesPage() {
+function authLabel(n: NodeRow): string {
+  if (n.allowed !== 1) return "revoked";
+  if (n.auth_mode === "pernode") return n.token_pinned_at ? "per-node" : "per-node (pending)";
+  return "legacy token";
+}
+
+export default async function NodesPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const sp = await searchParams;
+  const provisioned = typeof sp.provisioned === "string" ? sp.provisioned : undefined;
+  const token = typeof sp.token === "string" ? sp.token : undefined;
+  const error = typeof sp.error === "string" ? sp.error : undefined;
+
   const nodes = db()
-    .prepare("SELECT name, online, last_seen, capabilities, pools, scrub_status FROM nodes ORDER BY name")
+    .prepare(
+      "SELECT name, online, last_seen, capabilities, pools, scrub_status, allowed, auth_mode, token_pinned_at FROM nodes ORDER BY name",
+    )
     .all() as NodeRow[];
 
   return (
     <>
       <h2>Nodes</h2>
+
+      {error && (
+        <div className="card" style={{ borderColor: "var(--warn)", marginBottom: 16 }}>
+          <p style={{ color: "var(--warn)" }}>{error}</p>
+        </div>
+      )}
+
+      {provisioned && token && (
+        <div className="card" style={{ borderColor: "var(--accent, #5fa0c2)", marginBottom: 16 }}>
+          <h3>Token for node “{provisioned}”</h3>
+          <p className="muted">Shown once. Run this on the node, then the agent reconnects automatically:</p>
+          <pre style={{ overflowX: "auto", padding: 12, background: "var(--panel-2)" }}>
+            <code>sudo lab-agent set-token {token}</code>
+          </pre>
+          <p className="muted" style={{ fontSize: 12 }}>
+            (Equivalent to writing the token into <code>/etc/lab-agent/config.toml</code> and running
+            <code> systemctl restart lab-agent</code>.)
+          </p>
+        </div>
+      )}
+
+      <div className="card" style={{ marginBottom: 16 }}>
+        <h3>Register a node</h3>
+        <form action={provisionNodeAction} style={{ display: "flex", gap: 8, alignItems: "center" }}>
+          <input name="name" placeholder="node name (e.g. gpu-01)" required pattern="[a-z0-9][a-z0-9\-]{0,62}" />
+          <button type="submit">Provision token</button>
+        </form>
+        <p className="muted" style={{ fontSize: 12, marginTop: 8 }}>
+          Adds the node to the allow-list and issues a per-node token. Only allow-listed nodes may connect.
+        </p>
+      </div>
+
       <div className="card">
         {nodes.length === 0 ? (
           <p className="muted">No nodes have connected yet.</p>
@@ -75,12 +128,14 @@ export default function NodesPage() {
               <tr>
                 <th>Node</th>
                 <th>Status</th>
+                <th>Auth</th>
                 <th>GPUs</th>
                 <th>Pools</th>
                 <th>Cold storage</th>
                 <th>Scrub</th>
                 <th>Issues</th>
                 <th>Last seen</th>
+                <th>Token</th>
               </tr>
             </thead>
             <tbody>
@@ -100,6 +155,7 @@ export default function NodesPage() {
                         {n.online ? "online" : "offline"}
                       </span>
                     </td>
+                    <td style={n.allowed !== 1 ? { color: "var(--warn)" } : undefined}>{authLabel(n)}</td>
                     <td>{caps.gpu_count ?? 0}</td>
                     <td>
                       {pools.length === 0
@@ -116,6 +172,20 @@ export default function NodesPage() {
                       )}
                     </td>
                     <td className="muted">{ago(n.last_seen)}</td>
+                    <td style={{ whiteSpace: "nowrap" }}>
+                      <form action={rotateNodeTokenAction} style={{ display: "inline" }}>
+                        <input type="hidden" name="name" value={n.name} />
+                        <button type="submit" style={{ background: "var(--panel-2)" }}>Rotate</button>
+                      </form>{" "}
+                      {n.allowed === 1 && (
+                        <form action={revokeNodeAction} style={{ display: "inline" }}>
+                          <input type="hidden" name="name" value={n.name} />
+                          <button type="submit" style={{ background: "var(--panel-2)", color: "var(--warn)" }}>
+                            Revoke
+                          </button>
+                        </form>
+                      )}
+                    </td>
                   </tr>
                 );
               })}

--- a/controller/src/app/(app)/settings/actions.ts
+++ b/controller/src/app/(app)/settings/actions.ts
@@ -4,9 +4,10 @@ import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
 import { sendTestEmail } from "@/lib/mailer";
 import { broadcastGpuPolicy, setSetting, TIB } from "@/lib/settings";
-import { currentAdmin } from "@/lib/auth";
+import { requireAdmin } from "@/lib/auth";
 
 export async function saveStorageSettingsAction(formData: FormData) {
+  await requireAdmin();
   const fastTb = Number(formData.get("fastTb"));
   const slowTb = Number(formData.get("slowTb"));
   const portStart = Number(formData.get("sshPortStart"));
@@ -23,6 +24,7 @@ export async function saveStorageSettingsAction(formData: FormData) {
 }
 
 export async function saveSmtpSettingsAction(formData: FormData) {
+  await requireAdmin();
   setSetting("smtpHost", String(formData.get("smtpHost") ?? "").trim());
   setSetting("smtpPort", Number(formData.get("smtpPort")) || 587);
   setSetting("smtpUser", String(formData.get("smtpUser") ?? "").trim());
@@ -36,6 +38,7 @@ export async function saveSmtpSettingsAction(formData: FormData) {
 }
 
 export async function saveAlertSettingsAction(formData: FormData) {
+  await requireAdmin();
   setSetting("alertsEnabled", formData.get("alertsEnabled") === "on");
   const level = String(formData.get("alertLevel") ?? "ERROR");
   setSetting("alertLevel", level === "WARN" ? "WARN" : "ERROR");
@@ -46,6 +49,7 @@ export async function saveAlertSettingsAction(formData: FormData) {
 }
 
 export async function saveGpuPolicyAction(formData: FormData) {
+  const who = (await requireAdmin()).email;
   setSetting("gpuEnabled", formData.get("gpuEnabled") === "on");
   setSetting("gpuImmediate", formData.get("gpuImmediate") === "on");
   setSetting("gpuUtilThreshold", Number(formData.get("gpuUtilThreshold")) || 5);
@@ -54,20 +58,21 @@ export async function saveGpuPolicyAction(formData: FormData) {
   setSetting("gpuWhitelistUsers", String(formData.get("gpuWhitelistUsers") ?? "").trim());
   setSetting("gpuWhitelistLabs", String(formData.get("gpuWhitelistLabs") ?? "").trim());
   // Push the new policy to every node immediately.
-  broadcastGpuPolicy((await currentAdmin())?.email);
+  broadcastGpuPolicy(who);
   revalidatePath("/settings");
 }
 
 export async function saveScrubSettingsAction(formData: FormData) {
+  await requireAdmin();
   setSetting("scrubEnabled", formData.get("scrubEnabled") === "on");
   setSetting("scrubIntervalDays", Number(formData.get("scrubIntervalDays")) || 30);
   revalidatePath("/settings");
 }
 
 export async function scrubNowAction() {
+  const actor = (await requireAdmin()).email;
   const { db } = await import("@/lib/db");
   const { enqueueTask } = await import("@/lib/queue");
-  const actor = (await currentAdmin())?.email;
   const nodes = db()
     .prepare("SELECT name, capabilities FROM nodes WHERE online = 1")
     .all() as { name: string; capabilities: string | null }[];
@@ -88,6 +93,7 @@ export async function scrubNowAction() {
 }
 
 export async function saveWebdavSettingsAction(formData: FormData) {
+  await requireAdmin();
   setSetting("webdavUrl", String(formData.get("webdavUrl") ?? "").trim());
   setSetting("webdavUser", String(formData.get("webdavUser") ?? "").trim());
   const pass = String(formData.get("webdavPass") ?? "");
@@ -98,12 +104,14 @@ export async function saveWebdavSettingsAction(formData: FormData) {
 }
 
 export async function backupNowAction() {
+  await requireAdmin();
   const { backupAll } = await import("@/lib/backup");
   const res = await backupAll();
   redirect(`/settings?backup=${encodeURIComponent(res.ok ? `Backed up ${res.name}` : `Failed: ${res.error}`)}`);
 }
 
 export async function restoreAction(formData: FormData) {
+  await requireAdmin();
   const name = String(formData.get("name") ?? "");
   const { stageRestore } = await import("@/lib/backup");
   const res = await stageRestore(name);
@@ -114,6 +122,7 @@ export async function restoreAction(formData: FormData) {
 }
 
 export async function testEmailAction(formData: FormData) {
+  await requireAdmin();
   const to = String(formData.get("to") ?? "").trim();
   const res = await sendTestEmail(to);
   const msg = res.sent

--- a/controller/src/app/(app)/students/actions.ts
+++ b/controller/src/app/(app)/students/actions.ts
@@ -1,11 +1,16 @@
 "use server";
 
 import { redirect } from "next/navigation";
-import { currentAdmin } from "@/lib/auth";
+import { requireAdmin } from "@/lib/auth";
 import { applyMapping, parseCsv } from "@/lib/csv";
 import { addStudentToLab } from "@/lib/students";
 
+// Upper bound on rows per import — prevents one POST from enqueuing thousands of root-agent useradd
+// tasks (H-06). Anything beyond this is rejected outright rather than silently truncated.
+const MAX_IMPORT_ROWS = 500;
+
 export async function importCsvAction(formData: FormData) {
+  const actor = (await requireAdmin()).email;
   const labId = Number(formData.get("labId"));
   const text = String(formData.get("csv") ?? "");
   const mapping = {
@@ -18,7 +23,9 @@ export async function importCsvAction(formData: FormData) {
 
   const parsed = parseCsv(text);
   const rows = applyMapping(parsed, mapping);
-  const actor = (await currentAdmin())?.email;
+  if (rows.length > MAX_IMPORT_ROWS) {
+    redirect(`/students?error=${encodeURIComponent(`Too many rows (${rows.length}); max ${MAX_IMPORT_ROWS} per import`)}`);
+  }
 
   let added = 0;
   let skipped = 0;

--- a/controller/src/app/login/page.tsx
+++ b/controller/src/app/login/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { adminCount, setSessionCookie, verifyLogin } from "@/lib/auth";
+import { AUTH_LIMIT, clientIp, consume } from "@/lib/ratelimit";
 
 export const dynamic = "force-dynamic";
 
@@ -7,6 +8,12 @@ async function login(formData: FormData) {
   "use server";
   const email = String(formData.get("email") ?? "");
   const password = String(formData.get("password") ?? "");
+  // Throttle by IP and by target email so neither password spraying nor a focused guess runs at
+  // server speed (H-02).
+  const ip = await clientIp();
+  if (!consume(`login:ip:${ip}`, AUTH_LIMIT) || !consume(`login:email:${email}`, AUTH_LIMIT)) {
+    redirect("/login?error=Too+many+attempts.+Try+again+later.");
+  }
   const admin = await verifyLogin(email, password);
   if (!admin) redirect("/login?error=Invalid+email+or+password");
   await setSessionCookie(admin);

--- a/controller/src/app/signup/page.tsx
+++ b/controller/src/app/signup/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { createAdmin, setSessionCookie } from "@/lib/auth";
+import { AUTH_LIMIT, clientIp, consume } from "@/lib/ratelimit";
 
 export const dynamic = "force-dynamic";
 
@@ -9,6 +10,11 @@ async function signup(formData: FormData) {
   const email = String(formData.get("email") ?? "");
   const password = String(formData.get("password") ?? "");
   const token = String(formData.get("token") ?? "");
+  // Throttle by IP so the shared signup token can't be brute-forced at server speed (H-02).
+  const ip = await clientIp();
+  if (!consume(`signup:ip:${ip}`, AUTH_LIMIT)) {
+    redirect("/signup?error=Too+many+attempts.+Try+again+later.");
+  }
   try {
     const admin = await createAdmin(name, email, password, token);
     await setSessionCookie(admin);

--- a/controller/src/lib/auth.ts
+++ b/controller/src/lib/auth.ts
@@ -4,6 +4,7 @@
  */
 
 import bcrypt from "bcryptjs";
+import { createHash, timingSafeEqual } from "node:crypto";
 import { SignJWT, jwtVerify } from "jose";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
@@ -11,7 +12,21 @@ import { db } from "./db";
 import { env } from "./env";
 
 const COOKIE = "lab_session";
-const SESSION_TTL = "7d";
+const SESSION_TTL = "24h"; // shortened from 7d (H-07); revocation is also enforced via token_version
+const SESSION_MAX_AGE = 60 * 60 * 24;
+const BCRYPT_COST = 12; // L-05: raise from 10
+const MIN_PASSWORD_LEN = 12; // L-05: enforced server-side, not just in the form
+
+// A bcrypt hash of a random string, compared against when no admin row matches, so login timing
+// doesn't reveal whether an email exists (L-03).
+const DUMMY_HASH = bcrypt.hashSync("no-such-user-placeholder", BCRYPT_COST);
+
+/** Constant-time string comparison for shared secrets (L-01). */
+export function safeEqual(a: string, b: string): boolean {
+  const ha = createHash("sha256").update(a).digest();
+  const hb = createHash("sha256").update(b).digest();
+  return timingSafeEqual(ha, hb);
+}
 
 // Lazily derived so importing this module doesn't read env at build time.
 let _secret: Uint8Array | null = null;
@@ -42,12 +57,15 @@ function tokenVersion(adminId: number): number {
 }
 
 export async function createAdmin(name: string, email: string, password: string, signupToken: string): Promise<Admin> {
-  if (signupToken !== env.signupToken) {
+  if (!safeEqual(signupToken, env.signupToken)) {
     throw new Error("Invalid signup token");
+  }
+  if (password.length < MIN_PASSWORD_LEN) {
+    throw new Error(`Password must be at least ${MIN_PASSWORD_LEN} characters`);
   }
   const existing = db().prepare("SELECT id FROM admins WHERE email = ?").get(email);
   if (existing) throw new Error("An admin with that email already exists");
-  const hash = await bcrypt.hash(password, 10);
+  const hash = await bcrypt.hash(password, BCRYPT_COST);
   const info = db()
     .prepare("INSERT INTO admins (name, email, password_hash, created_at) VALUES (?, ?, ?, ?)")
     .run(name, email, hash, Date.now());
@@ -56,9 +74,12 @@ export async function createAdmin(name: string, email: string, password: string,
 
 export async function verifyLogin(email: string, password: string): Promise<Admin | null> {
   const row = db().prepare("SELECT * FROM admins WHERE email = ?").get(email) as any;
-  if (!row) return null;
-  const ok = await bcrypt.compare(password, row.password_hash);
-  if (!ok) return null;
+  // Always run a bcrypt comparison (against a dummy hash when the email is unknown) so response
+  // timing doesn't reveal whether an admin exists (L-03).
+  const ok = await bcrypt.compare(password, row?.password_hash ?? DUMMY_HASH);
+  if (!row || !ok) return null;
+  // A disabled admin cannot authenticate (H-07).
+  if (row.is_active !== undefined && row.is_active !== 1) return null;
   return { id: row.id, name: row.name, email: row.email };
 }
 
@@ -78,8 +99,18 @@ export async function setSessionCookie(admin: Admin): Promise<void> {
     sameSite: "strict",
     secure: true,
     path: "/",
-    maxAge: 60 * 60 * 24 * 7,
+    maxAge: SESSION_MAX_AGE,
   });
+}
+
+/** Invalidate every outstanding session for an admin by bumping token_version (logout-all, H-07). */
+export function logoutAllSessions(adminId: number): void {
+  db().prepare("UPDATE admins SET token_version = token_version + 1 WHERE id = ?").run(adminId);
+}
+
+/** Enable/disable an admin. A disabled admin cannot log in and existing sessions are rejected. */
+export function setAdminActive(adminId: number, active: boolean): void {
+  db().prepare("UPDATE admins SET is_active = ? WHERE id = ?").run(active ? 1 : 0, adminId);
 }
 
 export async function clearSessionCookie(): Promise<void> {

--- a/controller/src/lib/auth.ts
+++ b/controller/src/lib/auth.ts
@@ -6,6 +6,7 @@
 import bcrypt from "bcryptjs";
 import { SignJWT, jwtVerify } from "jose";
 import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 import { db } from "./db";
 import { env } from "./env";
 
@@ -29,6 +30,15 @@ export interface SessionClaims {
   sub: string; // admin id
   email: string;
   name: string;
+  ver: number; // token_version at issue time; checked against the DB to allow revocation
+}
+
+/** token_version for an admin, or 0 if the row/column is absent. */
+function tokenVersion(adminId: number): number {
+  const row = db().prepare("SELECT token_version FROM admins WHERE id = ?").get(adminId) as
+    | { token_version: number }
+    | undefined;
+  return row?.token_version ?? 0;
 }
 
 export async function createAdmin(name: string, email: string, password: string, signupToken: string): Promise<Admin> {
@@ -53,7 +63,7 @@ export async function verifyLogin(email: string, password: string): Promise<Admi
 }
 
 export async function issueSession(admin: Admin): Promise<string> {
-  return new SignJWT({ email: admin.email, name: admin.name })
+  return new SignJWT({ email: admin.email, name: admin.name, ver: tokenVersion(admin.id) })
     .setProtectedHeader({ alg: "HS256" })
     .setSubject(String(admin.id))
     .setIssuedAt()
@@ -65,8 +75,8 @@ export async function setSessionCookie(admin: Admin): Promise<void> {
   const token = await issueSession(admin);
   (await cookies()).set(COOKIE, token, {
     httpOnly: true,
-    sameSite: "lax",
-    secure: env.isProd,
+    sameSite: "strict",
+    secure: true,
     path: "/",
     maxAge: 60 * 60 * 24 * 7,
   });
@@ -80,11 +90,38 @@ export async function currentAdmin(): Promise<SessionClaims | null> {
   const token = (await cookies()).get(COOKIE)?.value;
   if (!token) return null;
   try {
-    const { payload } = await jwtVerify(token, secretKey());
-    return { sub: payload.sub as string, email: payload.email as string, name: payload.name as string };
+    const { payload } = await jwtVerify(token, secretKey(), { algorithms: ["HS256"] });
+    return {
+      sub: payload.sub as string,
+      email: payload.email as string,
+      name: payload.name as string,
+      ver: typeof payload.ver === "number" ? payload.ver : 0,
+    };
   } catch {
     return null;
   }
+}
+
+/**
+ * Authoritative authorization gate for privileged Server Actions. Unlike currentAdmin() (which only
+ * verifies the JWT and never throws), this re-validates the subject against the admins table and
+ * rejects when the admin is missing, disabled, or carrying a stale token_version — then returns the
+ * verified Admin. Call it as the FIRST line of every mutating action. redirect() throws
+ * NEXT_REDIRECT, so the action body cannot proceed past an unauthenticated/invalid caller.
+ */
+export async function requireAdmin(): Promise<Admin> {
+  const claims = await currentAdmin();
+  if (!claims) redirect("/login");
+  const row = db()
+    .prepare("SELECT id, name, email, is_active, token_version FROM admins WHERE id = ?")
+    .get(Number(claims.sub)) as
+    | { id: number; name: string; email: string; is_active: number; token_version: number }
+    | undefined;
+  if (!row || row.is_active !== 1 || row.token_version !== claims.ver) {
+    await clearSessionCookie();
+    redirect("/login");
+  }
+  return { id: row.id, name: row.name, email: row.email };
 }
 
 export function adminCount(): number {

--- a/controller/src/lib/backup.ts
+++ b/controller/src/lib/backup.ts
@@ -91,8 +91,13 @@ export async function listBackups(): Promise<string[]> {
 /** Download a backup and stage it; takes effect on the next controller restart. */
 export async function stageRestore(name: string): Promise<{ ok: boolean; error?: string }> {
   if (!isWebdavConfigured()) return { ok: false, error: "WebDAV not configured" };
+  // Whitelist against the actual backup list — never fetch an attacker-chosen name onto disk as the
+  // next-boot DB. basename() already blocks traversal; this also blocks substituting a foreign file.
+  const safe = basename(name);
+  const known = await listBackups();
+  if (!known.includes(safe)) return { ok: false, error: "Unknown backup name" };
   try {
-    const data = await webdav.get(webdavConfig(), basename(name));
+    const data = await webdav.get(webdavConfig(), safe);
     writeFileSync(`${env.dbPath}.restore`, data);
     return { ok: true };
   } catch (err) {

--- a/controller/src/lib/db.ts
+++ b/controller/src/lib/db.ts
@@ -197,6 +197,16 @@ const MIGRATIONS: { id: string; sql: string }[] = [
     ALTER TABLE nodes ADD COLUMN scrub_status TEXT;       -- JSON: latest per-pool scrub status
     `,
   },
+  {
+    id: "0003_admin_session_state",
+    sql: `
+    -- is_active soft-disables an admin without deleting the row; token_version is embedded in the
+    -- session JWT so bumping it (logout-all / disable) invalidates all of that admin's outstanding
+    -- cookies. requireAdmin() re-checks both against the DB on every privileged action.
+    ALTER TABLE admins ADD COLUMN is_active INTEGER NOT NULL DEFAULT 1;
+    ALTER TABLE admins ADD COLUMN token_version INTEGER NOT NULL DEFAULT 0;
+    `,
+  },
 ];
 
 function migrate(conn: Database.Database): void {

--- a/controller/src/lib/db.ts
+++ b/controller/src/lib/db.ts
@@ -207,6 +207,20 @@ const MIGRATIONS: { id: string; sql: string }[] = [
     ALTER TABLE admins ADD COLUMN token_version INTEGER NOT NULL DEFAULT 0;
     `,
   },
+  {
+    id: "0004_node_tokens",
+    sql: `
+    -- Per-node identity. token_hash is the bcrypt hash of a node's own token (NULL = not yet
+    -- provisioned); allowed is the name allow-list flag; token_pinned_at records first successful
+    -- per-node auth (first-seen pin); auth_mode is 'legacy' (shared AGENT_TOKEN) or 'pernode'.
+    ALTER TABLE nodes ADD COLUMN token_hash TEXT;
+    ALTER TABLE nodes ADD COLUMN allowed INTEGER NOT NULL DEFAULT 0;
+    ALTER TABLE nodes ADD COLUMN token_pinned_at INTEGER;
+    ALTER TABLE nodes ADD COLUMN auth_mode TEXT NOT NULL DEFAULT 'legacy';
+    -- Pre-existing nodes were trusted under the shared token; keep them connecting on upgrade.
+    UPDATE nodes SET allowed = 1, auth_mode = 'legacy';
+    `,
+  },
 ];
 
 function migrate(conn: Database.Database): void {

--- a/controller/src/lib/env.ts
+++ b/controller/src/lib/env.ts
@@ -6,11 +6,14 @@
  * happens on first access at runtime, not during the Next.js build's static analysis.
  */
 
-function required(name: string, devFallback?: string): string {
+// Bootstrap secrets must be supplied in EVERY environment — no dev fallbacks. Published default
+// strings (the old "dev-*" values) let anyone forge an admin JWT or connect agents on a from-source
+// deploy, so we fail closed regardless of NODE_ENV (H-01). For local development, generate real
+// values once (e.g. `openssl rand -hex 32`) and put them in .env.local.
+function required(name: string): string {
   const value = process.env[name];
   if (value && value !== "") return value;
-  if (process.env.NODE_ENV !== "production" && devFallback !== undefined) return devFallback;
-  throw new Error(`Missing required env var ${name}`);
+  throw new Error(`Missing required env var ${name} (set a real value; there is no default)`);
 }
 
 export const env = {
@@ -21,13 +24,18 @@ export const env = {
     return parseInt(process.env.PORT ?? "8443", 10);
   },
   get signupToken(): string {
-    return required("SIGNUP_TOKEN", "dev-signup-token");
+    return required("SIGNUP_TOKEN");
   },
   get agentToken(): string {
-    return required("AGENT_TOKEN", "dev-agent-token");
+    return required("AGENT_TOKEN");
   },
   get sessionSecret(): string {
-    return required("SESSION_SECRET", "dev-session-secret-change-me-please");
+    const secret = required("SESSION_SECRET");
+    // HS256 keys shorter than the 256-bit output are trivially weaker; enforce a sane floor.
+    if (secret.length < 32) {
+      throw new Error("SESSION_SECRET must be at least 32 characters (use `openssl rand -hex 32`)");
+    }
+    return secret;
   },
   get isProd(): boolean {
     return process.env.NODE_ENV === "production";

--- a/controller/src/lib/env.ts
+++ b/controller/src/lib/env.ts
@@ -40,4 +40,10 @@ export const env = {
   get isProd(): boolean {
     return process.env.NODE_ENV === "production";
   },
+  // During the per-node-token rollout the shared AGENT_TOKEN still authenticates nodes whose row is
+  // auth_mode='legacy'. Set ALLOW_LEGACY_AGENT_TOKEN=0 once every node has its own token to refuse
+  // the shared token fleet-wide. Defaults on for backward compatibility.
+  get allowLegacyAgentToken(): boolean {
+    return process.env.ALLOW_LEGACY_AGENT_TOKEN !== "0";
+  },
 };

--- a/controller/src/lib/flash.ts
+++ b/controller/src/lib/flash.ts
@@ -1,0 +1,32 @@
+/**
+ * One-time, short-lived server-side flash store (M-07). Used to surface a freshly generated student
+ * password to the admin exactly once without ever putting the cleartext in a redirect URL, browser
+ * history, or access logs. The redirect carries only an opaque random id; the value is read and
+ * deleted on the next page render. Process-local (single long-lived controller process).
+ */
+
+import { randomBytes } from "node:crypto";
+
+interface Entry {
+  value: string;
+  expires: number;
+}
+
+const store = new Map<string, Entry>();
+const TTL_MS = 60 * 1000;
+
+/** Stash a value; returns an opaque id to put in the redirect. */
+export function putFlash(value: string): string {
+  const id = randomBytes(16).toString("hex");
+  store.set(id, { value, expires: Date.now() + TTL_MS });
+  return id;
+}
+
+/** Read and delete a flashed value, or null if missing/expired. */
+export function takeFlash(id: string): string | null {
+  const e = store.get(id);
+  if (!e) return null;
+  store.delete(id);
+  if (Date.now() > e.expires) return null;
+  return e.value;
+}

--- a/controller/src/lib/hub.ts
+++ b/controller/src/lib/hub.ts
@@ -13,8 +13,8 @@ import type { Duplex } from "node:stream";
 import { WebSocketServer, type WebSocket } from "ws";
 import { alertNodeOffline, alertTaskFailed, maybeAlertOnLog } from "./alerts";
 import { db } from "./db";
-import { env } from "./env";
 import { ingestTelemetry, storeOldfileScan } from "./ingest";
+import { verifyNodeAuth } from "./nodes";
 import { ackTask, claimTask, markTaskState, retryTask } from "./queue";
 import { getSetting } from "./settings";
 
@@ -73,24 +73,32 @@ export function createHub(): WebSocketServer {
 }
 
 function handleHello(ws: WebSocket, frame: any): string | null {
-  if (frame.token !== env.agentToken) {
-    ws.close(4001, "bad token");
+  const node = String(frame.node ?? "");
+  // Per-node identity: name must be on the allow-list AND the credential must verify (C-04, M-03).
+  const auth = verifyNodeAuth(node, String(frame.token ?? ""));
+  if (!auth.ok) {
+    ws.close(4001, auth.reason ?? "unauthorized");
     return null;
   }
-  const node = String(frame.node);
-  registerNode(node, frame.capabilities ?? {});
 
-  // Replace any stale connection for this node.
+  // Do NOT let a newcomer steal a live node's queue. Only supersede a dead/closing socket; a real
+  // duplicate is refused. A genuinely half-open peer is closed by the 20s ws ping timeout, after
+  // which its slot frees and the agent reconnects normally.
   const existing = connections.get(node);
+  if (existing && existing.ws.readyState === existing.ws.OPEN) {
+    ws.close(4003, "node already connected");
+    return null;
+  }
   if (existing) {
     clearInterval(existing.consumer);
     try {
-      existing.ws.close(4002, "superseded");
+      existing.ws.close();
     } catch {
       /* ignore */
     }
   }
 
+  registerNode(node, frame.capabilities ?? {});
   const consumer = setInterval(() => drainNode(node, ws), 400);
   connections.set(node, { ws, node, consumer });
   return node;
@@ -106,7 +114,7 @@ function drainNode(node: string, ws: WebSocket): void {
     try {
       ws.send(JSON.stringify(claimed.frame));
       ackTask(node, claimed.jobId, workerId);
-      markTaskState(claimed.frame.id, "sent");
+      markTaskState(node, claimed.frame.id, "sent");
     } catch {
       retryTask(node, claimed.jobId, workerId, "send failed");
       break;
@@ -119,7 +127,7 @@ function drainNode(node: string, ws: WebSocket): void {
 function ingestFrame(node: string, frame: any): void {
   switch (frame.type) {
     case "result":
-      handleResult(frame);
+      handleResult(node, frame);
       break;
     case "log":
       handleLog(node, frame);
@@ -135,13 +143,17 @@ function ingestFrame(node: string, frame: any): void {
   }
 }
 
-function handleResult(frame: any): void {
-  markTaskState(
+function handleResult(node: string, frame: any): void {
+  // Bind the result to the node the task was queued for. A foreign/unknown UUID matches no row, so a
+  // spoofing agent can't complete, fail, or poison another node's task (H-03). Drop it silently.
+  const changed = markTaskState(
+    node,
     frame.id,
     frame.ok ? "ok" : "failed",
     frame.result,
     frame.ok ? undefined : frame.error,
   );
+  if (!changed) return;
   if (!frame.ok) {
     const t = db().prepare("SELECT node, action FROM task_log WHERE task_uuid = ?").get(frame.id) as
       | { node: string; action: string }

--- a/controller/src/lib/hub.ts
+++ b/controller/src/lib/hub.ts
@@ -39,13 +39,32 @@ export function sendToNode(node: string, frame: unknown): boolean {
   return true;
 }
 
+// Frame ceiling: legitimate telemetry/log frames are a few KiB; cap well below the ws default
+// (~100 MiB) so one oversized frame can't balloon memory (M-02). Matches the agent's 8 MiB send cap.
+const MAX_FRAME_BYTES = 1024 * 1024; // 1 MiB
+// Per-connection message-rate cap: a token bucket refilling at RATE msgs/sec up to BURST.
+const MSG_RATE_PER_SEC = 50;
+const MSG_BURST = 100;
+
 export function createHub(): WebSocketServer {
-  const wss = new WebSocketServer({ noServer: true });
+  const wss = new WebSocketServer({ noServer: true, maxPayload: MAX_FRAME_BYTES });
 
   wss.on("connection", (ws: WebSocket) => {
     let node: string | null = null;
+    let tokens = MSG_BURST;
+    let lastRefill = Date.now();
 
     ws.on("message", (raw) => {
+      // Refill the bucket, then spend one token per message; flooding closes the socket.
+      const now = Date.now();
+      tokens = Math.min(MSG_BURST, tokens + ((now - lastRefill) / 1000) * MSG_RATE_PER_SEC);
+      lastRefill = now;
+      if (tokens < 1) {
+        ws.close(4008, "rate limit exceeded");
+        return;
+      }
+      tokens -= 1;
+
       let frame: any;
       try {
         frame = JSON.parse(raw.toString());
@@ -187,12 +206,12 @@ function handleLog(node: string, frame: any): void {
       frame.ts ?? Date.now(),
       node,
       frame.level ?? "INFO",
-      frame.source ?? null,
-      frame.lab ?? null,
-      frame.user ?? null,
-      frame.task_id ?? null,
-      frame.msg ?? "",
-      frame.detail ?? null,
+      boundedStr(frame.source, 32),
+      boundedStr(frame.lab, 40),
+      boundedStr(frame.user, 32),
+      boundedStr(frame.task_id, 64),
+      clampText(frame.msg, 2000) ?? "",
+      clampText(frame.detail, 8000),
     );
   maybeAlertOnLog({
     node,
@@ -203,34 +222,85 @@ function handleLog(node: string, frame: any): void {
   });
 }
 
-function handleEvent(node: string, frame: any): void {
-  const p = frame.payload ?? {};
-  if (frame.kind === "gpu") {
-    db()
-      .prepare(
-        `INSERT INTO gpu_events (node, pid, user, lab, vram_bytes, state, ts)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`,
-      )
-      .run(node, p.pid ?? null, p.user ?? null, p.lab ?? null, p.vram_bytes ?? null, p.state ?? "idle", frame.ts ?? Date.now());
-    void emailGpuEvent(p);
-  }
+const GPU_STATES = new Set(["idle", "warned", "killed"]);
+// Per (node,user,state) outbound-mail throttle so a spamming node can't flood a student (M-01).
+const gpuMailState = new Map<string, number>();
+const GPU_MAIL_WINDOW_MS = 10 * 60 * 1000;
+
+/** Coerce an unknown field to a bounded string (control chars stripped) or null. */
+function boundedStr(v: unknown, max = 64): string | null {
+  if (typeof v !== "string") return null;
+  // eslint-disable-next-line no-control-regex
+  const clean = Array.from(v).filter((c) => c >= " " && c !== "\x7f").join("").slice(0, max);
+  return clean.length ? clean : null;
 }
 
-async function emailGpuEvent(p: any): Promise<void> {
+function intOrNull(v: unknown): number | null {
+  return typeof v === "number" && Number.isFinite(v) ? Math.trunc(v) : null;
+}
+
+/** Length-clamp a free-text field (msg/detail), preserving newlines/tabs; null if not a string. */
+function clampText(v: unknown, max: number): string | null {
+  if (typeof v !== "string") return null;
+  return v.slice(0, max);
+}
+
+function handleEvent(node: string, frame: any): void {
+  if (frame.kind !== "gpu") return;
+  const raw = frame.payload ?? {};
+  // Validate the payload before it touches the DB or an email (M-01).
+  const p = {
+    pid: intOrNull(raw.pid),
+    user: boundedStr(raw.user, 32),
+    lab: boundedStr(raw.lab, 40),
+    vram_bytes: intOrNull(raw.vram_bytes),
+    state: GPU_STATES.has(raw.state) ? (raw.state as string) : "idle",
+  };
+  db()
+    .prepare(
+      `INSERT INTO gpu_events (node, pid, user, lab, vram_bytes, state, ts)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(node, p.pid, p.user, p.lab, p.vram_bytes, p.state, intOrNull(frame.ts) ?? Date.now());
+  void emailGpuEvent(node, p);
+}
+
+async function emailGpuEvent(
+  node: string,
+  p: { user: string | null; lab: string | null; pid: number | null; state: string },
+): Promise<void> {
   if (!p.user || (p.state !== "warned" && p.state !== "killed")) return;
+  // Only email a student the sending node actually hosts — a node can't target arbitrary students.
+  const owns = db()
+    .prepare(
+      `SELECT 1 FROM students
+         JOIN lab_members ON lab_members.student_id = students.id
+         JOIN labs ON labs.id = lab_members.lab_id
+         JOIN nodes ON nodes.id = labs.node_id
+        WHERE students.username = ? AND nodes.name = ? LIMIT 1`,
+    )
+    .get(p.user, node);
+  if (!owns) return;
   const row = db().prepare("SELECT email FROM students WHERE username = ?").get(p.user) as
     | { email: string | null }
     | undefined;
   if (!row?.email) return;
+  // Throttle repeated mail for the same (node,user,state).
+  const key = `${node}:${p.user}:${p.state}`;
+  const now = Date.now();
+  const last = gpuMailState.get(key) ?? 0;
+  if (now - last < GPU_MAIL_WINDOW_MS) return;
+  gpuMailState.set(key, now);
+
   const { sendGpuKillEmail, sendGpuWarningEmail } = await import("./mailer");
   if (p.state === "warned") {
     await sendGpuWarningEmail(row.email, {
-      lab: p.lab ?? null,
+      lab: p.lab,
       pid: p.pid,
       graceMinutes: getSetting("gpuGraceMinutes"),
     });
   } else {
-    await sendGpuKillEmail(row.email, { lab: p.lab ?? null, pid: p.pid });
+    await sendGpuKillEmail(row.email, { lab: p.lab, pid: p.pid });
   }
 }
 

--- a/controller/src/lib/hub.ts
+++ b/controller/src/lib/hub.ts
@@ -230,7 +230,6 @@ const GPU_MAIL_WINDOW_MS = 10 * 60 * 1000;
 /** Coerce an unknown field to a bounded string (control chars stripped) or null. */
 function boundedStr(v: unknown, max = 64): string | null {
   if (typeof v !== "string") return null;
-  // eslint-disable-next-line no-control-regex
   const clean = Array.from(v).filter((c) => c >= " " && c !== "\x7f").join("").slice(0, max);
   return clean.length ? clean : null;
 }

--- a/controller/src/lib/labs.ts
+++ b/controller/src/lib/labs.ts
@@ -6,6 +6,15 @@
 import { db } from "./db";
 import { enqueueTask } from "./queue";
 
+// Lab names become ZFS dataset components and the docker container name on a root agent. Usernames
+// are already strictly gated everywhere; close the asymmetry by allow-listing lab names too (M-04):
+// a leading alphanumeric then alphanumerics/hyphen/underscore, no slashes/dots/whitespace, <= 40.
+export const LAB_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,39}$/;
+
+export function isValidLabName(name: string): boolean {
+  return LAB_NAME_RE.test(name);
+}
+
 export interface Lab {
   id: number;
   name: string;
@@ -62,6 +71,9 @@ export interface CreateLabInput {
 }
 
 export function createLab(input: CreateLabInput): Lab {
+  if (!isValidLabName(input.name)) {
+    throw new Error("Invalid lab name (use letters, digits, hyphen or underscore; max 40 chars)");
+  }
   const node = db().prepare("SELECT name FROM nodes WHERE id = ?").get(input.nodeId) as
     | { name: string }
     | undefined;

--- a/controller/src/lib/mailer.ts
+++ b/controller/src/lib/mailer.ts
@@ -67,12 +67,12 @@ export interface CredentialEmail {
 
 export async function sendGpuWarningEmail(
   to: string,
-  opts: { lab: string | null; pid: number; graceMinutes: number },
+  opts: { lab: string | null; pid: number | null; graceMinutes: number },
 ): Promise<SendResult> {
   return sendMail(
     to,
     "Idle GPU process warning",
-    `One of your processes (PID ${opts.pid}${opts.lab ? `, lab ${opts.lab}` : ""}) is holding GPU` +
+    `One of your processes (PID ${opts.pid ?? "?"}${opts.lab ? `, lab ${opts.lab}` : ""}) is holding GPU` +
       ` memory but is not using the GPU.\n\nIf it stays idle it will be terminated in about ` +
       `${opts.graceMinutes} minutes to free the GPU for others. If you still need it, start using ` +
       `the GPU again or contact an admin.\n\n— Lab Manager`,
@@ -81,12 +81,12 @@ export async function sendGpuWarningEmail(
 
 export async function sendGpuKillEmail(
   to: string,
-  opts: { lab: string | null; pid: number },
+  opts: { lab: string | null; pid: number | null },
 ): Promise<SendResult> {
   return sendMail(
     to,
     "Idle GPU process terminated",
-    `Your idle process (PID ${opts.pid}${opts.lab ? `, lab ${opts.lab}` : ""}) was terminated ` +
+    `Your idle process (PID ${opts.pid ?? "?"}${opts.lab ? `, lab ${opts.lab}` : ""}) was terminated ` +
       `because it held GPU memory without using the GPU. Please checkpoint long-running work and ` +
       `keep the GPU active, or ask an admin to whitelist your job.\n\n— Lab Manager`,
   );

--- a/controller/src/lib/nodes.ts
+++ b/controller/src/lib/nodes.ts
@@ -1,0 +1,105 @@
+/**
+ * Per-node identity for the agent hub.
+ *
+ * The hub used to trust one shared AGENT_TOKEN plus whatever node name the client claimed, so any
+ * token holder could impersonate any node and drain its privileged task queue (C-04). Each node now
+ * has its own token (bcrypt-hashed at rest) and must be on the allow-list. A node is provisioned in
+ * the UI; first successful per-node auth pins the identity. The shared token still works for nodes
+ * left in 'legacy' mode during rollout (gated by env.allowLegacyAgentToken).
+ */
+
+import bcrypt from "bcryptjs";
+import { randomBytes } from "node:crypto";
+import { db } from "./db";
+import { env } from "./env";
+
+// DNS-label-ish: lowercase alphanumeric + hyphen, 1-63 chars, must start alphanumeric. Rejects the
+// literal "undefined", control chars, whitespace, and path/queue separators (M-03).
+export const NODE_NAME_RE = /^[a-z0-9][a-z0-9-]{0,62}$/;
+
+export function isValidNodeName(name: string): boolean {
+  return NODE_NAME_RE.test(name);
+}
+
+export interface NodeAuthResult {
+  ok: boolean;
+  reason?: string;
+}
+
+/** Generate a fresh node token (the plaintext is shown once and never stored). */
+export function generateNodeToken(): string {
+  return randomBytes(24).toString("hex");
+}
+
+interface NodeAuthRow {
+  id: number;
+  allowed: number;
+  token_hash: string | null;
+  auth_mode: string;
+  token_pinned_at: number | null;
+}
+
+/**
+ * Verify a hello frame's (name, token) against the node allow-list and credential. Synchronous so
+ * it can run inline in the hub's message handler; uses bcrypt.compareSync.
+ */
+export function verifyNodeAuth(name: string, token: string): NodeAuthResult {
+  if (!isValidNodeName(name)) return { ok: false, reason: "invalid node name" };
+  if (!token) return { ok: false, reason: "missing token" };
+  const row = db()
+    .prepare("SELECT id, allowed, token_hash, auth_mode, token_pinned_at FROM nodes WHERE name = ?")
+    .get(name) as NodeAuthRow | undefined;
+  if (!row || row.allowed !== 1) return { ok: false, reason: "unknown or blocked node" };
+
+  if (row.auth_mode === "pernode") {
+    if (!row.token_hash || !bcrypt.compareSync(token, row.token_hash)) {
+      return { ok: false, reason: "bad node token" };
+    }
+    if (row.token_pinned_at === null) {
+      db().prepare("UPDATE nodes SET token_pinned_at = ? WHERE id = ?").run(Date.now(), row.id);
+    }
+    return { ok: true };
+  }
+
+  // Legacy: shared AGENT_TOKEN, only while the rollout flag permits it.
+  if (!env.allowLegacyAgentToken) return { ok: false, reason: "legacy token disabled" };
+  if (token !== env.agentToken) return { ok: false, reason: "bad token" };
+  return { ok: true };
+}
+
+/** Register (or pre-register) a node and issue it a token. Returns the one-time plaintext token. */
+export function provisionNode(name: string, actor: string): string {
+  if (!isValidNodeName(name)) throw new Error(`invalid node name '${name}'`);
+  const token = generateNodeToken();
+  const hash = bcrypt.hashSync(token, 10);
+  const now = Date.now();
+  db()
+    .prepare(
+      `INSERT INTO nodes (name, allowed, token_hash, auth_mode, token_pinned_at, online, created_at)
+       VALUES (?, 1, ?, 'pernode', NULL, 0, ?)
+       ON CONFLICT(name) DO UPDATE SET
+         allowed = 1, token_hash = excluded.token_hash, auth_mode = 'pernode', token_pinned_at = NULL`,
+    )
+    .run(name, hash, now);
+  audit(actor, "node.provision", name);
+  return token;
+}
+
+/** Rotate an existing node's token. Returns the new one-time plaintext token. */
+export function rotateNodeToken(name: string, actor: string): string {
+  const exists = db().prepare("SELECT 1 FROM nodes WHERE name = ?").get(name);
+  if (!exists) throw new Error(`unknown node '${name}'`);
+  return provisionNode(name, actor);
+}
+
+/** Remove a node from the allow-list (its token stops working immediately). */
+export function revokeNode(name: string, actor: string): void {
+  db().prepare("UPDATE nodes SET allowed = 0 WHERE name = ?").run(name);
+  audit(actor, "node.revoke", name);
+}
+
+function audit(actor: string, action: string, target: string): void {
+  db()
+    .prepare("INSERT INTO audit_log (ts, actor, action, target) VALUES (?, ?, ?, ?)")
+    .run(Date.now(), actor, action, target);
+}

--- a/controller/src/lib/nodes.ts
+++ b/controller/src/lib/nodes.ts
@@ -10,6 +10,7 @@
 
 import bcrypt from "bcryptjs";
 import { randomBytes } from "node:crypto";
+import { safeEqual } from "./auth";
 import { db } from "./db";
 import { env } from "./env";
 
@@ -63,7 +64,7 @@ export function verifyNodeAuth(name: string, token: string): NodeAuthResult {
 
   // Legacy: shared AGENT_TOKEN, only while the rollout flag permits it.
   if (!env.allowLegacyAgentToken) return { ok: false, reason: "legacy token disabled" };
-  if (token !== env.agentToken) return { ok: false, reason: "bad token" };
+  if (!safeEqual(token, env.agentToken)) return { ok: false, reason: "bad token" };
   return { ok: true };
 }
 

--- a/controller/src/lib/queue.ts
+++ b/controller/src/lib/queue.ts
@@ -90,10 +90,23 @@ export function retryTask(node: string, jobId: number, workerId: string, error: 
   }
 }
 
-export function markTaskState(taskUuid: string, state: string, result?: unknown, error?: string): void {
-  db()
+/**
+ * Update a task's lifecycle state, bound to the node the task was queued for. Returns true if a row
+ * matched. The `node` binding means a compromised/spoofing agent cannot complete, fail, or poison a
+ * task that belongs to a different node (H-03) — a foreign UUID simply matches nothing.
+ */
+export function markTaskState(
+  node: string,
+  taskUuid: string,
+  state: string,
+  result?: unknown,
+  error?: string,
+): boolean {
+  const info = db()
     .prepare(
-      `UPDATE task_log SET state = ?, result = ?, error = ?, updated_at = ? WHERE task_uuid = ?`,
+      `UPDATE task_log SET state = ?, result = ?, error = ?, updated_at = ?
+       WHERE task_uuid = ? AND node = ?`,
     )
-    .run(state, result === undefined ? null : JSON.stringify(result), error ?? null, Date.now(), taskUuid);
+    .run(state, result === undefined ? null : JSON.stringify(result), error ?? null, Date.now(), taskUuid, node);
+  return info.changes > 0;
 }

--- a/controller/src/lib/ratelimit.ts
+++ b/controller/src/lib/ratelimit.ts
@@ -1,0 +1,47 @@
+/**
+ * In-memory per-key rate limiter (token bucket) for unauthenticated endpoints — login and signup.
+ * The controller is a single long-lived process, so process-local state is sufficient and avoids a
+ * dependency; it resets on restart, which is acceptable for brute-force throttling (H-02).
+ */
+
+import { headers } from "next/headers";
+
+interface Bucket {
+  tokens: number;
+  last: number;
+}
+
+const buckets = new Map<string, Bucket>();
+
+export interface RateLimitOptions {
+  /** Sustained refill rate, tokens per second. */
+  ratePerSec: number;
+  /** Bucket capacity (max burst). */
+  burst: number;
+}
+
+/** Consume one token for `key`. Returns true if allowed, false if the bucket is empty. */
+export function consume(key: string, opts: RateLimitOptions): boolean {
+  const now = Date.now();
+  const b = buckets.get(key) ?? { tokens: opts.burst, last: now };
+  b.tokens = Math.min(opts.burst, b.tokens + ((now - b.last) / 1000) * opts.ratePerSec);
+  b.last = now;
+  if (b.tokens < 1) {
+    buckets.set(key, b);
+    return false;
+  }
+  b.tokens -= 1;
+  buckets.set(key, b);
+  return true;
+}
+
+/** Best-effort client IP from common proxy headers; falls back to a constant bucket. */
+export async function clientIp(): Promise<string> {
+  const h = await headers();
+  const fwd = h.get("x-forwarded-for");
+  if (fwd) return fwd.split(",")[0]!.trim();
+  return h.get("x-real-ip") ?? "unknown";
+}
+
+// Tuned for interactive auth: a handful of attempts, then throttled. ~5 burst, refilling 1 / 12s.
+export const AUTH_LIMIT: RateLimitOptions = { ratePerSec: 1 / 12, burst: 5 };

--- a/controller/src/lib/secrets.ts
+++ b/controller/src/lib/secrets.ts
@@ -1,0 +1,49 @@
+/**
+ * Transparent encryption-at-rest for stored credential strings (SMTP/WebDAV passwords) — M-05.
+ *
+ * AES-256-GCM with a key derived from SESSION_SECRET via scrypt, so no extra mandatory env var is
+ * introduced (rotating SESSION_SECRET invalidates stored secrets, which is acceptable and noted in
+ * the README). Ciphertext is tagged with a version prefix; decryptSecret() passes through any value
+ * that isn't in that format, so pre-existing plaintext rows keep working and are re-encrypted the
+ * next time they're saved.
+ */
+
+import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from "node:crypto";
+import { env } from "./env";
+
+const PREFIX = "enc:v1:";
+const SALT = "lab-manager:secrets:v1"; // fixed salt: the master secret already carries the entropy.
+
+let _key: Buffer | null = null;
+function key(): Buffer {
+  if (!_key) _key = scryptSync(env.sessionSecret, SALT, 32);
+  return _key;
+}
+
+/** Encrypt a secret string to "enc:v1:<iv>:<tag>:<ct>" (all base64). Empty string passes through. */
+export function encryptSecret(plain: string): string {
+  if (plain === "") return "";
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key(), iv);
+  const ct = Buffer.concat([cipher.update(plain, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `${PREFIX}${iv.toString("base64")}:${tag.toString("base64")}:${ct.toString("base64")}`;
+}
+
+/** Decrypt a value produced by encryptSecret. A value not in that format is returned unchanged. */
+export function decryptSecret(stored: string): string {
+  if (!stored.startsWith(PREFIX)) return stored; // legacy plaintext or empty
+  const [ivB64, tagB64, ctB64] = stored.slice(PREFIX.length).split(":");
+  if (!ivB64 || !tagB64 || !ctB64) return stored;
+  try {
+    const decipher = createDecipheriv("aes-256-gcm", key(), Buffer.from(ivB64, "base64"));
+    decipher.setAuthTag(Buffer.from(tagB64, "base64"));
+    return Buffer.concat([decipher.update(Buffer.from(ctB64, "base64")), decipher.final()]).toString("utf8");
+  } catch {
+    return ""; // wrong key / tampered — fail closed to empty rather than leak or crash
+  }
+}
+
+export function isEncrypted(value: string): boolean {
+  return value.startsWith(PREFIX);
+}

--- a/controller/src/lib/settings.ts
+++ b/controller/src/lib/settings.ts
@@ -6,8 +6,12 @@
 
 import { db } from "./db";
 import { enqueueTask } from "./queue";
+import { decryptSecret, encryptSecret } from "./secrets";
 
 export const TIB = 1024 ** 4;
+
+// Credential settings encrypted at rest (M-05). Stored AES-GCM-encrypted; decrypted on read.
+const ENCRYPTED_KEYS = new Set<keyof Settings>(["smtpPass", "webdavPass"]);
 
 export interface Settings {
   fastQuotaDefaultBytes: number;
@@ -127,7 +131,11 @@ export function getSetting<K extends keyof Settings>(key: K): Settings[K] {
     | undefined;
   if (!row) return DEFAULT_SETTINGS[key];
   try {
-    return JSON.parse(row.value) as Settings[K];
+    const parsed = JSON.parse(row.value) as Settings[K];
+    if (ENCRYPTED_KEYS.has(key) && typeof parsed === "string") {
+      return decryptSecret(parsed) as Settings[K];
+    }
+    return parsed;
   } catch {
     return DEFAULT_SETTINGS[key];
   }
@@ -142,12 +150,16 @@ export function getSettings(): Settings {
 }
 
 export function setSetting<K extends keyof Settings>(key: K, value: Settings[K]): void {
+  const toStore =
+    ENCRYPTED_KEYS.has(key) && typeof value === "string"
+      ? (encryptSecret(value) as Settings[K])
+      : value;
   db()
     .prepare(
       `INSERT INTO settings (key, value) VALUES (?, ?)
        ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
     )
-    .run(key, JSON.stringify(value));
+    .run(key, JSON.stringify(toStore));
 }
 
 /** Pick the lowest SSH port in range not already assigned to a lab. */

--- a/controller/src/middleware.ts
+++ b/controller/src/middleware.ts
@@ -1,0 +1,33 @@
+/**
+ * Defense-in-depth auth gate. Server Actions compile to POST endpoints that do NOT pass through the
+ * page layout, so the layout's redirect is not a real gate — requireAdmin() (in lib/auth.ts) is the
+ * authority and re-checks the DB. This middleware runs on the edge (no DB access there), so it only
+ * blocks requests with a missing or unverifiable session cookie early, before they reach an action.
+ *
+ * The matcher excludes the public auth routes, Next internals, and the /agent WebSocket upgrade
+ * (handled by the custom server.ts before Next routing).
+ */
+
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { jwtVerify } from "jose";
+
+export const config = {
+  matcher: ["/((?!login|signup|_next/static|_next/image|favicon.ico|agent).*)"],
+};
+
+export async function middleware(req: NextRequest) {
+  const token = req.cookies.get("lab_session")?.value;
+  const loginUrl = new URL("/login", req.url);
+  if (!token) return NextResponse.redirect(loginUrl);
+  const secret = process.env.SESSION_SECRET;
+  // env.ts fails closed in every environment (see required()), so a missing secret here means a
+  // misconfigured deploy — refuse rather than fall back to a guessable key.
+  if (!secret) return NextResponse.redirect(loginUrl);
+  try {
+    await jwtVerify(token, new TextEncoder().encode(secret), { algorithms: ["HS256"] });
+  } catch {
+    return NextResponse.redirect(loginUrl);
+  }
+  return NextResponse.next();
+}

--- a/controller/tests/actions-auth.test.ts
+++ b/controller/tests/actions-auth.test.ts
@@ -1,0 +1,62 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+// Configure env before importing modules that read it at load time.
+const tmp = mkdtempSync(join(tmpdir(), "lab-ctl-actions-"));
+process.env.DB_PATH = join(tmp, "controller.db");
+process.env.SIGNUP_TOKEN = "test-signup";
+process.env.AGENT_TOKEN = "test-agent";
+process.env.SESSION_SECRET = "test-session-secret-test-session";
+
+// No session cookie -> currentAdmin() returns null -> requireAdmin() must redirect/throw.
+vi.mock("next/headers", () => ({
+  cookies: async () => ({ get: () => undefined, set: () => {}, delete: () => {} }),
+}));
+vi.mock("next/navigation", () => ({
+  redirect: (to: string) => {
+    throw new Error(`NEXT_REDIRECT:${to}`);
+  },
+}));
+vi.mock("next/cache", () => ({ revalidatePath: () => {} }));
+
+describe("Server Actions reject unauthenticated callers", () => {
+  let labs: typeof import("../src/app/(app)/labs/actions.js");
+  let students: typeof import("../src/app/(app)/students/actions.js");
+  let settings: typeof import("../src/app/(app)/settings/actions.js");
+
+  beforeAll(async () => {
+    labs = await import("../src/app/(app)/labs/actions.js");
+    students = await import("../src/app/(app)/students/actions.js");
+    settings = await import("../src/app/(app)/settings/actions.js");
+  });
+
+  const fd = () => new FormData();
+
+  it("every gated action redirects to /login with no session", async () => {
+    const calls: Array<Promise<unknown>> = [
+      labs.createLabAction(fd()),
+      labs.setQuotaAction(fd()),
+      labs.destroyLabAction(fd()),
+      labs.rescanAction(fd()),
+      labs.recreateContainerAction(fd()),
+      labs.addMemberAction(fd()),
+      labs.removeMemberAction(fd()),
+      students.importCsvAction(fd()),
+      settings.saveStorageSettingsAction(fd()),
+      settings.saveSmtpSettingsAction(fd()),
+      settings.saveAlertSettingsAction(fd()),
+      settings.saveGpuPolicyAction(fd()),
+      settings.saveScrubSettingsAction(fd()),
+      settings.scrubNowAction(),
+      settings.saveWebdavSettingsAction(fd()),
+      settings.backupNowAction(),
+      settings.restoreAction(fd()),
+      settings.testEmailAction(fd()),
+    ];
+    for (const c of calls) {
+      await expect(c).rejects.toThrow(/NEXT_REDIRECT:\/login/);
+    }
+  });
+});

--- a/controller/tests/auth.test.ts
+++ b/controller/tests/auth.test.ts
@@ -19,17 +19,17 @@ describe("admin signup token gate", () => {
 
   it("rejects a wrong signup token", async () => {
     await expect(
-      auth.createAdmin("Ed", "ed@uga.edu", "password123", "wrong-token"),
+      auth.createAdmin("Ed", "ed@uga.edu", "password123456", "wrong-token"),
     ).rejects.toThrow(/signup token/i);
     expect(auth.adminCount()).toBe(0);
   });
 
   it("creates an admin with the correct token and verifies login", async () => {
-    const admin = await auth.createAdmin("Ed", "ed@uga.edu", "password123", "test-signup");
+    const admin = await auth.createAdmin("Ed", "ed@uga.edu", "password123456", "test-signup");
     expect(admin.email).toBe("ed@uga.edu");
     expect(auth.adminCount()).toBe(1);
 
-    const ok = await auth.verifyLogin("ed@uga.edu", "password123");
+    const ok = await auth.verifyLogin("ed@uga.edu", "password123456");
     expect(ok?.email).toBe("ed@uga.edu");
 
     const bad = await auth.verifyLogin("ed@uga.edu", "wrongpass");
@@ -38,7 +38,13 @@ describe("admin signup token gate", () => {
 
   it("rejects duplicate email", async () => {
     await expect(
-      auth.createAdmin("Ed2", "ed@uga.edu", "password123", "test-signup"),
+      auth.createAdmin("Ed2", "ed@uga.edu", "password123456", "test-signup"),
     ).rejects.toThrow(/already exists/i);
+  });
+
+  it("enforces a minimum password length (L-05)", async () => {
+    await expect(
+      auth.createAdmin("Shorty", "short@uga.edu", "tooshort", "test-signup"),
+    ).rejects.toThrow(/at least 12/i);
   });
 });

--- a/controller/tests/env.test.ts
+++ b/controller/tests/env.test.ts
@@ -30,27 +30,30 @@ describe("env defaults", () => {
 
 describe("required secrets", () => {
   it("returns the explicit value when set", () => {
-    vi.stubEnv("SESSION_SECRET", "explicit-secret");
-    expect(env.sessionSecret).toBe("explicit-secret");
+    vi.stubEnv("SESSION_SECRET", "explicit-secret-explicit-secret-32");
+    expect(env.sessionSecret).toBe("explicit-secret-explicit-secret-32");
   });
 
-  it("uses the dev fallback outside production", () => {
+  it("fails closed outside production — no dev fallback (H-01)", () => {
     vi.stubEnv("NODE_ENV", "development");
     vi.stubEnv("SIGNUP_TOKEN", undefined as unknown as string);
-    expect(env.signupToken).toBe("dev-signup-token");
+    expect(() => env.signupToken).toThrow(/Missing required env var SIGNUP_TOKEN/);
     vi.stubEnv("AGENT_TOKEN", undefined as unknown as string);
-    expect(env.agentToken).toBe("dev-agent-token");
+    expect(() => env.agentToken).toThrow(/Missing required env var AGENT_TOKEN/);
   });
 
-  it("throws in production when a required var is missing", () => {
-    vi.stubEnv("NODE_ENV", "production");
+  it("throws when a required var is missing", () => {
     vi.stubEnv("SESSION_SECRET", undefined as unknown as string);
     expect(() => env.sessionSecret).toThrow(/Missing required env var SESSION_SECRET/);
   });
 
   it("treats an empty string as missing", () => {
-    vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("AGENT_TOKEN", "");
     expect(() => env.agentToken).toThrow(/AGENT_TOKEN/);
+  });
+
+  it("rejects a SESSION_SECRET shorter than 32 chars", () => {
+    vi.stubEnv("SESSION_SECRET", "too-short");
+    expect(() => env.sessionSecret).toThrow(/at least 32 characters/);
   });
 });

--- a/controller/tests/labs.test.ts
+++ b/controller/tests/labs.test.ts
@@ -40,6 +40,21 @@ function makeLab(name: string) {
   });
 }
 
+describe("lab name validation (M-04)", () => {
+  it("accepts a simple name and rejects junk", () => {
+    expect(labs.isValidLabName("bio-101")).toBe(true);
+    expect(labs.isValidLabName("../etc")).toBe(false);
+    expect(labs.isValidLabName("a/b")).toBe(false);
+    expect(labs.isValidLabName("has space")).toBe(false);
+    expect(labs.isValidLabName("")).toBe(false);
+  });
+
+  it("createLab throws on an invalid name (no task enqueued)", () => {
+    expect(() => makeLab("bad/name")).toThrow(/Invalid lab name/);
+    expect(enqueueTask).not.toHaveBeenCalled();
+  });
+});
+
 describe("createLab", () => {
   it("inserts the lab, enqueues lab.create, and audits", () => {
     const lab = makeLab("bio");

--- a/controller/tests/nodes.test.ts
+++ b/controller/tests/nodes.test.ts
@@ -1,0 +1,74 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const tmp = mkdtempSync(join(tmpdir(), "lab-ctl-nodes-"));
+process.env.DB_PATH = join(tmp, "controller.db");
+process.env.SIGNUP_TOKEN = "t";
+process.env.AGENT_TOKEN = "shared-agent-token";
+process.env.SESSION_SECRET = "test-session-secret-test-session";
+
+let nodes: typeof import("../src/lib/nodes");
+let dbmod: typeof import("../src/lib/db");
+
+beforeAll(async () => {
+  nodes = await import("../src/lib/nodes");
+  dbmod = await import("../src/lib/db");
+});
+
+describe("node name validation (M-03)", () => {
+  it("accepts dns-label-ish names and rejects junk", () => {
+    expect(nodes.isValidNodeName("gpu-01")).toBe(true);
+    expect(nodes.isValidNodeName("a")).toBe(true);
+    expect(nodes.isValidNodeName("undefined")).toBe(true); // a literal valid name, distinct from missing
+    expect(nodes.isValidNodeName("")).toBe(false);
+    expect(nodes.isValidNodeName("-bad")).toBe(false);
+    expect(nodes.isValidNodeName("UPPER")).toBe(false);
+    expect(nodes.isValidNodeName("gpu 1")).toBe(false);
+    expect(nodes.isValidNodeName("gpu\n1")).toBe(false);
+    expect(nodes.isValidNodeName("a".repeat(64))).toBe(false);
+  });
+});
+
+describe("verifyNodeAuth (C-04)", () => {
+  it("rejects an unknown / not-allow-listed node", () => {
+    expect(nodes.verifyNodeAuth("ghost", "anything").ok).toBe(false);
+  });
+
+  it("accepts the correct per-node token, rejects a wrong one, and pins first-seen", () => {
+    const token = nodes.provisionNode("gpu-a", "admin@uga.edu");
+    expect(nodes.verifyNodeAuth("gpu-a", "wrong").ok).toBe(false);
+
+    const before = dbmod.db().prepare("SELECT token_pinned_at FROM nodes WHERE name = ?").get("gpu-a") as any;
+    expect(before.token_pinned_at).toBeNull();
+
+    expect(nodes.verifyNodeAuth("gpu-a", token).ok).toBe(true);
+    const after = dbmod.db().prepare("SELECT token_pinned_at FROM nodes WHERE name = ?").get("gpu-a") as any;
+    expect(typeof after.token_pinned_at).toBe("number");
+  });
+
+  it("does not accept the shared token for a per-node node", () => {
+    nodes.provisionNode("gpu-b", "admin@uga.edu");
+    expect(nodes.verifyNodeAuth("gpu-b", "shared-agent-token").ok).toBe(false);
+  });
+
+  it("accepts the shared token only for an allow-listed legacy node", () => {
+    // Simulate a node backfilled by migration 0004 (allowed=1, auth_mode='legacy').
+    dbmod
+      .db()
+      .prepare(
+        "INSERT INTO nodes (name, allowed, auth_mode, online, created_at) VALUES (?, 1, 'legacy', 0, ?)",
+      )
+      .run("legacy-node", Date.now());
+    expect(nodes.verifyNodeAuth("legacy-node", "shared-agent-token").ok).toBe(true);
+    expect(nodes.verifyNodeAuth("legacy-node", "nope").ok).toBe(false);
+  });
+
+  it("revoke removes a node from the allow-list", () => {
+    const token = nodes.provisionNode("gpu-c", "admin@uga.edu");
+    expect(nodes.verifyNodeAuth("gpu-c", token).ok).toBe(true);
+    nodes.revokeNode("gpu-c", "admin@uga.edu");
+    expect(nodes.verifyNodeAuth("gpu-c", token).ok).toBe(false);
+  });
+});

--- a/controller/tests/queue.test.ts
+++ b/controller/tests/queue.test.ts
@@ -74,7 +74,7 @@ describe("claim / ack", () => {
 describe("markTaskState", () => {
   it("transitions task_log state and stores the result", () => {
     const frame = queue.enqueueTask("gpu-1", "lab.create", { lab: "y" });
-    queue.markTaskState(frame.id, "ok", { container: "abc" });
+    expect(queue.markTaskState("gpu-1", frame.id, "ok", { container: "abc" })).toBe(true);
     const row = dbmod.db().prepare("SELECT * FROM task_log WHERE task_uuid = ?").get(frame.id) as any;
     expect(row.state).toBe("ok");
     expect(JSON.parse(row.result)).toEqual({ container: "abc" });
@@ -83,10 +83,19 @@ describe("markTaskState", () => {
 
   it("stores an error string on failure", () => {
     const frame = queue.enqueueTask("gpu-1", "lab.create");
-    queue.markTaskState(frame.id, "failed", undefined, "boom");
+    expect(queue.markTaskState("gpu-1", frame.id, "failed", undefined, "boom")).toBe(true);
     const row = dbmod.db().prepare("SELECT * FROM task_log WHERE task_uuid = ?").get(frame.id) as any;
     expect(row.state).toBe("failed");
     expect(row.result).toBeNull();
     expect(row.error).toBe("boom");
+  });
+
+  it("refuses to mutate a task that belongs to a different node (H-03)", () => {
+    const frame = queue.enqueueTask("node-owner", "student.add", { username: "alice" });
+    // A spoofing agent ("node-evil") tries to complete node-owner's task.
+    expect(queue.markTaskState("node-evil", frame.id, "ok", { hijacked: true })).toBe(false);
+    const row = dbmod.db().prepare("SELECT * FROM task_log WHERE task_uuid = ?").get(frame.id) as any;
+    expect(row.state).toBe("queued"); // untouched
+    expect(row.result).toBeNull();
   });
 });

--- a/controller/tests/ratelimit.test.ts
+++ b/controller/tests/ratelimit.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { consume } from "../src/lib/ratelimit";
+
+describe("rate limiter (H-02)", () => {
+  it("allows up to the burst then blocks", () => {
+    const opts = { ratePerSec: 0, burst: 3 };
+    const key = "test:burst";
+    expect(consume(key, opts)).toBe(true);
+    expect(consume(key, opts)).toBe(true);
+    expect(consume(key, opts)).toBe(true);
+    expect(consume(key, opts)).toBe(false); // 4th in the window is throttled
+  });
+
+  it("keys are independent", () => {
+    const opts = { ratePerSec: 0, burst: 1 };
+    expect(consume("test:a", opts)).toBe(true);
+    expect(consume("test:b", opts)).toBe(true);
+    expect(consume("test:a", opts)).toBe(false);
+  });
+});

--- a/controller/tests/require-admin.test.ts
+++ b/controller/tests/require-admin.test.ts
@@ -1,0 +1,87 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Configure env before importing modules that read it at load time.
+const tmp = mkdtempSync(join(tmpdir(), "lab-ctl-reqadmin-"));
+process.env.DB_PATH = join(tmp, "controller.db");
+process.env.SIGNUP_TOKEN = "test-signup";
+process.env.AGENT_TOKEN = "test-agent";
+process.env.SESSION_SECRET = "test-session-secret-test-session";
+
+// Mutable cookie store backing the next/headers mock.
+let cookieValue: string | undefined;
+const cookieStore = {
+  get: (name: string) => (name === "lab_session" && cookieValue ? { value: cookieValue } : undefined),
+  set: () => {},
+  delete: () => {
+    cookieValue = undefined;
+  },
+};
+vi.mock("next/headers", () => ({ cookies: async () => cookieStore }));
+
+// redirect() throws NEXT_REDIRECT in real Next; emulate that so callers can't proceed.
+class RedirectError extends Error {
+  constructor(public to: string) {
+    super(`NEXT_REDIRECT:${to}`);
+  }
+}
+vi.mock("next/navigation", () => ({
+  redirect: (to: string) => {
+    throw new RedirectError(to);
+  },
+}));
+
+describe("requireAdmin gate", () => {
+  let auth: typeof import("../src/lib/auth.js");
+  let db: typeof import("../src/lib/db.js");
+  let adminId: number;
+
+  beforeAll(async () => {
+    auth = await import("../src/lib/auth.js");
+    db = await import("../src/lib/db.js");
+    const admin = await auth.createAdmin("Ed", "ed@uga.edu", "password123", "test-signup");
+    adminId = admin.id;
+  });
+
+  beforeEach(() => {
+    cookieValue = undefined;
+    // reset admin state between cases
+    db.db().prepare("UPDATE admins SET is_active = 1, token_version = 0 WHERE id = ?").run(adminId);
+  });
+
+  it("redirects when there is no session cookie", async () => {
+    await expect(auth.requireAdmin()).rejects.toThrow(/NEXT_REDIRECT:\/login/);
+  });
+
+  it("redirects on a token signed with the wrong secret", async () => {
+    cookieValue = "not-a-real-jwt";
+    await expect(auth.requireAdmin()).rejects.toThrow(/NEXT_REDIRECT:\/login/);
+  });
+
+  it("returns the verified admin for a valid session", async () => {
+    cookieValue = await auth.issueSession({ id: adminId, name: "Ed", email: "ed@uga.edu" });
+    const admin = await auth.requireAdmin();
+    expect(admin.email).toBe("ed@uga.edu");
+    expect(admin.id).toBe(adminId);
+  });
+
+  it("rejects a disabled admin (is_active = 0)", async () => {
+    cookieValue = await auth.issueSession({ id: adminId, name: "Ed", email: "ed@uga.edu" });
+    db.db().prepare("UPDATE admins SET is_active = 0 WHERE id = ?").run(adminId);
+    await expect(auth.requireAdmin()).rejects.toThrow(/NEXT_REDIRECT:\/login/);
+  });
+
+  it("rejects a stale token_version (revoked session)", async () => {
+    cookieValue = await auth.issueSession({ id: adminId, name: "Ed", email: "ed@uga.edu" });
+    // Bump the version after the token was issued — emulates logout-all / revoke.
+    db.db().prepare("UPDATE admins SET token_version = token_version + 1 WHERE id = ?").run(adminId);
+    await expect(auth.requireAdmin()).rejects.toThrow(/NEXT_REDIRECT:\/login/);
+  });
+
+  it("rejects a deleted admin", async () => {
+    cookieValue = await auth.issueSession({ id: 99999, name: "Ghost", email: "ghost@uga.edu" });
+    await expect(auth.requireAdmin()).rejects.toThrow(/NEXT_REDIRECT:\/login/);
+  });
+});

--- a/controller/tests/require-admin.test.ts
+++ b/controller/tests/require-admin.test.ts
@@ -41,7 +41,7 @@ describe("requireAdmin gate", () => {
   beforeAll(async () => {
     auth = await import("../src/lib/auth.js");
     db = await import("../src/lib/db.js");
-    const admin = await auth.createAdmin("Ed", "ed@uga.edu", "password123", "test-signup");
+    const admin = await auth.createAdmin("Ed", "ed@uga.edu", "password123456", "test-signup");
     adminId = admin.id;
   });
 

--- a/controller/tests/secrets.test.ts
+++ b/controller/tests/secrets.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+process.env.SESSION_SECRET = "test-session-secret-test-session";
+process.env.SIGNUP_TOKEN = "t";
+process.env.AGENT_TOKEN = "t";
+
+import { decryptSecret, encryptSecret, isEncrypted } from "../src/lib/secrets";
+
+describe("secrets at rest (M-05)", () => {
+  it("round-trips a value and marks it encrypted", () => {
+    const enc = encryptSecret("hunter2");
+    expect(isEncrypted(enc)).toBe(true);
+    expect(enc).not.toContain("hunter2");
+    expect(decryptSecret(enc)).toBe("hunter2");
+  });
+
+  it("passes through legacy plaintext (not enc-prefixed)", () => {
+    expect(decryptSecret("plain-old-password")).toBe("plain-old-password");
+  });
+
+  it("empty string stays empty", () => {
+    expect(encryptSecret("")).toBe("");
+    expect(decryptSecret("")).toBe("");
+  });
+
+  it("produces a different ciphertext each time (random IV)", () => {
+    expect(encryptSecret("same")).not.toBe(encryptSecret("same"));
+  });
+});

--- a/controller/tests/settings.test.ts
+++ b/controller/tests/settings.test.ts
@@ -37,6 +37,20 @@ describe("getSetting / setSetting", () => {
     expect(settings.getSetting("gpuEnabled")).toBe(true);
   });
 
+  it("encrypts credential settings at rest but reads them back plaintext (M-05)", () => {
+    settings.setSetting("smtpPass", "super-secret-pw");
+    settings.setSetting("webdavPass", "dav-secret");
+    // getSetting decrypts transparently.
+    expect(settings.getSetting("smtpPass")).toBe("super-secret-pw");
+    expect(settings.getSetting("webdavPass")).toBe("dav-secret");
+    // The raw stored value must NOT contain the plaintext.
+    const raw = dbmod.db().prepare("SELECT value FROM settings WHERE key = 'smtpPass'").get() as {
+      value: string;
+    };
+    expect(raw.value).not.toContain("super-secret-pw");
+    expect(raw.value).toContain("enc:v1:");
+  });
+
   it("falls back to default when the stored value is corrupt JSON", () => {
     dbmod
       .db()

--- a/controller/vitest.config.ts
+++ b/controller/vitest.config.ts
@@ -1,6 +1,11 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    // Mirror the tsconfig "@/*" -> "src/*" path alias so Server Action modules resolve under test.
+    alias: { "@": fileURLToPath(new URL("./src", import.meta.url)) },
+  },
   test: {
     environment: "node",
     include: ["tests/**/*.test.ts"],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,9 @@
 services:
   controller:
     build: ./controller
+    # For production, pin to an immutable released image rather than :latest (M-09), e.g.
+    #   image: ghcr.io/ec061/lab-controller@sha256:<digest>
+    # (copy the digest CI prints for the tag you intend to run).
     image: ghcr.io/ec061/lab-controller:latest
     restart: unless-stopped
     ports:

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -14,6 +14,14 @@ RUN apt-get update \
         openssh-server sudo python3-pip python3-venv curl nano ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && sed -i 's/^#\?PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config \
+    # Harden sshd: students authenticate with passwords, but root login is off, brute force is
+    # throttled, and the login window is short (H-05). Instructors can still use key auth.
+    && sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config \
+    && sed -i 's/^#\?MaxAuthTries.*/MaxAuthTries 3/' /etc/ssh/sshd_config \
+    && sed -i 's/^#\?LoginGraceTime.*/LoginGraceTime 30/' /etc/ssh/sshd_config \
+    && printf '\nPermitRootLogin no\nMaxAuthTries 3\nLoginGraceTime 30\n' >> /etc/ssh/sshd_config \
+    # Lock the root account password so it cannot be used for SSH/su.
+    && passwd -l root \
     && mkdir -p /var/run/sshd /labdata /labusers
 
 COPY entrypoint.sh /entrypoint.sh

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -7,7 +7,8 @@
 # Build + tag for use as a lab image:
 #   docker build -t custom-ssh ./image
 
-FROM ubuntu:noble
+# Pinned by digest for reproducible builds (M-09); Dependabot bumps it, the tag comment stays readable.
+FROM ubuntu:noble@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Fixes every finding from the 2026-06-20 security audit (4 Critical, 7 High, 9 Medium, 10 Low, 2 Info), sequenced into 5 waves (one commit each) so history maps to the audit's recommended fix order. To be **rebase-merged** into `main`.

## What changed, by wave

**Wave 1 — authenticate the admin API (C-01/02/03, H-06).** Server Actions ran unauthenticated (auth was only in the page layout). Added `requireAdmin()` that re-validates the JWT subject against the DB and redirects when unauthenticated, called first in all 18 mutating actions; added `middleware.ts` defense-in-depth; migration `0003` adds `admins.is_active`/`token_version`; bounded CSV import; whitelisted `restoreAction`; cookie `secure`+`SameSite=Strict`; HS256 pinned.

**Wave 2 — fail closed on secrets (H-01).** `env.ts` requires `SESSION_SECRET`/`SIGNUP_TOKEN`/`AGENT_TOKEN` in every environment (no dev fallbacks); `SESSION_SECRET` ≥ 32 chars. README/.env.example updated.

**Wave 3 — per-node identity (C-04, H-03/04, M-03).** Migration `0004` + `lib/nodes.ts`: per-node bcrypt tokens, name allow-list, first-seen pinning. Hub verifies identity, refuses to supersede a live connection, and binds result frames to the authenticated node (`markTaskState(node, …) AND node = ?`). Backward-compatible `legacy` rollout via `ALLOW_LEGACY_AGENT_TOKEN`. New Nodes UI (provision/rotate/revoke, token shown once) + `lab-agent set-token`.

**Wave 4 — harden image + inbound surface (H-02, H-05, M-01/02/04).** sshd `PermitRootLogin no`/`MaxAuthTries 3`/locked root; **students no longer auto-added to sudo**; `umask 027`. Login/signup rate limiting; hub `maxPayload` + message-rate cap; GPU-event validation + node-ownership + mail throttle; lab-name allow-list (controller + agent).

**Wave 5 — secrets-at-rest, sessions, supply chain, hardening.** AES-GCM encryption of SMTP/WebDAV secrets at rest (M-05); session revocation enforced + logout-all + 24h TTL (H-07); student password out of the redirect URL via a one-time flash (M-07); GPU killer PID-reuse guard (M-06); GitHub Actions pinned to SHAs (M-08); base images pinned by digest (M-09); constant-time compares (L-01), dummy-hash login (L-03), password policy + bcrypt cost 12 (L-05), TLS-disable warning (L-08), docker image/env allow-list (L-10), `uv.lock` + pinned install (I-02), local `tsx` at boot (L-07 partial).

## Notes / accepted items
- **L-06 (flat admin model):** kept by request — all admins fully privileged. With the auth gate in place the IDOR is an accepted insider-only risk.
- **L-07 (compile-to-JS runtime):** did the safe half (local `tsx`, no `npx` fetch); full JS compile of the custom server is follow-up needing a real Docker build.
- **I-01 (WS upgrade Origin):** mitigated by the token; restrict `/agent` at the network layer.
- **Operational:** new nodes must be provisioned in the UI before they can connect; existing nodes keep working via the legacy flag during rollout.

## Verification
- Controller: 127 vitest tests pass; `tsc` clean; `next build` clean (middleware registered).
- Agent: 168 pytest pass; ruff clean.
- New tests: `requireAdmin` gate, all-actions-reject-anonymous, per-node auth/allow-list/pinning, H-03 task-binding regression, secrets round-trip + encryption-at-rest, rate limiter, lab-name + docker image/env validation, GPU PID-reuse guard, agent `set-token`.
- Real ZFS/Docker/GPU paths still need a real node (pre-existing project caveat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)