### PR TITLE
perf(controller): drop recursive chown, add .dockerignore

### DIFF
--- a/controller/.dockerignore
+++ b/controller/.dockerignore
@@ -1,0 +1,13 @@
+# Keep the build context small and stop local artifacts from busting the build cache or leaking into
+# the image. node_modules is rebuilt in the deps stage; .next is rebuilt by `npm run build`.
+node_modules
+.next
+tests
+*.tsbuildinfo
+.git
+.gitignore
+Dockerfile
+.dockerignore
+# Secrets / local env — never ship these. The committed example is fine to keep out too.
+.env
+.env.*

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -22,16 +22,19 @@ WORKDIR /app
 ENV NODE_ENV=production
 # Non-root runtime user.
 RUN useradd --create-home --uid 10001 app
-COPY --from=build /app/node_modules ./node_modules
-COPY --from=build /app/.next ./.next
-COPY --from=build /app/public ./public
-COPY --from=build /app/package.json ./package.json
-COPY --from=build /app/next.config.js ./next.config.js
-COPY --from=build /app/tsconfig.json ./tsconfig.json
-COPY --from=build /app/server.ts ./server.ts
-COPY --from=build /app/src ./src
-# DB lives on a mounted volume.
-RUN mkdir -p /app/data && chown -R app:app /app
+# COPY --chown sets ownership inline during extraction. A separate `chown -R app:app /app` instead
+# rewrites every node_modules file into a fresh ~hundreds-of-MB layer (~90s on arm64) and bloats the
+# image — so set ownership at copy time and only chown the writable data dir afterwards.
+COPY --from=build --chown=app:app /app/node_modules ./node_modules
+COPY --from=build --chown=app:app /app/.next ./.next
+COPY --from=build --chown=app:app /app/public ./public
+COPY --from=build --chown=app:app /app/package.json ./package.json
+COPY --from=build --chown=app:app /app/next.config.js ./next.config.js
+COPY --from=build --chown=app:app /app/tsconfig.json ./tsconfig.json
+COPY --from=build --chown=app:app /app/server.ts ./server.ts
+COPY --from=build --chown=app:app /app/src ./src
+# DB lives on a mounted volume; only this dir is written at runtime.
+RUN mkdir -p /app/data && chown app:app /app /app/data
 USER app
 EXPOSE 8443
 # Invoke the tsx binary that's already in node_modules rather than `npx tsx`, which can reach out to


### PR DESCRIPTION
Speeds up the controller image build. From the arm64 build log, the slowest step (91.5s) was the runtime stage's `chown -R app:app /app`, which rewrites every `node_modules` file into a fresh duplicate layer (also bloating the image and slowing export/push).

- Set ownership inline with `COPY --chown=app:app` and only `chown` the writable `/app/data` dir → eliminates the ~90s step and the duplicate layer.
- Add `.dockerignore` (node_modules/.next/tests/*.tsbuildinfo/.env) → smaller context, stabler cache, leaner image.

Note: `npm ci` is only ~13s (prebuilt native binaries are used), so the Node base version is *not* the bottleneck — no version change needed.

Validated by dispatching `build-controller.yml` on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)