### PR TITLE
ci: split multi-arch build to native runners; fix Turbopack build warnings

### DIFF
--- a/.github/workflows/build-controller.yml
+++ b/.github/workflows/build-controller.yml
@@ -1,8 +1,17 @@
 name: Build controller image
 
+# Gated on CI: a push to main runs the "CI" workflow; only once it succeeds does this build fire.
+# The image is then built on two NATIVE runners in parallel (amd64 + arm64, no QEMU emulation) and
+# stitched into a single multi-arch manifest by the merge job. Version tags (v*) and manual runs
+# build directly without waiting on CI.
+#
+# NOTE: workflow_run always uses the copy of this file on the default branch — these changes only
+# take effect once merged to main.
 on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
   push:
-    branches: [main]
     tags: ["v*"]
   workflow_dispatch:
 
@@ -12,12 +21,36 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # Build on: CI success on main, or a version tag / manual dispatch. PR and rewrite/** CI runs
+    # (different head_branch/event) are filtered out so we only publish from main.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'main' &&
+       github.event.workflow_run.event == 'push')
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
+      - name: Compute platform slug
+        env:
+          platform: ${{ matrix.platform }}
+        run: echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          # For workflow_run, check out the exact commit CI validated. Empty for push/dispatch, which
+          # falls back to the triggering ref (the tag or branch).
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Log in to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
@@ -26,32 +59,87 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Docker metadata
+      - name: Docker metadata (labels)
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE }}
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        with:
+          context: ./controller
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          # Per-arch GHA cache scope so the two runners don't clobber each other's layer cache.
+          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}
+          # No provenance/SBOM attestation manifest — that is the spurious "unknown/unknown" entry on
+          # the GHCR package page. Drops the manifest list back to the two real architectures.
+          provenance: false
+          sbom: false
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: [build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - name: Docker metadata (tags)
         id: meta
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE }}
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=ref,event=branch
-            type=semver,pattern={{version}}
+            # main (workflow_run) and manual runs move :latest; a v* tag push is a release and only
+            # gets its semver tag. ('push' here is exclusively the tags: ["v*"] trigger.)
+            type=raw,value=latest,enable=${{ github.event_name != 'push' }}
             type=sha
+            type=semver,pattern={{version}}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3
-        with:
-          platforms: arm64
+      - name: Create and push manifest list
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE }}@sha256:%s ' *)
 
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
-
-      - name: Build and push
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
-        with:
-          context: ./controller
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Inspect manifest
+        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ steps.meta.outputs.version }}

--- a/controller/src/lib/db.ts
+++ b/controller/src/lib/db.ts
@@ -6,8 +6,12 @@
  */
 
 import Database from "better-sqlite3";
-import { existsSync, mkdirSync, renameSync, rmSync } from "node:fs";
-import { dirname } from "node:path";
+// node:fs / node:path are loaded via process.getBuiltinModule rather than a static import so the
+// Turbopack build tracer doesn't see filesystem calls here and pull the whole project into the
+// (unused — we run a custom server, not standalone output) NFT trace. See the build warning at
+// https://nextjs.org/docs/messages/nft-unexpected-file.
+const { existsSync, mkdirSync, renameSync, rmSync } = process.getBuiltinModule("node:fs");
+const { dirname } = process.getBuiltinModule("node:path");
 import { env } from "./env";
 
 /** If a WebDAV restore was staged as <dbPath>.restore, swap it in before opening. */

--- a/controller/src/proxy.ts
+++ b/controller/src/proxy.ts
@@ -1,7 +1,7 @@
 /**
  * Defense-in-depth auth gate. Server Actions compile to POST endpoints that do NOT pass through the
  * page layout, so the layout's redirect is not a real gate — requireAdmin() (in lib/auth.ts) is the
- * authority and re-checks the DB. This middleware runs on the edge (no DB access there), so it only
+ * authority and re-checks the DB. This proxy runs on the edge (no DB access there), so it only
  * blocks requests with a missing or unverifiable session cookie early, before they reach an action.
  *
  * The matcher excludes the public auth routes, Next internals, and the /agent WebSocket upgrade
@@ -16,7 +16,7 @@ export const config = {
   matcher: ["/((?!login|signup|_next/static|_next/image|favicon.ico|agent).*)"],
 };
 
-export async function middleware(req: NextRequest) {
+export async function proxy(req: NextRequest) {
   const token = req.cookies.get("lab_session")?.value;
   const loginUrl = new URL("/login", req.url);
   if (!token) return NextResponse.redirect(loginUrl);


### PR DESCRIPTION
## Build pipeline
- **CI-gated build**: the controller image now builds via `workflow_run` on the `CI` workflow — a merge to main runs CI first and only builds on green. PR / `rewrite/**` / failed CI runs are filtered out (`head_branch` + `event` guards). `v*` tags and manual dispatch still build directly.
- **Native parallel multi-arch**: amd64 on `ubuntu-latest` + arm64 on the native `ubuntu-24.04-arm` runner, in parallel — no more QEMU emulation (the slow part). Per-arch digests are stitched into one manifest with `buildx imagetools`. Per-arch GHA cache scopes avoid cross-clobbering.
- **`provenance: false` / `sbom: false`**: drops the spurious `unknown/unknown` manifest entry (the third "OS/Arch" on the GHCR package page).

## Controller build warnings (Next 16.2.9 + Turbopack)
- **NFT trace**: `db.ts` now loads `node:fs` / `node:path` via `process.getBuiltinModule(...)` so Turbopack's build tracer stops pulling the whole project into the (unused — custom server, not standalone) NFT trace. Bisected the trace to confirm `node:fs` was the trigger.
- **middleware → proxy**: renamed `middleware.ts` → `proxy.ts` and `middleware()` → `proxy()` for the renamed Next 16 file convention.

Verified locally: zero build warnings, `tsc`/`eslint`/130 vitest tests pass.

> Note: `workflow_run` always uses the default-branch copy of the workflow, so the new pipeline takes effect once this merges to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)