### PR TITLE
feat(controller): pin Server Action origin via CONTROLLER_DOMAIN env

### DIFF
--- a/controller/.env.example
+++ b/controller/.env.example
@@ -6,6 +6,12 @@ DB_PATH=./data/controller.db
 # HTTP + agent-WebSocket port.
 PORT=8443
 
+# Public domain the controller is served at (host only, no scheme), e.g. lab.cs.uga.edu.
+# Set this whenever a reverse proxy terminates TLS in front of the controller — without it Next.js
+# rejects Server Action POSTs whose Origin doesn't match the internal Host (CSRF protection).
+# Comma-separated for multiple hosts; a leading "*." wildcard label is allowed. Empty → same-origin only.
+CONTROLLER_DOMAIN=
+
 # These three secrets are REQUIRED in every environment (dev included) — there are no built-in
 # defaults. The app refuses to start without them. Generate real values, e.g.:
 #   openssl rand -hex 32

--- a/controller/next.config.js
+++ b/controller/next.config.js
@@ -1,8 +1,23 @@
 /** @type {import('next').NextConfig} */
+
+// Server Actions are CSRF-protected by comparing the request Origin to the Host. Behind a
+// TLS-terminating reverse proxy the internal Host (e.g. controller:8443) differs from the public
+// domain, so the check rejects every action unless the public domain is allow-listed here.
+// CONTROLLER_DOMAIN pins that domain (host only, no scheme) — set it in compose for any deployment
+// reached through a proxy or under a real hostname. Comma-separated to allow more than one; a leading
+// wildcard label is supported (e.g. "lab.cs.uga.edu" or "*.cs.uga.edu"). Unset → same-origin only.
+const allowedOrigins = (process.env.CONTROLLER_DOMAIN ?? "")
+  .split(",")
+  .map((d) => d.trim())
+  .filter(Boolean);
+
 const nextConfig = {
   reactStrictMode: true,
   // better-sqlite3 and honker-node are native modules — keep them external to the server bundle.
   serverExternalPackages: ["better-sqlite3", "@russellthehippo/honker-node"],
+  ...(allowedOrigins.length > 0 && {
+    experimental: { serverActions: { allowedOrigins } },
+  }),
 };
 
 export default nextConfig;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,10 @@ services:
       SIGNUP_TOKEN: ${SIGNUP_TOKEN:?set SIGNUP_TOKEN}
       AGENT_TOKEN: ${AGENT_TOKEN:?set AGENT_TOKEN}
       SESSION_SECRET: ${SESSION_SECRET:?set SESSION_SECRET}
+      # Public domain the controller is reached at (host only, no scheme), e.g. lab.cs.uga.edu.
+      # Required when a reverse proxy terminates TLS in front of the controller, otherwise Server
+      # Action requests fail their CSRF/origin check. Comma-separated for multiple; "" → same-origin.
+      CONTROLLER_DOMAIN: ${CONTROLLER_DOMAIN:-}
       NODE_ENV: production
     volumes:
       - controller-data:/app/data


### PR DESCRIPTION
## What

Adds a `CONTROLLER_DOMAIN` compose env that pins the controller's public domain into Next.js `experimental.serverActions.allowedOrigins`.

## Why

The controller's admin API is built on Next.js Server Actions, which are CSRF-protected by requiring the request `Origin` to match the `Host`. Behind a TLS-terminating reverse proxy the public domain (e.g. `lab.cs.uga.edu`) differs from the internal `Host` (`controller:8443`), so **every Server Action POST gets rejected** with no way to configure the allowed domain.

## Changes

- `controller/next.config.js` — parse `CONTROLLER_DOMAIN` (comma-separated, host only, `*.` wildcard label allowed) into `experimental.serverActions.allowedOrigins`. Unset → same-origin only (no change for direct `:8443` access).
- `docker-compose.yml` — pass `CONTROLLER_DOMAIN: ${CONTROLLER_DOMAIN:-}` through (optional, defaults empty).
- `controller/.env.example` — document the new var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)