### PR TITLE
feat(controller): theme switch, responsive tables, editable + cloneable labs

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,8 +215,21 @@ Env vars (controller bootstrap only — everything else is set in the UI):
 | `SESSION_SECRET` | signs admin session cookies |
 | `DB_PATH` | SQLite path (mount a volume here in Docker) |
 | `PORT` | HTTP + agent-WebSocket port (default 8443) |
+| `CONTROLLER_DOMAIN` | public domain the controller is served at (host only, e.g. `lab.cs.uga.edu`). Required when a reverse proxy terminates TLS in front of it — otherwise Next.js rejects Server Action POSTs whose `Origin` ≠ internal `Host` (CSRF check). Comma-separated for multiple; `*.` wildcard label allowed; unset → same-origin only |
 
 The published image is `ghcr.io/ec061/lab-controller` (built by CI on tags/main).
+
+> **Data dir permissions (bind mounts).** The container runs as a non-root user (uid **10001**).
+> The repo's compose uses a named volume (`controller-data`), which inherits that ownership
+> automatically. If you instead bind-mount a host directory onto `/app/data` (e.g. a 1Panel/Portainer
+> deploy mounting `./data`), that host dir is typically owned by `root` and the app can't write to it
+> — boot fails with `SqliteError: unable to open database file` (`SQLITE_CANTOPEN`). Fix by giving the
+> bind-mounted dir to uid 10001 once:
+>
+> ```bash
+> sudo chown 10001:10001 ./data        # the host path mounted at /app/data
+> docker compose restart controller
+> ```
 
 ### First login
 

--- a/controller/src/app/(app)/_components/NavLinks.tsx
+++ b/controller/src/app/(app)/_components/NavLinks.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+
+const NAV: [string, string][] = [
+  ["/dashboard", "Dashboard"],
+  ["/nodes", "Nodes"],
+  ["/labs", "Labs"],
+  ["/students", "Students"],
+  ["/gpu", "GPU"],
+  ["/logs", "Logs"],
+  ["/settings", "Settings"],
+];
+
+export function NavLinks() {
+  const pathname = usePathname();
+  return (
+    <nav>
+      {NAV.map(([href, label]) => {
+        const active = pathname === href || pathname.startsWith(`${href}/`);
+        return (
+          <a key={href} href={href} className={active ? "active" : undefined}>
+            {label}
+          </a>
+        );
+      })}
+    </nav>
+  );
+}

--- a/controller/src/app/(app)/_components/ThemeToggle.tsx
+++ b/controller/src/app/(app)/_components/ThemeToggle.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type Theme = "dark" | "light";
+
+export function ThemeToggle() {
+  // Start as null so the first client render matches the server (no theme-specific label),
+  // then sync to whatever the pre-paint inline script put on <html>.
+  const [theme, setTheme] = useState<Theme | null>(null);
+
+  useEffect(() => {
+    // One-time read of the theme the pre-paint inline script wrote to <html>; the server can't
+    // know it, so we sync after mount. This is the intended use of the escape hatch below.
+    const current = document.documentElement.getAttribute("data-theme");
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setTheme(current === "light" ? "light" : "dark");
+  }, []);
+
+  function toggle() {
+    const next: Theme = theme === "light" ? "dark" : "light";
+    setTheme(next);
+    document.documentElement.setAttribute("data-theme", next);
+    try {
+      localStorage.setItem("theme", next);
+    } catch {
+      /* private mode / storage disabled — theme just won't persist */
+    }
+  }
+
+  // Render a stable label until the effect resolves the real theme.
+  const label = theme === "light" ? "🌙  Dark mode" : "☀️  Light mode";
+  return (
+    <button type="button" className="theme-toggle" onClick={toggle} suppressHydrationWarning>
+      {theme === null ? "Theme" : label}
+    </button>
+  );
+}

--- a/controller/src/app/(app)/gpu/page.tsx
+++ b/controller/src/app/(app)/gpu/page.tsx
@@ -39,6 +39,7 @@ export default function GpuPage() {
         {snapshot.length === 0 ? (
           <p className="muted">No GPU processes reported.</p>
         ) : (
+          <div className="table-wrap">
           <table>
             <thead>
               <tr>
@@ -65,6 +66,7 @@ export default function GpuPage() {
               ))}
             </tbody>
           </table>
+          </div>
         )}
       </div>
 
@@ -73,6 +75,7 @@ export default function GpuPage() {
         {events.length === 0 ? (
           <p className="muted">No events yet.</p>
         ) : (
+          <div className="table-wrap">
           <table>
             <thead>
               <tr>
@@ -99,6 +102,7 @@ export default function GpuPage() {
               ))}
             </tbody>
           </table>
+          </div>
         )}
       </div>
     </>

--- a/controller/src/app/(app)/labs/[id]/page.tsx
+++ b/controller/src/app/(app)/labs/[id]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 import { db } from "@/lib/db";
 import { takeFlash } from "@/lib/flash";
 import { ago, fmtBytes, pct } from "@/lib/format";
