### PR TITLE
fix(agent): overlay2 storage driver support; feat(controller): delete node

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ sudo zpool create -o ashift=12 slow /dev/sda
 # Datasets the agent uses (it creates per-lab children under these automatically).
 sudo zfs create fast/labs
 sudo zfs create slow/labs
-sudo zfs create fast/docker     # Docker's zfs storage driver lives here
+# (Docker's own storage is set up separately in step 1.3.)
 ```
 
 ### 1.2 Dataset properties
@@ -63,18 +63,49 @@ sudo zfs set xattr=sa fast slow
 sudo zfs set recordsize=1M slow
 ```
 
-### 1.3 Point Docker at the zfs storage driver
+### 1.3 Docker storage: overlay2 on an xfs zvol (recommended)
+
+Lab containers run under Sysbox, and **Sysbox cannot use Docker's `zfs` storage driver on a kernel
+without `shiftfs`** — e.g. stock Ubuntu kernels ≥ 6.8, which dropped shiftfs in favour of ID-mapped
+mounts. With the `zfs` driver a container's rootfs is a zfs dataset, and `sysbox-mgr` rejects it
+with `unknown fs` (its filesystem table has no entry for ZFS), so no lab container can start.
+
+Run Docker on the **`overlay2`** driver instead, backed by an **xfs filesystem on a ZFS zvol carved
+from the fast pool**. Docker's layers still live on the NVMe, Sysbox gets the overlayfs rootfs it
+supports natively, and `--storage-opt size=` (the per-lab writable-layer quota) still works because
+xfs supports project quotas.
 
 ```bash
+# A thin (sparse) zvol on the fast pool for Docker's data-root (grow later with `zfs set volsize`).
+sudo zfs create -s -V 1T fast/dockervol
+# xfs with ftype=1 (required by overlay2) + project quota (required by --storage-opt size).
+sudo mkfs.xfs -m crc=1 -L docker /dev/zvol/fast/dockervol
+sudo mkdir -p /fast/docker
+sudo mount -o prjquota /dev/zvol/fast/dockervol /fast/docker
+
+# Persist the mount, order it before docker, and make docker require it. nofail keeps boot alive if
+# the zvol is ever missing; RequiresMountsFor stops docker starting on the wrong (empty) directory.
+echo '/dev/zvol/fast/dockervol /fast/docker xfs prjquota,nofail,x-systemd.requires=zfs-volumes.target,x-systemd.before=docker.service 0 0' | sudo tee -a /etc/fstab
+sudo mkdir -p /etc/systemd/system/docker.service.d
+printf '[Unit]\nRequiresMountsFor=/fast/docker\n' | sudo tee /etc/systemd/system/docker.service.d/10-data-root-mount.conf
+sudo systemctl daemon-reload
+
 sudo tee /etc/docker/daemon.json >/dev/null <<'JSON'
 {
-  "storage-driver": "zfs",
+  "storage-driver": "overlay2",
   "data-root": "/fast/docker"
 }
 JSON
 sudo systemctl restart docker
-docker info | grep -i 'Storage Driver'   # should print: Storage Driver: zfs
+docker info | grep -iE 'Storage Driver|Backing Filesystem'   # overlay2 / xfs
 ```
+
+> **ZFS storage driver — only on kernels with a working `shiftfs`.** Some older Ubuntu HWE kernels
+> still ship shiftfs; there the native `zfs` driver works under Sysbox. Use `zfs create fast/docker`,
+> `sudo zfs set acltype=posixacl xattr=sa fast/docker`, and a `daemon.json` with
+> `"storage-driver": "zfs"` instead of the zvol above. `lab-agent doctor` accepts either driver
+> (for overlay2 it additionally checks the backing filesystem is xfs). On shiftfs-less kernels the
+> `zfs` driver fails to launch lab containers, so prefer overlay2.
 
 > **Migrating an existing Docker root.** Changing `data-root` (or the storage driver) does **not**
 > move existing data — Docker just starts empty at the new path, orphaning the old images/containers
