### PR TITLE
ci: publish :latest + arm64 image; raise default container quota to 300g

### DIFF
--- a/.github/workflows/build-controller.yml
+++ b/.github/workflows/build-controller.yml
@@ -32,9 +32,15 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE }}
           tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=sha
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3
+        with:
+          platforms: arm64
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
@@ -43,6 +49,7 @@ jobs:
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: ./controller
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -76,6 +76,25 @@ sudo systemctl restart docker
 docker info | grep -i 'Storage Driver'   # should print: Storage Driver: zfs
 ```
 
+> **Migrating an existing Docker root.** Changing `data-root` (or the storage driver) does **not**
+> move existing data — Docker just starts empty at the new path, orphaning the old images/containers
+> under `/var/lib/docker`. On a node that has already run Docker, migrate before restarting:
+>
+> ```bash
+> sudo systemctl stop docker docker.socket           # stop the engine and its socket
+> sudo rsync -aHAX --info=progress2 /var/lib/docker/ /fast/docker/   # copy data onto the ZFS dataset
+> # ...write /etc/docker/daemon.json as above, then:
+> sudo systemctl start docker
+> docker info | grep -iE 'Storage Driver|Docker Root Dir'   # zfs, /fast/docker
+> docker images && docker ps -a                      # confirm images/containers survived
+> sudo mv /var/lib/docker /var/lib/docker.old         # remove only after you've verified
+> ```
+>
+> The old overlay2/devicemapper layers are **not** reusable under the `zfs` driver, so a clean node
+> (no prior Docker data) needs none of this — just write `daemon.json` and restart. If migrating is
+> not worth it, instead `docker save` the images you care about and `docker load` them after the
+> switch.
+
 > Per-student scratch/cold datasets are bind-mounted into the lab container with `rshared`
 > propagation so they appear live. Make the ZFS mounts shared once per boot:
 > `sudo mount --make-rshared /fast && sudo mount --make-rshared /slow`.

--- a/agent/src/lab_agent/executors/docker.py
+++ b/agent/src/lab_agent/executors/docker.py
@@ -59,7 +59,7 @@ class ContainerOptions:
     cpus: str = "4"
     memory: str = "8g"
     shm_size: str = "1g"
-    image_quota: str = "50g"  # writable layer quota via zfs storage driver
+    image_quota: str = "300g"  # writable layer quota via zfs storage driver
     ssh_port: int = 0
     restart: str = "unless-stopped"
     extra_env: dict[str, str] = field(default_factory=dict)

--- a/controller/src/app/(app)/labs/actions.ts
+++ b/controller/src/app/(app)/labs/actions.ts
@@ -32,7 +32,7 @@ export async function createLabAction(formData: FormData) {
     cpus: String(formData.get("cpus") ?? "4"),
     memory: String(formData.get("memory") ?? "8g"),
     shm_size: String(formData.get("shmSize") ?? "1g"),
-    image_quota: String(formData.get("imageQuota") ?? "50g"),
+    image_quota: String(formData.get("imageQuota") ?? "300g"),
     restart: String(formData.get("restart") ?? "unless-stopped"),
   };
 

--- a/controller/src/app/(app)/labs/page.tsx
+++ b/controller/src/app/(app)/labs/page.tsx
@@ -90,7 +90,7 @@ export default function LabsPage() {
             </div>
             <div>
               <label>Image size quota</label>
-              <input name="imageQuota" defaultValue="50g" />
+              <input name="imageQuota" defaultValue="300g" />
             </div>
             <div>
               <label>Restart policy</label>


### PR DESCRIPTION
## Why

A deploy of `ghcr.io/ec061/lab-controller:latest` failed with `not found`. Root cause: `docker/metadata-action` only auto-adds the `latest` tag on **semver git tags**, not on branch pushes — so the main-only build pipeline never published `:latest`, even though the package is public. This PR makes `:latest` real, adds an arm64 image, and folds in the unrelated quota/README edits from the same working session.

## Changes

**CI — `.github/workflows/build-controller.yml`**
- Tag every default-branch build as `latest`: `type=raw,value=latest,enable={{is_default_branch}}`.
- Multi-arch build: add `docker/setup-qemu-action` and `platforms: linux/amd64,linux/arm64` (arm64/v8) on the build-push step.

**Default container quota 50g → 300g** — updated all three sources of the default so they stay consistent:
- `agent/.../executors/docker.py` — `ContainerOptions.image_quota`
- `controller/.../labs/page.tsx` — create-lab form default
- `controller/.../labs/actions.ts` — server-action fallback

Enforced at container creation (`docker run --storage-opt size=`); existing labs keep their old quota until *Recreate container*.

**README** — add a Docker data-root migration step to §1.3 (stop docker → `rsync /var/lib/docker` → `/fast/docker` → restart → verify → archive old root), since changing `data-root`/storage-driver doesn't move existing data.

## Notes
- arm64 builds cross-compile under QEMU; the `node:26-bookworm-slim` base is a multi-arch manifest list, so the pinned digest resolves per-platform.
- `agent/tests/test_docker.py` passes explicit quota values, so the default change doesn't affect tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)