-import { getLab } from "@/lib/labs";
+import { containerOptionsOf, getLab } from "@/lib/labs";
 import { listMembers } from "@/lib/students";
 import { TIB } from "@/lib/settings";
 import {
@@ -12,6 +12,7 @@ import {
   removeMemberAction,
   rescanAction,
   setQuotaAction,
+  updateLabSettingsAction,
 } from "../actions";
 
 export const dynamic = "force-dynamic";
@@ -60,15 +61,17 @@ export default async function LabDetail({
   searchParams,
 }: {
   params: Promise<{ id: string }>;
-  searchParams: Promise<{ newuser?: string; pwid?: string; emailed?: string }>;
+  searchParams: Promise<{ newuser?: string; pwid?: string; emailed?: string; saved?: string }>;
 }) {
   const { id } = await params;
-  const { newuser, pwid, emailed } = await searchParams;
+  const { newuser, pwid, emailed, saved } = await searchParams;
+  const savedMsg = saved ? takeFlash(saved) : null;
   // The cleartext password is fetched once from the server-side flash store, never the URL (M-07).
   const pw = pwid ? takeFlash(pwid) : null;
   const labId = Number(id);
   const lab = getLab(labId);
   if (!lab) notFound();
+  const opts = containerOptionsOf(lab);
   const members = listMembers(labId);
   const dockerUsed = dockerByStudent(labId);
 
@@ -94,6 +97,12 @@ export default async function LabDetail({
           {lab.online ? "online" : "offline"}
         </span>
       </h2>
+
+      {savedMsg && (
+        <div className="card" style={{ borderColor: "var(--accent)" }}>
+          <p style={{ margin: 0, color: "var(--accent)" }}>{savedMsg}</p>
+        </div>
+      )}
 
       <div className="card">
         <p style={{ margin: 0 }}>
@@ -137,6 +146,51 @@ export default async function LabDetail({
           <button type="submit" style={{ width: 140, marginTop: 0 }}>
             Apply
           </button>
+        </form>
+      </div>
+
+      <div className="card">
+        <h3 style={{ marginTop: 0 }}>Lab settings</h3>
+        <p className="muted" style={{ fontSize: 12, marginTop: 0 }}>
+          PI email is metadata. Changing the image or any container option recreates the container
+          (student data on the fast/slow pools is preserved). The node and SSH port can&apos;t change.
+        </p>
+        <form action={updateLabSettingsAction} style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12, maxWidth: 720 }}>
+          <input type="hidden" name="labId" value={lab.id} />
+          <div>
+            <label>PI email</label>
+            <input name="piEmail" type="email" defaultValue={lab.pi_email ?? ""} placeholder="pi@uga.edu" />
+          </div>
+          <div>
+            <label>Base image</label>
+            <input name="image" defaultValue={lab.image} />
+          </div>
+          <div></div>
+          <div>
+            <label>CPUs</label>
+            <input name="cpus" defaultValue={opts.cpus} />
+          </div>
+          <div>
+            <label>RAM</label>
+            <input name="memory" defaultValue={opts.memory} />
+          </div>
+          <div>
+            <label>Shared memory</label>
+            <input name="shmSize" defaultValue={opts.shm_size} />
+          </div>
+          <div>
+            <label>Image size quota</label>
+            <input name="imageQuota" defaultValue={opts.image_quota} />
+          </div>
+          <div>
+            <label>Restart policy</label>
+            <input name="restart" defaultValue={opts.restart} />
+          </div>
+          <div style={{ display: "flex", alignItems: "end" }}>
+            <button type="submit" style={{ width: 160, marginTop: 0 }}>
+              Save settings
+            </button>
+          </div>
         </form>
       </div>
 
@@ -203,7 +257,7 @@ export default async function LabDetail({
                       <label className="muted" style={{ margin: 0, display: "inline-flex", gap: 4, alignItems: "center" }}>
                         <input type="checkbox" name="deleteData" style={{ width: "auto" }} /> delete data
                       </label>
-                      <button type="submit" style={{ width: "auto", marginTop: 0, padding: "6px 10px", background: "var(--panel-2)" }}>
+                      <button type="submit" className="secondary" style={{ width: "auto", marginTop: 0, padding: "6px 10px" }}>
                         Remove
                       </button>
                     </form>
@@ -257,13 +311,13 @@ export default async function LabDetail({
       <div className="card" style={{ display: "flex", gap: 12 }}>
         <form action={recreateContainerAction}>
           <input type="hidden" name="labId" value={lab.id} />
-          <button type="submit" style={{ width: 200, marginTop: 0, background: "var(--panel-2)" }}>
+          <button type="submit" className="secondary" style={{ width: 200, marginTop: 0 }}>
             Recreate container
           </button>
         </form>
         <form action={destroyLabAction}>
           <input type="hidden" name="labId" value={lab.id} />
-          <button type="submit" style={{ width: 200, marginTop: 0, background: "var(--err)" }}>
+          <button type="submit" className="danger" style={{ width: 200, marginTop: 0 }}>
             Destroy lab + data
           </button>
         </form>

--- a/controller/src/app/(app)/labs/_components/CreateLabForm.tsx
+++ b/controller/src/app/(app)/labs/_components/CreateLabForm.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useState } from "react";
+
+export interface NodeOpt {
+  id: number;
+  name: string;
+  online: number;
+}
+
+export interface LabTemplate {
+  id: number;
+  name: string;
+  image: string;
+  fastTb: number;
+  slowTb: number;
+  cpus: string;
+  memory: string;
+  shmSize: string;
+  imageQuota: string;
+  restart: string;
+}
+
+interface Props {
+  nodes: NodeOpt[];
+  labs: LabTemplate[];
+  defaultFastTb: number;
+  defaultSlowTb: number;
+  action: (formData: FormData) => void | Promise<void>;
+}
+
+export function CreateLabForm({ nodes, labs, defaultFastTb, defaultSlowTb, action }: Props) {
+  const blank: Omit<LabTemplate, "id" | "name"> = {
+    image: "custom-ssh",
+    fastTb: defaultFastTb,
+    slowTb: defaultSlowTb,
+    cpus: "4",
+    memory: "8g",
+    shmSize: "1g",
+    imageQuota: "300g",
+    restart: "unless-stopped",
+  };
+  const [copyFrom, setCopyFrom] = useState<number>(0);
+  const [cfg, setCfg] = useState(blank);
+
+  function onCopyFromChange(id: number) {
+    setCopyFrom(id);
+    const src = labs.find((l) => l.id === id);
+    if (src) {
+      const { id: _id, name: _name, ...rest } = src;
+      void _id;
+      void _name;
+      setCfg(rest);
+    } else {
+      setCfg(blank);
+    }
+  }
+
+  const set = (patch: Partial<typeof cfg>) => setCfg((c) => ({ ...c, ...patch }));
+
+  return (
+    <form action={action} style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12 }}>
+      {labs.length > 0 && (
+        <div style={{ gridColumn: "1 / -1", display: "flex", gap: 16, alignItems: "end", flexWrap: "wrap" }}>
+          <div style={{ flex: 1, minWidth: 220 }}>
+            <label>Copy configuration from</label>
+            <select
+              name="copyFromLabId"
+              value={copyFrom}
+              onChange={(e) => onCopyFromChange(Number(e.target.value))}
+            >
+              <option value={0}>— start from defaults —</option>
+              {labs.map((l) => (
+                <option key={l.id} value={l.id}>
+                  {l.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <label
+            className="muted"
+            style={{ margin: 0, display: "inline-flex", gap: 6, alignItems: "center", opacity: copyFrom ? 1 : 0.5 }}
+          >
+            <input type="checkbox" name="copyStudents" disabled={!copyFrom} style={{ width: "auto" }} />
+            Also enroll the same students
+          </label>
+        </div>
+      )}
+
+      <div>
+        <label>Name</label>
+        <input name="name" required placeholder="bio-x" />
+      </div>
+      <div>
+        <label>Node</label>
+        <select name="nodeId" required defaultValue="">
+          <option value="" disabled>
+            Select node…
+          </option>
+          {nodes.map((n) => (
+            <option key={n.id} value={n.id}>
+              {n.name} {n.online ? "(online)" : "(offline)"}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label>PI email</label>
+        <input name="piEmail" type="email" placeholder="pi@uga.edu" />
+      </div>
+      <div>
+        <label>Base image</label>
+        <input name="image" value={cfg.image} onChange={(e) => set({ image: e.target.value })} />
+      </div>
+      <div>
+        <label>Fast quota (TB)</label>
+        <input
+          name="fastTb"
+          type="number"
+          step="0.5"
+          value={cfg.fastTb}
+          onChange={(e) => set({ fastTb: Number(e.target.value) })}
+        />
+      </div>
+      <div>
+        <label>Slow quota (TB)</label>
+        <input
+          name="slowTb"
+          type="number"
+          step="0.5"
+          value={cfg.slowTb}
+          onChange={(e) => set({ slowTb: Number(e.target.value) })}
+        />
+      </div>
+      <div style={{ gridColumn: "1 / -1", marginTop: 4 }}>
+        <span className="muted" style={{ fontSize: 12 }}>
+          Container options below are set at creation; changing them later (from the lab page)
+          recreates the container with data preserved. All GPUs are always attached.
+        </span>
+      </div>
+      <div>
+        <label>CPUs</label>
+        <input name="cpus" value={cfg.cpus} onChange={(e) => set({ cpus: e.target.value })} />
+      </div>
+      <div>
+        <label>RAM</label>
+        <input name="memory" value={cfg.memory} onChange={(e) => set({ memory: e.target.value })} />
+      </div>
+      <div>
+        <label>Shared memory</label>
+        <input name="shmSize" value={cfg.shmSize} onChange={(e) => set({ shmSize: e.target.value })} />
+      </div>
+      <div>
+        <label>Image size quota</label>
+        <input name="imageQuota" value={cfg.imageQuota} onChange={(e) => set({ imageQuota: e.target.value })} />
+      </div>
+      <div>
+        <label>Restart policy</label>
+        <input name="restart" value={cfg.restart} onChange={(e) => set({ restart: e.target.value })} />
+      </div>
+      <div style={{ gridColumn: "1 / -1" }}>
+        <button type="submit" style={{ width: 160 }}>
+          Create lab
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/controller/src/app/(app)/labs/actions.ts
+++ b/controller/src/app/(app)/labs/actions.ts
@@ -5,10 +5,10 @@ import { revalidatePath } from "next/cache";
 import { requireAdmin } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { putFlash } from "@/lib/flash";
-import { createLab, destroyLab, updateQuota } from "@/lib/labs";
+import { createLab, destroyLab, getLab, updateLabSettings, updateQuota } from "@/lib/labs";
 import { enqueueTask } from "@/lib/queue";
 import { getSettings, nextSshPort, TIB } from "@/lib/settings";
-import { addStudentToLab, removeStudentFromLab } from "@/lib/students";
+import { addStudentToLab, copyMembers, removeStudentFromLab } from "@/lib/students";
 
 // Enforcing auth gate: throws/redirects when the caller is not a live admin, and returns the
 // verified email used as the audit actor. Call as the first line of every action.
@@ -23,10 +23,16 @@ export async function createLabAction(formData: FormData) {
   const name = String(formData.get("name") ?? "").trim();
   const nodeId = Number(formData.get("nodeId"));
   const piEmail = String(formData.get("piEmail") ?? "").trim() || undefined;
-  const image = String(formData.get("image") ?? "").trim() || "custom-ssh";
+  if (!name || !nodeId) throw new Error("Name and node are required");
+
+  // Optionally seed configuration (image, quotas, container options) from an existing lab. The
+  // explicit form fields still win, so the source lab acts as a starting template, not a lock.
+  const copyFromLabId = Number(formData.get("copyFromLabId")) || 0;
+  const source = copyFromLabId ? getLab(copyFromLabId) : undefined;
+
+  const image = String(formData.get("image") ?? "").trim() || source?.image || "custom-ssh";
   const fastTb = Number(formData.get("fastTb"));
   const slowTb = Number(formData.get("slowTb"));
-  if (!name || !nodeId) throw new Error("Name and node are required");
 
   const containerOptions = {
     cpus: String(formData.get("cpus") ?? "4"),
@@ -36,7 +42,7 @@ export async function createLabAction(formData: FormData) {
     restart: String(formData.get("restart") ?? "unless-stopped"),
   };
 
-  createLab({
+  const lab = createLab({
     name,
     nodeId,
     piEmail,
@@ -47,7 +53,42 @@ export async function createLabAction(formData: FormData) {
     containerOptions,
     actor: who,
   });
+
+  // Optionally enroll the source lab's students into the new lab (fresh accounts + emailed creds).
+  if (source && formData.get("copyStudents") === "on") {
+    const res = await copyMembers(source.id, lab.id, who);
+    const msg = `Imported ${res.added} student${res.added === 1 ? "" : "s"} from ${source.name}` +
+      (res.emailed ? `; ${res.emailed} emailed credentials` : "") +
+      (res.skipped ? `; ${res.skipped} already members` : "");
+    const fid = putFlash(msg);
+    revalidatePath("/labs");
+    redirect(`/labs?imported=${fid}`);
+  }
+
   revalidatePath("/labs");
+}
+
+export async function updateLabSettingsAction(formData: FormData) {
+  const who = await actor();
+  const labId = Number(formData.get("labId"));
+  const piEmail = String(formData.get("piEmail") ?? "").trim();
+  const image = String(formData.get("image") ?? "").trim() || "custom-ssh";
+  const containerOptions = {
+    cpus: String(formData.get("cpus") ?? "4"),
+    memory: String(formData.get("memory") ?? "8g"),
+    shm_size: String(formData.get("shmSize") ?? "1g"),
+    image_quota: String(formData.get("imageQuota") ?? "300g"),
+    restart: String(formData.get("restart") ?? "unless-stopped"),
+  };
+  const recreated = updateLabSettings(labId, { piEmail, image, containerOptions }, who);
+  revalidatePath(`/labs/${labId}`);
+  revalidatePath("/labs");
+  const fid = putFlash(
+    recreated
+      ? "Settings saved — container is being recreated (data preserved)."
+      : "Settings saved.",
+  );
+  redirect(`/labs/${labId}?saved=${fid}`);
 }
 
 export async function setQuotaAction(formData: FormData) {

--- a/controller/src/app/(app)/labs/page.tsx
+++ b/controller/src/app/(app)/labs/page.tsx
@@ -1,16 +1,12 @@
 import { db } from "@/lib/db";
+import { takeFlash } from "@/lib/flash";
 import { fmtBytes, pct } from "@/lib/format";
-import { listLabs } from "@/lib/labs";
+import { containerOptionsOf, listLabs } from "@/lib/labs";
 import { getSettings, TIB } from "@/lib/settings";
 import { createLabAction } from "./actions";
+import { CreateLabForm, type LabTemplate, type NodeOpt } from "./_components/CreateLabForm";
 
 export const dynamic = "force-dynamic";
-
-interface NodeOpt {
-  id: number;
-  name: string;
-  online: number;
-}
 
 function latestUsage(labId: number, pool: string): { used: number; quota: number | null } | null {
   const row = db()
@@ -22,86 +18,55 @@ function latestUsage(labId: number, pool: string): { used: number; quota: number
   return row ? { used: row.used_bytes, quota: row.quota_bytes } : null;
 }
 
-export default function LabsPage() {
+export default async function LabsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ imported?: string }>;
+}) {
+  const { imported } = await searchParams;
+  const importedMsg = imported ? takeFlash(imported) : null;
   const labs = listLabs();
   const nodes = db().prepare("SELECT id, name, online FROM nodes ORDER BY name").all() as NodeOpt[];
   const settings = getSettings();
 
+  const templates: LabTemplate[] = labs.map((l) => {
+    const opts = containerOptionsOf(l);
+    return {
+      id: l.id,
+      name: l.name,
+      image: l.image,
+      fastTb: l.fast_quota_bytes / TIB,
+      slowTb: l.slow_quota_bytes / TIB,
+      cpus: opts.cpus,
+      memory: opts.memory,
+      shmSize: opts.shm_size,
+      imageQuota: opts.image_quota,
+      restart: opts.restart,
+    };
+  });
+
   return (
     <>
       <h2>Labs</h2>
+
+      {importedMsg && (
+        <div className="card" style={{ borderColor: "var(--accent)", marginBottom: 16 }}>
+          <p style={{ margin: 0, color: "var(--accent)" }}>{importedMsg}</p>
+        </div>
+      )}
 
       <div className="card">
         <h3 style={{ marginTop: 0 }}>Create lab</h3>
         {nodes.length === 0 ? (
           <p className="muted">Connect a node first — a lab is pinned to one node.</p>
         ) : (
-          <form action={createLabAction} style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12 }}>
-            <div>
-              <label>Name</label>
-              <input name="name" required placeholder="bio-x" />
-            </div>
-            <div>
-              <label>Node</label>
-              <select name="nodeId" required defaultValue="">
-                <option value="" disabled>
-                  Select node…
-                </option>
-                {nodes.map((n) => (
-                  <option key={n.id} value={n.id}>
-                    {n.name} {n.online ? "(online)" : "(offline)"}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <div>
-              <label>PI email</label>
-              <input name="piEmail" type="email" placeholder="pi@uga.edu" />
-            </div>
-            <div>
-              <label>Base image</label>
-              <input name="image" defaultValue="custom-ssh" />
-            </div>
-            <div>
-              <label>Fast quota (TB)</label>
-              <input name="fastTb" type="number" step="0.5" defaultValue={settings.fastQuotaDefaultBytes / TIB} />
-            </div>
-            <div>
-              <label>Slow quota (TB)</label>
-              <input name="slowTb" type="number" step="0.5" defaultValue={settings.slowQuotaDefaultBytes / TIB} />
-            </div>
-            <div style={{ gridColumn: "1 / -1", marginTop: 4 }}>
-              <span className="muted" style={{ fontSize: 12 }}>
-                Container options below are set once at creation; changing them later requires
-                &ldquo;recreate container&rdquo; (data is preserved). All GPUs are always attached.
-              </span>
-            </div>
-            <div>
-              <label>CPUs</label>
-              <input name="cpus" defaultValue="4" />
-            </div>
-            <div>
-              <label>RAM</label>
-              <input name="memory" defaultValue="8g" />
-            </div>
-            <div>
-              <label>Shared memory</label>
-              <input name="shmSize" defaultValue="1g" />
-            </div>
-            <div>
-              <label>Image size quota</label>
-              <input name="imageQuota" defaultValue="300g" />
-            </div>
-            <div>
-              <label>Restart policy</label>
-              <input name="restart" defaultValue="unless-stopped" />
-            </div>
-            <div style={{ gridColumn: "1 / -1" }}>
-              <button type="submit" style={{ width: 160 }}>
-                Create lab
-              </button>
-            </div>
-          </form>
+          <CreateLabForm
+            nodes={nodes}
+            labs={templates}
+            defaultFastTb={settings.fastQuotaDefaultBytes / TIB}
+            defaultSlowTb={settings.slowQuotaDefaultBytes / TIB}
+            action={createLabAction}
+          />
         )}
       </div>
 
@@ -109,6 +74,7 @@ export default function LabsPage() {
         {labs.length === 0 ? (
           <p className="muted">No labs yet.</p>
         ) : (
+          <div className="table-wrap">
           <table>
             <thead>
               <tr>
@@ -151,6 +117,7 @@ export default function LabsPage() {
               })}
             </tbody>
           </table>
+          </div>
         )}
       </div>
     </>

--- a/controller/src/app/(app)/layout.tsx
+++ b/controller/src/app/(app)/layout.tsx
@@ -1,6 +1,8 @@
 import { redirect } from "next/navigation";
 import type { ReactNode } from "react";
-import { clearSessionCookie, currentAdmin, logoutAllSessions } from "@/lib/auth";
+import { clearSessionCookie, currentAdmin } from "@/lib/auth";
+import { NavLinks } from "./_components/NavLinks";
+import { ThemeToggle } from "./_components/ThemeToggle";
 
 // Authed pages read cookies/DB per request — never statically prerender them.
 export const dynamic = "force-dynamic";
@@ -11,24 +13,6 @@ async function logout() {
   redirect("/login");
 }
 
-async function logoutEverywhere() {
-  "use server";
-  const admin = await currentAdmin();
-  if (admin) logoutAllSessions(Number(admin.sub));
-  await clearSessionCookie();
-  redirect("/login");
-}
-
-const NAV = [
-  ["/dashboard", "Dashboard"],
-  ["/nodes", "Nodes"],
-  ["/labs", "Labs"],
-  ["/students", "Students"],
-  ["/gpu", "GPU"],
-  ["/logs", "Logs"],
-  ["/settings", "Settings"],
-];
-
 export default async function AppLayout({ children }: { children: ReactNode }) {
   const admin = await currentAdmin();
   if (!admin) redirect("/login");
@@ -36,24 +20,18 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
     <div className="layout">
       <aside className="sidebar">
         <h1>Lab Manager</h1>
-        <nav>
-          {NAV.map(([href, label]) => (
-            <a key={href} href={href}>
-              {label}
-            </a>
-          ))}
-        </nav>
-        <form action={logout} style={{ marginTop: 24 }}>
-          <button type="submit" style={{ background: "var(--panel-2)" }}>
-            Sign out
-          </button>
-        </form>
-        <form action={logoutEverywhere} style={{ marginTop: 8 }}>
-          <button type="submit" style={{ background: "var(--panel-2)", fontSize: 12 }}>
-            Sign out everywhere
-          </button>
-        </form>
-        <p className="muted" style={{ marginTop: 16, fontSize: 12 }}>{admin.email}</p>
+        <NavLinks />
+        <div className="sidebar-footer">
+          <form action={logout}>
+            <button type="submit" className="secondary">
+              Sign out
+            </button>
+          </form>
+          <ThemeToggle />
+          <p className="muted" style={{ marginTop: 16, fontSize: 12, wordBreak: "break-all" }}>
+            {admin.email}
+          </p>
+        </div>
       </aside>
       <main className="content">{children}</main>
     </div>

--- a/controller/src/app/(app)/logs/page.tsx
+++ b/controller/src/app/(app)/logs/page.tsx
@@ -101,6 +101,7 @@ export default async function LogsPage({
         {logs.length === 0 ? (
           <p className="muted">No matching logs.</p>
         ) : (
+          <div className="table-wrap">
           <table>
             <thead>
               <tr>
@@ -135,6 +136,7 @@ export default async function LogsPage({
               ))}
             </tbody>
           </table>
+          </div>
         )}
       </div>
     </>

--- a/controller/src/app/(app)/nodes/page.tsx
+++ b/controller/src/app/(app)/nodes/page.tsx
@@ -123,6 +123,7 @@ export default async function NodesPage({
         {nodes.length === 0 ? (
           <p className="muted">No nodes have connected yet.</p>
         ) : (
+          <div className="table-wrap">
           <table>
             <thead>
               <tr>
@@ -175,12 +176,18 @@ export default async function NodesPage({
                     <td style={{ whiteSpace: "nowrap" }}>
                       <form action={rotateNodeTokenAction} style={{ display: "inline" }}>
                         <input type="hidden" name="name" value={n.name} />
-                        <button type="submit" style={{ background: "var(--panel-2)" }}>Rotate</button>
+                        <button type="submit" className="secondary" style={{ width: "auto", padding: "6px 12px" }}>
+                          Rotate
+                        </button>
                       </form>{" "}
                       {n.allowed === 1 && (
                         <form action={revokeNodeAction} style={{ display: "inline" }}>
                           <input type="hidden" name="name" value={n.name} />
-                          <button type="submit" style={{ background: "var(--panel-2)", color: "var(--warn)" }}>
+                          <button
+                            type="submit"
+                            className="secondary"
+                            style={{ width: "auto", padding: "6px 12px", color: "var(--warn)" }}
+                          >
                             Revoke
                           </button>
                         </form>
@@ -191,6 +198,7 @@ export default async function NodesPage({
               })}
             </tbody>
           </table>
+          </div>
         )}
       </div>
     </>

--- a/controller/src/app/(app)/settings/page.tsx
+++ b/controller/src/app/(app)/settings/page.tsx
@@ -123,7 +123,7 @@ export default async function SettingsPage({
             <label>Send test email to</label>
             <input name="to" type="email" placeholder="you@uga.edu" />
           </div>
-          <button type="submit" style={{ width: 140, marginTop: 0, background: "var(--panel-2)" }}>
+          <button type="submit" className="secondary" style={{ width: 140, marginTop: 0 }}>
             Send test
           </button>
         </form>
@@ -226,7 +226,7 @@ export default async function SettingsPage({
           </div>
         </form>
         <form action={scrubNowAction} style={{ marginTop: 12 }}>
-          <button type="submit" style={{ width: 140, marginTop: 0, background: "var(--panel-2)" }}>
+          <button type="submit" className="secondary" style={{ width: 140, marginTop: 0 }}>
             Scrub now
           </button>
         </form>
@@ -263,7 +263,7 @@ export default async function SettingsPage({
           </div>
         </form>
         <form action={backupNowAction} style={{ marginTop: 12 }}>
-          <button type="submit" style={{ width: 140, marginTop: 0, background: "var(--panel-2)" }}>
+          <button type="submit" className="secondary" style={{ width: 140, marginTop: 0 }}>
             Back up now
           </button>
         </form>
@@ -284,7 +284,7 @@ export default async function SettingsPage({
                     <td style={{ textAlign: "right" }}>
                       <form action={restoreAction}>
                         <input type="hidden" name="name" value={b} />
-                        <button type="submit" style={{ width: "auto", marginTop: 0, padding: "6px 10px", background: "var(--panel-2)" }}>
+                        <button type="submit" className="secondary" style={{ width: "auto", marginTop: 0, padding: "6px 10px" }}>
                           Stage restore
                         </button>
                       </form>

--- a/controller/src/app/(app)/students/page.tsx
+++ b/controller/src/app/(app)/students/page.tsx
@@ -83,6 +83,7 @@ export default async function StudentsPage({
         {students.length === 0 ? (
           <p className="muted">No students yet.</p>
         ) : (
+          <div className="table-wrap">
           <table>
             <thead>
               <tr>
@@ -103,6 +104,7 @@ export default async function StudentsPage({
               ))}
             </tbody>
           </table>
+          </div>
         )}
       </div>
     </>

--- a/controller/src/app/globals.css
+++ b/controller/src/app/globals.css
@@ -1,4 +1,7 @@
-:root {
+/* Dark is the default theme; it applies when no data-theme is set and when it is "dark".
+   An inline script in the root layout sets data-theme before paint to avoid a flash. */
+:root,
+:root[data-theme="dark"] {
   --bg: #0f1115;
   --panel: #1a1d24;
   --panel-2: #232732;
@@ -9,9 +12,27 @@
   --ok: #3fb950;
   --warn: #d29922;
   --err: #f85149;
+  --shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+}
+
+:root[data-theme="light"] {
+  --bg: #f4f5f7;
+  --panel: #ffffff;
+  --panel-2: #eceef1;
+  --border: #d7dbe0;
+  --text: #1c2128;
+  --muted: #5a6472;
+  --accent: #2f6fed;
+  --ok: #1a7f37;
+  --warn: #9a6700;
+  --err: #cf222e;
+  --shadow: 0 1px 3px rgba(27, 33, 40, 0.08);
 }
 
 * { box-sizing: border-box; }
+
+html { color-scheme: dark; }
+html[data-theme="light"] { color-scheme: light; }
 
 body {
   margin: 0;
@@ -27,23 +48,34 @@ a:hover { text-decoration: underline; }
 .sidebar {
   width: 220px; flex-shrink: 0; background: var(--panel);
   border-right: 1px solid var(--border); padding: 20px 12px;
+  display: flex; flex-direction: column;
+  position: sticky; top: 0; align-self: flex-start; height: 100vh;
 }
 .sidebar h1 { font-size: 15px; margin: 0 0 18px 8px; }
+.sidebar nav { display: flex; flex-direction: column; gap: 2px; }
 .sidebar nav a {
-  display: block; padding: 8px 10px; border-radius: 6px; color: var(--text); margin-bottom: 2px;
+  display: block; padding: 8px 10px; border-radius: 6px; color: var(--text);
 }
 .sidebar nav a:hover { background: var(--panel-2); text-decoration: none; }
-.content { flex: 1; padding: 28px 32px; max-width: 1100px; }
+.sidebar nav a.active {
+  background: var(--panel-2); color: var(--accent); font-weight: 600;
+  box-shadow: inset 2px 0 0 var(--accent);
+}
+.sidebar-footer { margin-top: auto; padding-top: 16px; }
+.content { flex: 1; min-width: 0; padding: 28px 32px; max-width: 1180px; }
 
 .card {
   background: var(--panel); border: 1px solid var(--border);
-  border-radius: 10px; padding: 18px 20px; margin-bottom: 18px;
+  border-radius: 10px; padding: 18px 20px; margin-bottom: 18px; box-shadow: var(--shadow);
 }
 h2 { font-size: 18px; margin: 0 0 14px; }
 
+/* Wide tables (e.g. Nodes) scroll horizontally inside their card instead of overflowing. */
+.table-wrap { overflow-x: auto; margin: 0 -4px; }
 table { width: 100%; border-collapse: collapse; }
 th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--border); }
-th { color: var(--muted); font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: .04em; }
+tbody tr:last-child td { border-bottom: 0; }
+th { color: var(--muted); font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: .04em; white-space: nowrap; }
 
 .badge { display: inline-block; padding: 2px 8px; border-radius: 99px; font-size: 12px; font-weight: 600; }
 .badge.online { background: rgba(63,185,80,.15); color: var(--ok); }
@@ -61,5 +93,21 @@ button {
   background: var(--accent); color: #fff; font-weight: 600; cursor: pointer; font-size: 14px;
 }
 button:hover { filter: brightness(1.08); }
+/* Secondary/danger buttons must set an explicit text color so they stay legible in light mode
+   (the base rule's white-on-accent would otherwise leave white text on a light panel). */
+button.secondary { background: var(--panel-2); color: var(--text); border: 1px solid var(--border); }
+button.danger { background: var(--err); color: #fff; }
+select {
+  width: 100%; padding: 9px 11px; border-radius: 7px; border: 1px solid var(--border);
+  background: var(--panel-2); color: var(--text); font-size: 14px;
+}
 .error { color: var(--err); margin-top: 12px; font-size: 13px; }
 .muted { color: var(--muted); }
+
+.theme-toggle {
+  margin-top: 8px; width: 100%; padding: 8px 10px; border-radius: 7px;
+  border: 1px solid var(--border); background: var(--panel-2); color: var(--text);
+  font-size: 13px; font-weight: 600; cursor: pointer;
+  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+}
+.theme-toggle:hover { filter: brightness(1.08); }

--- a/controller/src/app/layout.tsx
+++ b/controller/src/app/layout.tsx
@@ -7,9 +7,16 @@ export const metadata: Metadata = {
   description: "Multi-node ZFS lab manager",
 };
 
+// Set the theme on <html> before first paint so there's no dark/light flash on load.
+// Defaults to dark; honours a previously saved choice from localStorage.
+const THEME_INIT = `(function(){try{var t=localStorage.getItem('theme');document.documentElement.setAttribute('data-theme',t==='light'?'light':'dark');}catch(e){document.documentElement.setAttribute('data-theme','dark');}})();`;
+
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" data-theme="dark" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: THEME_INIT }} />
+      </head>
       <body>{children}</body>
     </html>
   );

--- a/controller/src/lib/labs.ts
+++ b/controller/src/lib/labs.ts
@@ -26,8 +26,38 @@ export interface Lab {
   slow_quota_bytes: number;
   image: string;
   ssh_port: number | null;
+  container_options: string | null;
   status: string;
   created_at: number;
+}
+
+export interface ContainerOptions {
+  cpus: string;
+  memory: string;
+  shm_size: string;
+  image_quota: string;
+  restart: string;
+}
+
+export const DEFAULT_CONTAINER_OPTIONS: ContainerOptions = {
+  cpus: "4",
+  memory: "8g",
+  shm_size: "1g",
+  image_quota: "300g",
+  restart: "unless-stopped",
+};
+
+/** Parse a lab's stored container_options JSON, filling any missing keys with defaults. */
+export function containerOptionsOf(lab: Pick<Lab, "container_options">): ContainerOptions {
+  let parsed: Partial<ContainerOptions> = {};
+  if (lab.container_options) {
+    try {
+      parsed = JSON.parse(lab.container_options) as Partial<ContainerOptions>;
+    } catch {
+      parsed = {};
+    }
+  }
+  return { ...DEFAULT_CONTAINER_OPTIONS, ...parsed };
 }
 
 export function listLabs(): Lab[] {
@@ -133,6 +163,61 @@ export function updateQuota(
   }
   enqueueTask(lab.node_name, "lab.set_quota", params, actor);
   audit(actor, "lab.set_quota", lab.name, JSON.stringify(params));
+}
+
+export interface UpdateLabSettingsInput {
+  piEmail?: string | null;
+  image?: string;
+  containerOptions?: Record<string, unknown>;
+}
+
+/**
+ * Edit a lab's configuration after creation. PI email is metadata only. Changing the image or any
+ * container option rewrites the stored config and recreates the container (data is preserved, same
+ * path as the manual "recreate container" action). Returns true if a recreate was enqueued.
+ */
+export function updateLabSettings(labId: number, input: UpdateLabSettingsInput, actor?: string): boolean {
+  const lab = getLab(labId);
+  if (!lab) throw new Error("Unknown lab");
+
+  if (input.piEmail !== undefined) {
+    db().prepare("UPDATE labs SET pi_email = ? WHERE id = ?").run(input.piEmail || null, labId);
+  }
+
+  const prevOpts = db().prepare("SELECT container_options FROM labs WHERE id = ?").get(labId) as
+    | { container_options: string | null }
+    | undefined;
+  const imageChanged = input.image !== undefined && input.image !== lab.image;
+  const optsChanged =
+    input.containerOptions !== undefined &&
+    JSON.stringify(input.containerOptions) !== (prevOpts?.container_options ?? "null");
+
+  if (input.image !== undefined) {
+    db().prepare("UPDATE labs SET image = ? WHERE id = ?").run(input.image, labId);
+  }
+  if (input.containerOptions !== undefined) {
+    db()
+      .prepare("UPDATE labs SET container_options = ? WHERE id = ?")
+      .run(JSON.stringify(input.containerOptions), labId);
+  }
+
+  audit(actor, "lab.update_settings", lab.name);
+
+  if (imageChanged || optsChanged) {
+    enqueueTask(
+      lab.node_name,
+      "container.recreate",
+      {
+        lab: lab.name,
+        image: input.image ?? lab.image,
+        ssh_port: lab.ssh_port,
+        container_options: input.containerOptions ?? (prevOpts?.container_options ? JSON.parse(prevOpts.container_options) : {}),
+      },
+      actor,
+    );
+    return true;
+  }
+  return false;
 }
 
 export function destroyLab(labId: number, actor?: string): void {

--- a/controller/src/lib/students.ts
+++ b/controller/src/lib/students.ts
@@ -114,6 +114,43 @@ export async function addStudentToLab(
   return { student: record, password, emailed };
 }
 
+export interface CopyMembersResult {
+  added: number;
+  emailed: number;
+  skipped: number; // already members of the destination lab
+}
+
+/**
+ * Enroll every student of `fromLabId` into `toLabId`. Each gets a fresh account/password on the
+ * destination node (same path as a manual add), so credentials are emailed where an address exists.
+ * Students already in the destination lab are skipped. Used by "create lab → import students".
+ */
+export async function copyMembers(
+  fromLabId: number,
+  toLabId: number,
+  actor?: string,
+): Promise<CopyMembersResult> {
+  const source = listMembers(fromLabId);
+  const result: CopyMembersResult = { added: 0, emailed: 0, skipped: 0 };
+  for (const m of source) {
+    const already = db()
+      .prepare("SELECT id FROM lab_members WHERE lab_id = ? AND student_id = ?")
+      .get(toLabId, m.id);
+    if (already) {
+      result.skipped += 1;
+      continue;
+    }
+    const res = await addStudentToLab(
+      toLabId,
+      { username: m.username, email: m.email ?? undefined, name: m.name ?? undefined, studentId: m.student_id ?? undefined },
+      actor,
+    );
+    result.added += 1;
+    if (res.emailed) result.emailed += 1;
+  }
+  return result;
+}
+
 export function removeStudentFromLab(
   labId: number,
   studentId: number,


### PR DESCRIPTION
## Summary
UI/UX overhaul of the controller admin app, addressing sidebar overflow, theming, and lab lifecycle gaps.

### Layout & theming
- **Light/dark theme**, dark by default. A pre-paint inline script sets `data-theme` from `localStorage` (no flash); a `ThemeToggle` client component in the sidebar persists the choice. New light palette + `color-scheme` hints.
- **Wide tables** (Nodes, Labs, GPU, Students, Logs) now scroll horizontally inside their card via `.table-wrap` instead of overflowing the page.
- **Sticky, full-height sidebar** with active-route highlighting (`NavLinks`). Removed the **Sign out everywhere** action.
- Theme-safe `button.secondary` / `button.danger` classes + `select` styling, replacing inline `panel-2` backgrounds that were invisible white-on-light in light mode.

### Edit a lab after creation
- New `updateLabSettings()` + **Lab settings** card on the lab detail page: change PI email, base image, and container options (CPUs/RAM/shm/image quota/restart).
- Image/option changes recreate the container with data preserved (same path as the existing recreate); PI email is metadata-only.

### Create a lab from another lab (import settings + students)
- `CreateLabForm` adds a **Copy configuration from** dropdown that live-fills image, quotas, and container options from an existing lab.
- Optional **Also enroll the same students** checkbox → `copyMembers()` re-provisions accounts on the new lab and emails credentials where an address exists, reporting an added/emailed/already-members summary.

## Testing
- `tsc --noEmit` clean
- `eslint src` clean
- `vitest run` → 130 passing
- `next build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)