@@ -82,18 +113,17 @@ docker info | grep -i 'Storage Driver'   # should print: Storage Driver: zfs
 >
 > ```bash
 > sudo systemctl stop docker docker.socket           # stop the engine and its socket
-> sudo rsync -aHAX --info=progress2 /var/lib/docker/ /fast/docker/   # copy data onto the ZFS dataset
+> sudo rsync -aHAX --info=progress2 /var/lib/docker/ /fast/docker/   # copy data onto the new root
 > # ...write /etc/docker/daemon.json as above, then:
 > sudo systemctl start docker
-> docker info | grep -iE 'Storage Driver|Docker Root Dir'   # zfs, /fast/docker
+> docker info | grep -iE 'Storage Driver|Docker Root Dir'   # overlay2, /fast/docker
 > docker images && docker ps -a                      # confirm images/containers survived
 > sudo mv /var/lib/docker /var/lib/docker.old         # remove only after you've verified
 > ```
 >
-> The old overlay2/devicemapper layers are **not** reusable under the `zfs` driver, so a clean node
-> (no prior Docker data) needs none of this — just write `daemon.json` and restart. If migrating is
-> not worth it, instead `docker save` the images you care about and `docker load` them after the
-> switch.
+> Layers are only reusable when the storage driver is unchanged (overlay2 → overlay2). When you also
+> switch drivers, the old layers are **not** reusable — on a clean node just write `daemon.json` and
+> restart; otherwise `docker save` the images you care about and `docker load` them after the switch.
 
 > Per-student scratch/cold datasets are bind-mounted into the lab container with `rshared`
 > propagation so they appear live. Make the ZFS mounts shared once per boot:
@@ -126,21 +156,30 @@ host.
 
 ```bash
 # Install Sysbox CE (see upstream for the current .deb); it registers the sysbox-runc runtime.
-docker info | grep -i runtimes   # should now list: nvidia runc sysbox-runc
+docker info | grep -i runtimes   # should now list: runc sysbox-runc (and nvidia on GPU nodes)
 ```
 
-Requirements: a recent Ubuntu LTS (22.04/24.04; shiftfs or kernel ≥ 5.19 idmapped mounts). Because
-the host uses the **`zfs` Docker storage driver**, set ACL props on the docker dataset so Sysbox's
-ID-shifting works (harmless on Sysbox ≥ 0.6.5, which no longer requires it):
+Requirements: a recent Ubuntu LTS (22.04/24.04; shiftfs or kernel ≥ 5.19 idmapped mounts).
 
-```bash
-sudo zfs set acltype=posixacl xattr=sa fast/docker
-```
+> **Pin Docker to a Sysbox-compatible version.** Sysbox CE 0.7.0 does **not** support containerd 2.x
+> / Docker ≥ 28 — lab containers fail to create with `namespace {"time" ""} does not exist`. Install
+> Docker from the **27.x** line on **containerd 1.7.x** and hold the packages so an `apt upgrade`
+> can't silently break the node:
+>
+> ```bash
+> sudo apt-get install -y --allow-downgrades \
+>     docker-ce=5:27.5.1-1~ubuntu.24.04~noble \
+>     docker-ce-cli=5:27.5.1-1~ubuntu.24.04~noble \
+>     containerd.io=1.7.29-1~ubuntu.24.04~noble
+> sudo apt-mark hold docker-ce docker-ce-cli containerd.io
+> ```
 
-> **Validate once before fleet rollout** (the GPU+ZFS pairing is community-validated, not
-> vendor-documented): `docker run --rm --runtime=sysbox-runc --device nvidia.com/gpu=all custom-ssh
-> nvidia-smi` should see the GPUs, and `--storage-opt size=20g` should still start and enforce the
-> writable-layer quota under sysbox-runc.
+> **Validate once before fleet rollout.** With the recommended overlay2 setup from step 1.3:
+> `docker run --rm --runtime=sysbox-runc --storage-opt size=20g custom-ssh` should start and enforce
+> the writable-layer quota, and on GPU nodes
+> `docker run --rm --runtime=sysbox-runc --device nvidia.com/gpu=all custom-ssh nvidia-smi` should
+> see the GPUs. (On a kernel using the `zfs` Docker driver, this is the step that fails with
+> `unknown fs` — see step 1.3.)
 
 ### 1.6 Install the agent
 
