### PR TITLE
ci: lowercase GHCR image name in multi-arch build/merge

### DIFF
--- a/.github/workflows/build-controller.yml
+++ b/.github/workflows/build-controller.yml
@@ -41,10 +41,15 @@ jobs:
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
     steps:
-      - name: Compute platform slug
+      - name: Compute platform slug and lowercase image
         env:
           platform: ${{ matrix.platform }}
-        run: echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+          image: ${{ env.IMAGE }}
+        run: |
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+          # GHCR repository names must be lowercase; the owner (github.repository_owner) may not be.
+          # metadata-action lowercases its own outputs, but the raw outputs= name below does not.
+          echo "IMAGE_LC=${image,,}" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -75,7 +80,7 @@ jobs:
           context: ./controller
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_LC }},push-by-digest=true,name-canonical=true,push=true
           # Per-arch GHA cache scope so the two runners don't clobber each other's layer cache.
           cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
           cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}
@@ -105,6 +110,11 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Lowercase image
+        env:
+          image: ${{ env.IMAGE }}
+        run: echo "IMAGE_LC=${image,,}" >> "$GITHUB_ENV"
+
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -126,7 +136,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_LC }}
           tags: |
             # main (workflow_run) and manual runs move :latest; a v* tag push is a release and only
             # gets its semver tag. ('push' here is exclusively the tags: ["v*"] trigger.)
@@ -139,7 +149,7 @@ jobs:
         run: |
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE }}@sha256:%s ' *)
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_LC }}@sha256:%s ' *)
 
       - name: Inspect manifest
-        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ steps.meta.outputs.version }}
+        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_LC }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
Fixes the failed run on the new multi-arch pipeline: `repository name (EC061/lab-controller) must be lowercase`.

`github.repository_owner` is mixed-case (`EC061`), but GHCR repository names must be lowercase. `metadata-action` lowercases its own tag outputs, so the old single-job workflow was fine — but the new pipeline's raw `outputs=name=...` (per-arch build) and `imagetools` refs (merge) used the mixed-case env directly and Docker rejected the push.

Lowercase the image into `IMAGE_LC` in both jobs and use it for the build `outputs` name, the manifest source digests, and the inspect.

Validated by dispatching `build-controller.yml` on this branch before merge (PRs don't trigger the build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)