### PR TITLE
fix(controller): set AsyncLocalStorage global before next loads

### DIFF
--- a/controller/server.ts
+++ b/controller/server.ts
@@ -5,6 +5,8 @@
  * (dev: `tsx watch server.ts`; prod/Docker: `tsx server.ts`).
  */
 
+// Must stay first: sets globalThis.AsyncLocalStorage before any `next` module loads (see node-env.ts).
+import "./src/lib/node-env";
 import { createServer } from "node:http";
 import next from "next";
 import { attachHub } from "./src/lib/hub";

--- a/controller/src/lib/node-env.ts
+++ b/controller/src/lib/node-env.ts
@@ -1,0 +1,10 @@
+// Must be imported before "next". Next reads globalThis.AsyncLocalStorage at module-load time (in
+// work-async-storage-instance.js), but its own polyfill (node-environment-baseline) only runs later
+// inside app.prepare() — so a custom server that imports `next` first crashes. Mirror the baseline
+// here so the global is in place before any next module loads.
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const g = globalThis as Record<string, unknown>;
+if (typeof g.AsyncLocalStorage !== "function") {
+  g.AsyncLocalStorage = AsyncLocalStorage;
+}


### PR DESCRIPTION
The production container crashed at boot:

```
Error: Invariant: AsyncLocalStorage accessed in runtime where it is not available
  at .../next/dist/server/app-render/work-async-storage-instance.js:11
```

**Root cause (pre-existing, not from the build changes):** `import next from "next"` loads `next.js` (which only sets up the require-hook), **not** Next's `node-environment-baseline`, which is the file that sets `globalThis.AsyncLocalStorage`. The baseline only runs later inside `app.prepare()` — so `work-async-storage-instance.js` gets imported first and throws. A custom server run via `tsx` hits this in production mode.

**Fix:** add `src/lib/node-env.ts` (mirrors the baseline: sets `globalThis.AsyncLocalStorage` from `node:async_hooks`) and import it as the **first** statement in `server.ts`, before `next`. Node 22+ already provides a global `WebSocket`, so only `AsyncLocalStorage` needs the shim.

Verified locally: prod server (`NODE_ENV=production tsx server.ts`) boots and serves `HTTP 307 → /login`. `eslint`/`tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)