@@ -249,7 +288,9 @@ open **Settings** and configure:
 ## 3. Day-to-day use
 
 - **Nodes** — see which servers are online, their GPUs, pools, cold-storage backend (ZFS or SMB),
-  latest scrub status, and any host-prep issues.
+  latest scrub status, and any host-prep issues. Provision/rotate a per-node token, **revoke** a node
+  (its token stops working but its row and history stay), or **delete** it outright (removed only when
+  no labs are still pinned to it).
 - **Labs** — create a lab (pick its node, fast/slow quota, base image, and container options). Container
   options (CPU/RAM/shared-memory/image-size quota/restart) are **set once at creation**; changing them
   needs *Recreate container* (data is preserved). All GPUs are always attached. Quotas are editable

--- a/agent/src/lab_agent/system.py
+++ b/agent/src/lab_agent/system.py
@@ -42,8 +42,28 @@ def _is_mountpoint(path: str) -> bool:
     return os.path.ismount(path)
 
 
+# Docker storage drivers that work for lab containers under Sysbox:
+#   - "zfs":      container rootfs is a zfs dataset. Works under Sysbox ONLY on kernels that ship
+#                 shiftfs; on shiftfs-less kernels (e.g. stock Ubuntu kernels >= 6.8) sysbox-mgr
+#                 rejects the zfs rootfs with "unknown fs".
+#   - "overlay2": container rootfs is overlayfs, Sysbox's natively-supported path on any modern
+#                 kernel. Back the data-root with an xfs filesystem mounted with prjquota so the
+#                 per-lab writable-layer quota (docker --storage-opt size=) is still enforceable.
+DOCKER_DRIVERS_OK = ("zfs", "overlay2")
+
+
 def _docker_storage_driver() -> str:
     res = run(["docker", "info", "--format", "{{.Driver}}"], timeout=20)
+    return res.stdout.strip() if res.ok else ""
+
+
+def _docker_backing_fs() -> str:
+    """Filesystem under Docker's data-root (overlay2's 'Backing Filesystem'), e.g. 'xfs'."""
+    fmt = (
+        '{{range .DriverStatus}}{{if eq (index . 0) "Backing Filesystem"}}'
+        "{{index . 1}}{{end}}{{end}}"
+    )
+    res = run(["docker", "info", "--format", fmt], timeout=20)
     return res.stdout.strip() if res.ok else ""
 
 
@@ -86,8 +106,20 @@ def detect_capabilities(cfg: AgentConfig) -> Capabilities:
 
     driver = _docker_storage_driver() if docker_ok else ""
     docker_zfs = driver == "zfs"
-    if docker_ok and not docker_zfs:
-        issues.append(f"docker storage driver is '{driver}', expected 'zfs' (see host-prep docs)")
+    if docker_ok and driver not in DOCKER_DRIVERS_OK:
+        issues.append(
+            f"docker storage driver is '{driver}', expected one of "
+            f"{', '.join(DOCKER_DRIVERS_OK)} (see host-prep docs)"
+        )
+    # overlay2 only enforces --storage-opt size= on an xfs backing filesystem (mounted prjquota);
+    # without it, per-lab image-size quotas silently fail to apply.
+    if docker_ok and driver == "overlay2":
+        backing = _docker_backing_fs()
+        if backing != "xfs":
+            issues.append(
+                f"docker overlay2 backing filesystem is '{backing or 'unknown'}', expected 'xfs' "
+                "mounted with prjquota (needed for per-lab --storage-opt size quotas)"
+            )
 
     nv_runtime = _nvidia_runtime() if docker_ok else False
     gpus = _gpu_count()

--- a/agent/tests/test_system.py
+++ b/agent/tests/test_system.py
@@ -100,12 +100,12 @@ def test_missing_zfs_records_issue_and_skips_pool_checks(monkeypatch):
     assert "zfs command not found" in caps.issues
 
 
