### PR TITLE
feat(controller): infer SMTP implicit TLS from host scheme/port

### DIFF
--- a/controller/src/app/(app)/settings/actions.ts
+++ b/controller/src/app/(app)/settings/actions.ts
@@ -26,16 +26,49 @@ export async function saveStorageSettingsAction(formData: FormData) {
   revalidatePath("/settings");
 }
 
+// Implicit TLS is no longer a manual toggle: it's inferred from the SMTP host.
+// An https:// scheme (or port 465) means implicit TLS; http:// (or any other
+// port) means STARTTLS/none. The scheme and any embedded port are stripped so a
+// bare hostname is stored for nodemailer.
+function parseSmtpHost(
+  raw: string,
+  portField: number,
+): { host: string; port: number; secure: boolean } {
+  let input = raw.trim();
+  let scheme: "http" | "https" | null = null;
+  const m = input.match(/^(https?):\/\//i);
+  if (m) {
+    scheme = m[1].toLowerCase() as "http" | "https";
+    input = input.slice(m[0].length);
+  }
+  // Drop any trailing path/query.
+  input = input.split(/[/?#]/)[0];
+  // Pull an embedded port (host:port) out of the host string; it wins over the field.
+  let port = portField;
+  const colon = input.lastIndexOf(":");
+  if (colon !== -1) {
+    const p = Number(input.slice(colon + 1));
+    if (p > 0) port = p;
+    input = input.slice(0, colon);
+  }
+  const secure = scheme === "https" ? true : scheme === "http" ? false : port === 465;
+  return { host: input.trim(), port, secure };
+}
+
 export async function saveSmtpSettingsAction(formData: FormData) {
   await requireAdmin();
-  setSetting("smtpHost", String(formData.get("smtpHost") ?? "").trim());
-  setSetting("smtpPort", Number(formData.get("smtpPort")) || 587);
+  const { host, port, secure } = parseSmtpHost(
+    String(formData.get("smtpHost") ?? ""),
+    Number(formData.get("smtpPort")) || 587,
+  );
+  setSetting("smtpHost", host);
+  setSetting("smtpPort", port);
+  setSetting("smtpSecure", secure);
   setSetting("smtpUser", String(formData.get("smtpUser") ?? "").trim());
   const pass = String(formData.get("smtpPass") ?? "");
   // Only overwrite the stored password when a new one is entered (the field renders blank).
   if (pass) setSetting("smtpPass", pass);
   setSetting("smtpFrom", String(formData.get("smtpFrom") ?? "").trim());
-  setSetting("smtpSecure", formData.get("smtpSecure") === "on");
   setSetting("sshHostOverride", String(formData.get("sshHostOverride") ?? "").trim());
   revalidatePath("/settings");
 }

--- a/controller/src/app/(app)/settings/page.tsx
+++ b/controller/src/app/(app)/settings/page.tsx
@@ -86,7 +86,10 @@ export default async function SettingsPage({
         <form action={saveSmtpSettingsAction} style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 12, maxWidth: 520 }}>
           <div>
             <label>SMTP host</label>
-            <input name="smtpHost" defaultValue={s.smtpHost} placeholder="smtp.uga.edu" />
+            <input name="smtpHost" defaultValue={s.smtpHost} placeholder="https://smtp.uga.edu:465" />
+            <small style={{ color: "var(--muted)" }}>
+              Use https:// (or port 465) for implicit TLS; http:// for STARTTLS.
+            </small>
           </div>
           <div>
             <label>Port</label>
@@ -107,10 +110,6 @@ export default async function SettingsPage({
           <div>
             <label>SSH host override (optional)</label>
             <input name="sshHostOverride" defaultValue={s.sshHostOverride} placeholder="gpu.uga.edu" />
-          </div>
-          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <input type="checkbox" name="smtpSecure" defaultChecked={s.smtpSecure} style={{ width: "auto" }} />
-            <label style={{ margin: 0 }}>Implicit TLS (port 465)</label>
           </div>
           <div style={{ gridColumn: "1 / -1" }}>
             <button type="submit" style={{ width: 140 }}>


### PR DESCRIPTION
## Summary
- Remove the manual **Implicit TLS (port 465)** checkbox from the SMTP settings form.
- Derive `smtpSecure` at save time via a new `parseSmtpHost` helper:
  - `https://` scheme (or port `465`) → implicit TLS
  - `http://` scheme (or any other port) → STARTTLS/none
  - The scheme and any embedded `:port` are stripped, so a bare hostname is stored for nodemailer (an embedded port also overrides the Port field).
- Update the host field placeholder/help text to document the new convention.

No change to the SSH host override field (it controls the hostname written into student credential emails, not SMTP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)