-def test_wrong_docker_storage_driver_is_flagged(monkeypatch):
+def test_unsupported_docker_storage_driver_is_flagged(monkeypatch):
     runner = FakeRunner({
         "zfs version": _ok(),
         "docker version": _ok(),
-        "docker info --format {{.Driver}}": _ok("overlay2"),
-        "docker info --format {{.Runtimes}}": _ok("runc"),
+        "docker info --format {{.Driver}}": _ok("vfs"),
+        "docker info --format {{.Runtimes}}": _ok("runc sysbox-runc"),
         "nvidia-smi -L": _fail(),
         "zpool list -H -o name fast": _ok("fast"),
         "zpool list -H -o name slow": _ok("slow"),
@@ -113,7 +113,44 @@ def test_wrong_docker_storage_driver_is_flagged(monkeypatch):
     monkeypatch.setattr(system, "run", runner)
     caps = system.detect_capabilities(_cfg())
     assert caps.docker_zfs_driver is False
-    assert any("storage driver is 'overlay2'" in i for i in caps.issues)
+    assert any("storage driver is 'vfs'" in i for i in caps.issues)
+
+
+def test_overlay2_on_xfs_is_supported(monkeypatch):
+    # overlay2 on an xfs backing fs is a supported driver (Sysbox's native path on shiftfs-less
+    # kernels); it must NOT be flagged, even though it is not the zfs driver.
+    runner = FakeRunner({
+        "zfs version": _ok(),
+        "docker version": _ok("27.5"),
+        "docker info --format {{.Driver}}": _ok("overlay2"),
+        "docker info --format {{range .DriverStatus}}": _ok("xfs"),
+        "docker info --format {{.Runtimes}}": _ok("runc sysbox-runc"),
+        "nvidia-smi -L": _fail(),
+        "zpool list -H -o name fast": _ok("fast"),
+        "zpool list -H -o name slow": _ok("slow"),
+    })
+    monkeypatch.setattr(system, "run", runner)
+    caps = system.detect_capabilities(_cfg())
+    assert caps.docker_zfs_driver is False
+    assert not any("storage driver" in i for i in caps.issues)
+    assert not any("backing filesystem" in i for i in caps.issues)
+
+
+def test_overlay2_non_xfs_backing_is_flagged(monkeypatch):
+    # overlay2 on a non-xfs backing fs can't enforce per-lab --storage-opt size quotas.
+    runner = FakeRunner({
+        "zfs version": _ok(),
+        "docker version": _ok("27.5"),
+        "docker info --format {{.Driver}}": _ok("overlay2"),
+        "docker info --format {{range .DriverStatus}}": _ok("extfs"),
+        "docker info --format {{.Runtimes}}": _ok("runc sysbox-runc"),
+        "nvidia-smi -L": _fail(),
+        "zpool list -H -o name fast": _ok("fast"),
+        "zpool list -H -o name slow": _ok("slow"),
+    })
+    monkeypatch.setattr(system, "run", runner)
+    caps = system.detect_capabilities(_cfg())
+    assert any("backing filesystem is 'extfs'" in i for i in caps.issues)
 
 
 def test_missing_fast_pool_is_flagged(monkeypatch):

--- a/controller/src/app/(app)/nodes/actions.ts
+++ b/controller/src/app/(app)/nodes/actions.ts
@@ -2,7 +2,7 @@
 
 import { redirect } from "next/navigation";
 import { requireAdmin } from "@/lib/auth";
-import { isValidNodeName, provisionNode, revokeNode, rotateNodeToken } from "@/lib/nodes";
+import { deleteNode, isValidNodeName, provisionNode, revokeNode, rotateNodeToken } from "@/lib/nodes";
 
 // The freshly issued token is shown once on the Nodes page so the admin can paste the printed
 // `lab-agent set-token` command onto the node. It is never stored in plaintext.
@@ -32,4 +32,19 @@ export async function revokeNodeAction(formData: FormData) {
   const name = String(formData.get("name") ?? "").trim().toLowerCase();
   revokeNode(name, admin.email);
   redirect("/nodes?revoked=" + encodeURIComponent(name));
+}
+
+export async function deleteNodeAction(formData: FormData) {
+  const admin = await requireAdmin();
+  const name = String(formData.get("name") ?? "").trim().toLowerCase();
+  // deleteNode throws if labs are still pinned to the node; surface that as an error banner.
+  // (redirect() throws NEXT_REDIRECT internally, so it must be called OUTSIDE the try/catch.)
+  let error: string | null = null;
+  try {
+    deleteNode(name, admin.email);
+  } catch (e) {
+    error = e instanceof Error ? e.message : "could not delete node";
+  }
+  if (error) redirect("/nodes?error=" + encodeURIComponent(error));
+  redirect("/nodes?deleted=" + encodeURIComponent(name));
 }

--- a/controller/src/app/(app)/nodes/page.tsx
+++ b/controller/src/app/(app)/nodes/page.tsx
@@ -1,5 +1,10 @@
 import { db } from "@/lib/db";
-import { provisionNodeAction, revokeNodeAction, rotateNodeTokenAction } from "./actions";
+import {
+  deleteNodeAction,
+  provisionNodeAction,
+  revokeNodeAction,
+  rotateNodeTokenAction,
+} from "./actions";
 
 export const dynamic = "force-dynamic";
 
@@ -77,6 +82,7 @@ export default async function NodesPage({
   const provisioned = typeof sp.provisioned === "string" ? sp.provisioned : undefined;
   const token = typeof sp.token === "string" ? sp.token : undefined;
   const error = typeof sp.error === "string" ? sp.error : undefined;
+  const deleted = typeof sp.deleted === "string" ? sp.deleted : undefined;
 
   const nodes = db()
     .prepare(
@@ -91,6 +97,12 @@ export default async function NodesPage({
       {error && (
         <div className="card" style={{ borderColor: "var(--warn)", marginBottom: 16 }}>
           <p style={{ color: "var(--warn)" }}>{error}</p>
+        </div>
+      )}
+
+      {deleted && (
+        <div className="card" style={{ marginBottom: 16 }}>
+          <p className="muted">Node “{deleted}” was deleted.</p>
         </div>
       )}
 
@@ -191,7 +203,17 @@ export default async function NodesPage({
                             Revoke
                           </button>
                         </form>
-                      )}
+                      )}{" "}
+                      <form action={deleteNodeAction} style={{ display: "inline" }}>
+                        <input type="hidden" name="name" value={n.name} />
+                        <button
+                          type="submit"
+                          className="secondary"
+                          style={{ width: "auto", padding: "6px 12px", color: "var(--warn)" }}
+                        >
+                          Delete
+                        </button>
+                      </form>
                     </td>
                   </tr>
                 );

--- a/controller/src/lib/nodes.ts
+++ b/controller/src/lib/nodes.ts
@@ -99,6 +99,32 @@ export function revokeNode(name: string, actor: string): void {
   audit(actor, "node.revoke", name);
 }
 
+/**
+ * Permanently delete a node from the DB. Refuses if any lab is still pinned to it (labs.node_id is
+ * a RESTRICT foreign key — its storage lives on that machine). Also clears the node's queued tasks
+ * and live GPU snapshot so a later same-named node starts clean; historical logs/events are kept.
+ */
+export function deleteNode(name: string, actor: string): void {
+  const row = db().prepare("SELECT id FROM nodes WHERE name = ?").get(name) as
+    | { id: number }
+    | undefined;
+  if (!row) throw new Error(`unknown node '${name}'`);
+  const { n: labCount } = db()
+    .prepare("SELECT COUNT(*) AS n FROM labs WHERE node_id = ?")
+    .get(row.id) as { n: number };
+  if (labCount > 0) {
+    throw new Error(
+      `node '${name}' still has ${labCount} lab(s); delete or move them before deleting the node`,
+    );
+  }
+  db().transaction(() => {
+    db().prepare("DELETE FROM task_log WHERE node = ?").run(name);
+    db().prepare("DELETE FROM gpu_snapshot WHERE node = ?").run(name);
+    db().prepare("DELETE FROM nodes WHERE id = ?").run(row.id);
+  })();
+  audit(actor, "node.delete", name);
+}
+
 function audit(actor: string, action: string, target: string): void {
   db()
     .prepare("INSERT INTO audit_log (ts, actor, action, target) VALUES (?, ?, ?, ?)")

--- a/controller/tests/nodes.test.ts
+++ b/controller/tests/nodes.test.ts
@@ -72,3 +72,36 @@ describe("verifyNodeAuth (C-04)", () => {
     expect(nodes.verifyNodeAuth("gpu-c", token).ok).toBe(false);
   });
 });
+
+describe("deleteNode", () => {
+  it("permanently removes the node row and its token stops working", () => {
+    const token = nodes.provisionNode("gpu-del", "admin@uga.edu");
+    expect(nodes.verifyNodeAuth("gpu-del", token).ok).toBe(true);
+    nodes.deleteNode("gpu-del", "admin@uga.edu");
+    const row = dbmod.db().prepare("SELECT 1 FROM nodes WHERE name = ?").get("gpu-del");
+    expect(row).toBeUndefined();
+    // Auth fails because the node is no longer on the allow-list at all.
+    expect(nodes.verifyNodeAuth("gpu-del", token).ok).toBe(false);
+  });
+
+  it("throws on an unknown node", () => {
+    expect(() => nodes.deleteNode("does-not-exist", "admin@uga.edu")).toThrow(/unknown node/);
+  });
+
+  it("refuses to delete a node that still has labs pinned to it", () => {
+    nodes.provisionNode("gpu-haslabs", "admin@uga.edu");
+    const id = (
+      dbmod.db().prepare("SELECT id FROM nodes WHERE name = ?").get("gpu-haslabs") as { id: number }
+    ).id;
+    dbmod
+      .db()
+      .prepare(
+        `INSERT INTO labs (name, node_id, fast_quota_bytes, slow_quota_bytes, image, created_at)
+         VALUES (?, ?, 0, 0, 'custom-ssh', ?)`,
+      )
+      .run("lab-x", id, Date.now());
+    expect(() => nodes.deleteNode("gpu-haslabs", "admin@uga.edu")).toThrow(/still has 1 lab/);
+    // The node row is left intact when deletion is refused.
+    expect(dbmod.db().prepare("SELECT 1 FROM nodes WHERE name = ?").get("gpu-haslabs")).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Why
Lab containers run under Sysbox, which **cannot use Docker's `zfs` storage driver on kernels without `shiftfs`** (e.g. stock Ubuntu ≥ 6.8, which dropped shiftfs for ID-mapped mounts). With the zfs driver a container's rootfs is a zfs dataset and `sysbox-mgr` rejects it with `unknown fs` (its fs table has no ZFS magic entry), so **no lab container can start**. This was validated on a fresh node and reproduces reliably.

A second, independent issue: sysbox-runc 0.7.0 can't parse containerd 2.x / Docker ≥ 28 specs (`namespace {"time" ""} does not exist`).

## What
- **agent**: `lab-agent doctor` now accepts `overlay2` in addition to `zfs`, and (for overlay2) checks the backing filesystem is `xfs` — required for per-lab image-size quotas via `--storage-opt size`. Adds `_docker_backing_fs()`; tests updated/added.
- **controller**: adds `deleteNode()` plus a **Delete** action/button on the Nodes page. Refuses while any lab is still pinned to the node (FK-safe), and clears the node's queued tasks + live GPU snapshot. Tests added.
- **README**: host-prep §1.3 rewritten around **overlay2 on an xfs zvol** carved from the fast pool (Docker layers stay on NVMe; `--storage-opt size` works via xfs project quota); the `zfs` driver is kept as the option for shiftfs kernels. §1.5 documents pinning Docker to a Sysbox-compatible version (27.x / containerd 1.7.x). Nodes section documents delete vs revoke.

## Validation
- agent: `ruff` clean, **196 tests pass**.
- controller: `tsc` + `eslint` clean, **133 tests pass**, `next build` succeeds.
- End-to-end on a real node: controller-created lab launches under `sysbox-runc` with a 100g overlay2 quota, nested Docker works, per-lab fast/slow ZFS datasets + quotas intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)