### PR TITLE
Lab-quota-only storage: fix sysbox chown + lab.destroy; student/lab delete UX

### DIFF
--- a/agent/src/lab_agent/coldstore.py
+++ b/agent/src/lab_agent/coldstore.py
@@ -48,25 +48,11 @@ def set_lab_quota(cfg: AgentConfig, lab: str, quota_bytes: int | None) -> str:
     return "slow quota set on the owner node (cold storage is SMB here)"
 
 
-def create_user(cfg: AgentConfig, lab: str, user: str, quota_bytes: int | None = None) -> None:
-    if cfg.slow_is_zfs:
-        zfs.create_dataset(paths.user_cold(cfg, lab, user), quota_bytes=quota_bytes)
-    else:
-        coldfs.ensure_dir(paths.cold_user(cfg, lab, user))
-
-
 def destroy_lab(cfg: AgentConfig, lab: str) -> None:
     if cfg.slow_is_zfs:
         zfs.destroy_dataset(paths.lab_slow(cfg, lab), recursive=True)
     else:
         coldfs.remove_tree(paths.cold_lab(cfg, lab), guard=cfg.cold_root)
-
-
-def destroy_user(cfg: AgentConfig, lab: str, user: str) -> None:
-    if cfg.slow_is_zfs:
-        zfs.destroy_dataset(paths.user_cold(cfg, lab, user), recursive=True)
-    else:
-        coldfs.remove_tree(paths.cold_user(cfg, lab, user), guard=cfg.cold_root)
 
 
 # --------------------------------------------------------------------------- mounts (for docker)
@@ -122,10 +108,20 @@ def shared_scan_dir(cfg: AgentConfig, lab: str) -> str | None:
 
 
 def user_scan_dir(cfg: AgentConfig, lab: str, user: str) -> str | None:
-    """Existing directory holding a student's cold data, or None (None on the SMB client)."""
+    """Existing directory holding a student's cold data, or None (None on the SMB client).
+
+    A student's cold storage is a plain subdir of the lab's single slow `users` dataset (no
+    per-student datasets), so resolve that dataset's mountpoint and join the username under it.
+    """
     if not cfg.slow_is_zfs:
         return None
-    return _zfs_scan_dir(paths.user_cold(cfg, lab, user))
+    import os
+
+    users_mp = _zfs_scan_dir(paths.lab_slow_users(cfg, lab))
+    if users_mp is None:
+        return None
+    d = os.path.join(users_mp, user)
+    return d if os.path.isdir(d) else None
 
 
 def _zfs_scan_dir(dataset: str) -> str | None:

--- a/agent/src/lab_agent/executors/users.py
+++ b/agent/src/lab_agent/executors/users.py
@@ -1,12 +1,14 @@
 """In-container student user management via `docker exec`.
 
 A student is a Linux user inside the lab container with:
-  /home/<u>/scratch       -> /labusers/fast/<u>   (fast, per-student dataset)
-  /home/<u>/cold-storage  -> /labusers/slow/<u>   (slow, per-student dataset)
+  /home/<u>/scratch       -> /labusers/fast/<u>   (fast tier, a subdir of the lab's users mount)
+  /home/<u>/cold-storage  -> /labusers/slow/<u>   (slow tier, a subdir of the lab's users mount)
 
-The host-side ZFS datasets are created by the caller (studentops) before this runs; here we only
-create the user, set the password, wire the symlinks, and set umask. The script is piped via stdin
-so the password never appears in the host process list.
+There are no per-student datasets: /labusers/{fast,slow} are the lab's single users datasets,
+already UID-shifted by Sysbox, so we create each student's scratch/cold-storage as a plain subdir
+here and the chown to the student succeeds without host-side setup. We create the user, make the
+subdirs + symlinks, set the password, and set umask. The script is piped via stdin so the password
+never appears in the host process list.
 """
 
 from __future__ import annotations
@@ -71,7 +73,15 @@ def set_password(container: str, username: str, password: str) -> CommandResult:
 
 def remove_user(container: str, username: str, *, delete_home: bool = False) -> CommandResult:
     validate_username(username)
-    flag = "-r " if delete_home else ""
-    # `|| true` so removing an already-absent user is not an error.
-    script = f"userdel {flag}{username} 2>/dev/null || true\n"
+    # `|| true` so removing an already-absent user is not an error. When delete_home is set we also
+    # wipe the student's scratch/cold-storage subdirs under /labusers (there are no per-student
+    # datasets to destroy on the host — the data lives in these in-container subdirs). The username
+    # is USERNAME_RE-validated above, so it is safe to interpolate directly.
+    if delete_home:
+        script = (
+            f"userdel -r {username} 2>/dev/null || true\n"
+            f"rm -rf /labusers/fast/{username} /labusers/slow/{username}\n"
+        )
+    else:
+        script = f"userdel {username} 2>/dev/null || true\n"
     return _run_script(container, script)

--- a/agent/src/lab_agent/labops.py
+++ b/agent/src/lab_agent/labops.py
@@ -71,6 +71,13 @@ def set_lab_quota(cfg: AgentConfig, params: dict[str, Any]) -> tuple[Any, str]:
 
 def destroy_lab(cfg: AgentConfig, params: dict[str, Any]) -> tuple[Any, str]:
     lab = params["lab"]
+    # Remove the container FIRST. Its bind mounts of the lab's shared/users datasets keep those
+    # datasets busy, so `zfs destroy -r` fails ("dataset is busy") while the container exists. The
+    # container's data lives in the datasets (not its writable layer), so removing it loses nothing
+    # the teardown isn't already destroying.
+    from .executors import docker
+
+    docker.remove_container(docker.container_name(lab))
     zfs.destroy_dataset(lab_fast(cfg, lab), recursive=True)
     coldstore.destroy_lab(cfg, lab)
-    return {"lab": lab, "destroyed": True}, f"destroyed datasets for lab '{lab}'"
+    return {"lab": lab, "destroyed": True}, f"destroyed container + datasets for lab '{lab}'"

--- a/agent/src/lab_agent/paths.py
+++ b/agent/src/lab_agent/paths.py
@@ -1,13 +1,19 @@
-"""ZFS dataset naming for labs and students.
+"""ZFS dataset / path naming for labs and students.
 
-Layout (per node), rooted on the configured pools:
+Datasets (per node), rooted on the configured pools — one fast + one slow per lab, each with a
+`shared` and a `users` child. There are **no per-student datasets**: every student is a plain subdir
+of the lab's single `users` dataset, so the whole lab (shared + all students) is bounded by the one
+lab quota and per-student subdirs need no host-side setup.
 
     <fast>/labs/<lab>            (quota = lab fast quota)
-    <fast>/labs/<lab>/shared     -> mounted /labdata/fast
-    <fast>/labs/<lab>/users/<u>  -> mounted /home/<u>/scratch
+    <fast>/labs/<lab>/shared       -> mounted /labdata/fast
+    <fast>/labs/<lab>/users        -> mounted /labusers/fast   (each student: a /<u> subdir here)
     <slow>/labs/<lab>            (quota = lab slow quota)
-    <slow>/labs/<lab>/shared     -> mounted /labdata/slow
-    <slow>/labs/<lab>/users/<u>  -> mounted /home/<u>/cold-storage
+    <slow>/labs/<lab>/shared       -> mounted /labdata/slow
+    <slow>/labs/<lab>/users        -> mounted /labusers/slow   (each student: a /<u> subdir here)
+
+``user_scratch``/``user_cold`` return the filesystem path of a student's subdir under those `users`
+datasets (``<...>/users/<u>``) — a directory, not a dataset of its own.
 """
 
 from __future__ import annotations

--- a/agent/src/lab_agent/scan.py
+++ b/agent/src/lab_agent/scan.py
@@ -19,7 +19,7 @@ from typing import Any
 from . import coldstore
 from .config import AgentConfig
 from .executors import zfs
-from .paths import lab_fast_shared, user_scratch
+from .paths import lab_fast_shared, lab_fast_users
 
 
 @dataclass
@@ -66,6 +66,15 @@ def _zfs_dir(dataset: str) -> str | None:
     return mp
 
 
+def _user_subdir(parent_mp: str | None, user: str) -> str | None:
+    """A student's directory is a plain subdir of the lab's `users` dataset mountpoint (there are no
+    per-student datasets). Returns the subdir if it exists, else None."""
+    if parent_mp is None:
+        return None
+    d = os.path.join(parent_mp, user)
+    return d if os.path.isdir(d) else None
+
+
 def scan_lab(cfg: AgentConfig, params: dict[str, Any]) -> tuple[Any, str]:
     """Dispatcher handler for oldfiles.scan.
 
@@ -76,14 +85,16 @@ def scan_lab(cfg: AgentConfig, params: dict[str, Any]) -> tuple[Any, str]:
     users = params.get("users", [])
     threshold = float(params.get("threshold_days", 30))
 
-    # Each target resolves to a directory to walk. Fast datasets are always ZFS; cold-storage
-    # targets go through coldstore (a ZFS mountpoint, or an SMB directory).
+    # Each target resolves to a directory to walk. Shared data is its own ZFS dataset (or SMB dir);
+    # per-student data is a subdir of the lab's single fast/slow `users` dataset (no per-student
+    # datasets), so resolve the users mountpoint once and join each username under it.
     targets: list[tuple[str, str | None, str | None]] = [
         ("lab_fast_shared", None, _zfs_dir(lab_fast_shared(cfg, lab))),
         ("lab_slow_shared", None, coldstore.shared_scan_dir(cfg, lab)),
     ]
+    fast_users_mp = _zfs_dir(lab_fast_users(cfg, lab))
     for u in users:
-        targets.append(("user_scratch", u, _zfs_dir(user_scratch(cfg, lab, u))))
+        targets.append(("user_scratch", u, _user_subdir(fast_users_mp, u)))
         targets.append(("user_cold", u, coldstore.user_scan_dir(cfg, lab, u)))
 
     results = []

--- a/agent/src/lab_agent/studentops.py
+++ b/agent/src/lab_agent/studentops.py
@@ -1,31 +1,30 @@
 """Student handlers: add/remove a student in a lab's shared container.
 
-Adding a student creates their per-student ZFS datasets (scratch on fast, cold-storage on slow),
-applies any optional sub-quota, then creates the Linux user + symlinks inside the container.
+Storage model: there are no per-student ZFS datasets. A lab has a single fast `users` dataset and a
+single slow `users` dataset (each bind-mounted into the container), both covered by the lab's fast/
+slow quota. A student is just a plain subdir under those mounts, created *inside* the container
+by ``users.add_user``. Because the parent ``users`` mounts are already UID-shifted by Sysbox, the
+in-container ``mkdir``/``chown`` work without privilege; nothing is created on the host here.
+There is intentionally no per-student quota — usage is bounded by the lab quota alone.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-from . import coldstore
 from .config import AgentConfig
-from .executors import docker, users, zfs
-from .paths import user_scratch
+from .executors import docker, users
 
 
 def add_student(cfg: AgentConfig, params: dict[str, Any]) -> tuple[Any, str]:
     lab = params["lab"]
     username = params["username"]
     password = params["password"]
-    scratch_quota = params.get("scratch_quota_bytes")
-    cold_quota = params.get("cold_quota_bytes")
 
-    # Per-student datasets appear under the container's bind-mounted users parents. Scratch is
-    # always ZFS; cold storage goes through coldstore (ZFS or SMB).
-    zfs.create_dataset(user_scratch(cfg, lab, username), quota_bytes=scratch_quota)
-    coldstore.create_user(cfg, lab, username, cold_quota)
-
+    # No host-side dataset creation: add_user makes the student's scratch/cold-storage subdirs under
+    # the already-shifted /labusers mounts inside the container, so the chown succeeds. (The old
+    # per-student ZFS datasets appeared inside the userns as an unmapped UID and could not be
+    # chowned by container-root — the "Operation not permitted" failure this replaces.)
     users.add_user(docker.container_name(lab), username, password)
     return {"lab": lab, "username": username}, f"added student '{username}' to lab '{lab}'"
 
@@ -35,9 +34,8 @@ def remove_student(cfg: AgentConfig, params: dict[str, Any]) -> tuple[Any, str]:
     username = params["username"]
     delete_data = bool(params.get("delete_data", False))
 
+    # When delete_data is set, remove_user also wipes the student's /labusers/{fast,slow} subdirs
+    # inside the container. There are no per-student datasets to destroy on the host.
     users.remove_user(docker.container_name(lab), username, delete_home=delete_data)
-    if delete_data:
-        zfs.destroy_dataset(user_scratch(cfg, lab, username), recursive=True)
-        coldstore.destroy_user(cfg, lab, username)
     msg = f"removed student '{username}' from lab '{lab}'"
     return {"lab": lab, "username": username, "data_deleted": delete_data}, msg

--- a/agent/src/lab_agent/usagereport.py
+++ b/agent/src/lab_agent/usagereport.py
@@ -164,15 +164,18 @@ def build_snapshot(
 ) -> dict[str, Any]:
     """Pure builder: assemble the JSON snapshot for one lab from live ZFS + cached docker usage."""
     now = now if now is not None else now_ms()
-    usernames = sorted(lab_usage.users.keys())
+    # With no per-student ZFS datasets, scratch/cold no longer have cheap per-student metadata (the
+    # lab quota covers everyone), so a student may appear only in the docker-layer measurement.
+    # Union both sources so every known student is still listed, with whatever numbers exist.
+    usernames = sorted(set(lab_usage.users.keys()) | set(docker_usage.per_user.keys()))
     students = []
     for name in usernames:
-        tiers = lab_usage.users[name]
+        tiers = lab_usage.users.get(name, {})
         students.append(
             {
                 "username": name,
-                "scratch": _usage_pair(tiers.get("fast")),
-                "cold": _usage_pair(tiers.get("slow")),  # None under the SMB cold backend
+                "scratch": _usage_pair(tiers.get("fast")),  # None: no per-student dataset
+                "cold": _usage_pair(tiers.get("slow")),  # None: no per-student dataset/SMB
                 "docker_home_used": docker_usage.per_user.get(name),
             }
         )

--- a/agent/tests/test_coldstore.py
+++ b/agent/tests/test_coldstore.py
@@ -53,13 +53,6 @@ def test_smb_set_quota_is_noop():
     assert "owner" in note.lower() or "smb" in note.lower()
 
 
-def test_smb_create_user_makes_directory(monkeypatch):
-    dirs = []
-    monkeypatch.setattr(coldstore.coldfs, "ensure_dir", lambda p: dirs.append(p))
-    coldstore.create_user(_smb_cfg(), "bio", "alice", 100)
-    assert "/mnt/cold/labs/bio/users/alice" in dirs
-
-
 def test_smb_destroy_lab_guards_root(monkeypatch):
     calls = []
     monkeypatch.setattr(coldstore.coldfs, "remove_tree", lambda p, *, guard: calls.append((p, guard)))

--- a/agent/tests/test_labops.py
+++ b/agent/tests/test_labops.py
@@ -59,6 +59,24 @@ def test_set_lab_quota_live(monkeypatch):
 
 def test_destroy_lab_removes_both_roots(monkeypatch):
     _created, _quotas, destroyed = _patch_zfs(monkeypatch)
+    from lab_agent.executors import docker
+
+    monkeypatch.setattr(docker, "remove_container", lambda name: None)
     labops.destroy_lab(_cfg(), {"lab": "bio"})
     assert "fast/labs/bio" in destroyed
     assert "slow/labs/bio" in destroyed
+
+
+def test_destroy_lab_removes_container_before_datasets(monkeypatch):
+    # The container must be removed first; otherwise its bind mounts keep the datasets busy and
+    # `zfs destroy -r` fails ("dataset is busy"). Assert remove_container runs before destroy.
+    _created, _quotas, _destroyed = _patch_zfs(monkeypatch)
+    from lab_agent.executors import docker
+
+    order: list[str] = []
+    monkeypatch.setattr(docker, "remove_container", lambda name: order.append(f"rm:{name}"))
+    monkeypatch.setattr(labops.zfs, "destroy_dataset",
+                        lambda name, *, recursive=True: order.append(f"destroy:{name}"))
+    labops.destroy_lab(_cfg(), {"lab": "bio"})
+    assert order[0] == "rm:lab-bio"
+    assert any(o.startswith("destroy:") for o in order[1:])

--- a/agent/tests/test_scan.py
+++ b/agent/tests/test_scan.py
@@ -45,19 +45,21 @@ def test_scan_lab_resolves_mountpoints(tmp_path: Path, monkeypatch):
 
     cfg = AgentConfig(controller_url="ws://x", token="t", fast_pool="fast", slow_pool="slow")
 
-    # Make one user's scratch dataset "exist" and point at a real dir with an old file.
-    scratch_dir = tmp_path / "scratch"
-    scratch_dir.mkdir()
-    f = scratch_dir / "old.bin"
+    # The fast `users` dataset holds every student as a plain subdir (no per-student datasets), so
+    # the scan resolves the users mountpoint and walks <users_mp>/<username>.
+    users_mp = tmp_path / "users"
+    alice_dir = users_mp / "alice"
+    alice_dir.mkdir(parents=True)
+    f = alice_dir / "old.bin"
     f.write_bytes(b"x" * 200)
     old = time.time() - 90 * 86400
     os.utime(f, (old, old))
 
     def dataset_exists(ds):
-        return ds == "fast/labs/bio/users/alice"
+        return ds == "fast/labs/bio/users"
 
     def get_mountpoint(ds):
-        return str(scratch_dir)
+        return str(users_mp)
 
     monkeypatch.setattr(scan.zfs, "dataset_exists", dataset_exists)
     monkeypatch.setattr(scan.zfs, "get_mountpoint", get_mountpoint)

--- a/agent/tests/test_studentops.py
+++ b/agent/tests/test_studentops.py
@@ -7,53 +7,43 @@ def _cfg():
 
 
 def _patch(monkeypatch):
-    created, destroyed, user_calls = [], [], []
-    monkeypatch.setattr(
-        studentops.zfs, "create_dataset",
-        lambda name, *, quota_bytes=None, create_parents=True: created.append((name, quota_bytes)),
-    )
-    monkeypatch.setattr(
-        studentops.zfs, "destroy_dataset",
-        lambda name, *, recursive=True: destroyed.append(name),
-    )
-    monkeypatch.setattr(
-        studentops.users, "add_user",
-        lambda c, u, p: user_calls.append(("add", c, u, p)),
-    )
-    monkeypatch.setattr(
-        studentops.users, "remove_user",
-        lambda c, u, *, delete_home=False: user_calls.append(("remove", c, u, delete_home)),
-    )
-    return created, destroyed, user_calls
+    """Capture user add/remove calls. The new storage model has no per-student datasets, so
+    studentops only drives the in-container user executor."""
+    user_calls = []
+    monkeypatch.setattr(studentops.users, "add_user",
+                        lambda c, u, p: user_calls.append(("add", c, u, p)))
+    monkeypatch.setattr(studentops.users, "remove_user",
+                        lambda c, u, *, delete_home=False: user_calls.append(("remove", c, u, delete_home)))
+    return user_calls
 
 
-def test_add_student_creates_datasets_and_user(monkeypatch):
-    created, _destroyed, calls = _patch(monkeypatch)
+def test_add_student_only_creates_the_user(monkeypatch):
+    calls = _patch(monkeypatch)
     studentops.add_student(_cfg(), {"lab": "bio", "username": "alice", "password": "pw"})
-    names = [n for n, _ in created]
-    assert "fast/labs/bio/users/alice" in names
-    assert "slow/labs/bio/users/alice" in names
     assert ("add", "lab-bio", "alice", "pw") in calls
 
 
-def test_add_student_applies_sub_quota(monkeypatch):
-    created, _d, _c = _patch(monkeypatch)
-    studentops.add_student(
-        _cfg(), {"lab": "bio", "username": "alice", "password": "pw", "scratch_quota_bytes": 100}
+def test_add_student_ignores_legacy_quota_params(monkeypatch):
+    # scratch_quota_bytes / cold_quota_bytes are no longer honored (lab quota only); passing them is
+    # a no-op beyond creating the user.
+    calls = _patch(monkeypatch)
+    result, _msg = studentops.add_student(
+        _cfg(),
+        {"lab": "bio", "username": "alice", "password": "pw", "scratch_quota_bytes": 100},
     )
-    assert ("fast/labs/bio/users/alice", 100) in created
+    assert result == {"lab": "bio", "username": "alice"}
+    assert ("add", "lab-bio", "alice", "pw") in calls
 
 
 def test_remove_student_keeps_data_by_default(monkeypatch):
-    _c, destroyed, calls = _patch(monkeypatch)
+    calls = _patch(monkeypatch)
     studentops.remove_student(_cfg(), {"lab": "bio", "username": "alice"})
     assert ("remove", "lab-bio", "alice", False) in calls
-    assert destroyed == []
 
 
 def test_remove_student_deletes_data_when_requested(monkeypatch):
-    _c, destroyed, calls = _patch(monkeypatch)
+    # delete_data is forwarded to remove_user as delete_home; the in-container script wipes the
+    # /labusers subdirs (no host-side dataset destroy).
+    calls = _patch(monkeypatch)
     studentops.remove_student(_cfg(), {"lab": "bio", "username": "alice", "delete_data": True})
     assert ("remove", "lab-bio", "alice", True) in calls
-    assert "fast/labs/bio/users/alice" in destroyed
-    assert "slow/labs/bio/users/alice" in destroyed

--- a/agent/tests/test_users.py
+++ b/agent/tests/test_users.py
@@ -60,7 +60,15 @@ def test_remove_user_default_keeps_home(cap):
 
 def test_remove_user_delete_home(cap):
     users.remove_user("lab-bio", "alice", delete_home=True)
-    assert "userdel -r alice" in cap.calls[0]["input"]
+    script = cap.calls[0]["input"]
+    assert "userdel -r alice" in script
+    # Data lives in /labusers subdirs (no per-student datasets), so delete_home wipes them too.
+    assert "rm -rf /labusers/fast/alice /labusers/slow/alice" in script
+
+
+def test_remove_user_default_does_not_touch_labusers(cap):
+    users.remove_user("lab-bio", "alice")
+    assert "/labusers/" not in cap.calls[0]["input"]
 
 
 def test_exec_failure_raises(monkeypatch):

--- a/controller/src/app/(app)/_components/ConfirmButton.tsx
+++ b/controller/src/app/(app)/_components/ConfirmButton.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import type { ButtonHTMLAttributes } from "react";
+
+type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
+  /** Message shown in the confirmation dialog. Submitting only proceeds if the admin confirms. */
+  confirm: string;
+};
+
+/**
+ * A submit button that pops a native confirmation dialog before letting its form's Server Action
+ * run. Used for every destructive action (destroy lab, remove student, delete node) so a delete is
+ * never a single mis-click. Cancelling preventDefaults the submit; the surrounding <form action=…>
+ * (and any redirect the action performs) is otherwise untouched.
+ */
+export function ConfirmButton({ confirm: message, children, onClick, ...rest }: Props) {
+  return (
+    <button
+      {...rest}
+      onClick={(e) => {
+        if (!window.confirm(message)) {
+          e.preventDefault();
+          return;
+        }
+        onClick?.(e);
+      }}
+    >
+      {children}
+    </button>
+  );
+}

--- a/controller/src/app/(app)/labs/[id]/page.tsx
+++ b/controller/src/app/(app)/labs/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import { ConfirmButton } from "../../_components/ConfirmButton";
 import { db } from "@/lib/db";
 import { takeFlash } from "@/lib/flash";
 import { ago, fmtBytes, pct } from "@/lib/format";
@@ -257,9 +258,14 @@ export default async function LabDetail({
                       <label className="muted" style={{ margin: 0, display: "inline-flex", gap: 4, alignItems: "center" }}>
                         <input type="checkbox" name="deleteData" style={{ width: "auto" }} /> delete data
                       </label>
-                      <button type="submit" className="secondary" style={{ width: "auto", marginTop: 0, padding: "6px 10px" }}>
+                      <ConfirmButton
+                        type="submit"
+                        className="secondary"
+                        style={{ width: "auto", marginTop: 0, padding: "6px 10px" }}
+                        confirm={`Remove ${m.username} from ${lab.name}? If "delete data" is checked, their files are permanently erased.`}
+                      >
                         Remove
-                      </button>
+                      </ConfirmButton>
                     </form>
                   </td>
                 </tr>
@@ -317,9 +323,14 @@ export default async function LabDetail({
         </form>
         <form action={destroyLabAction}>
           <input type="hidden" name="labId" value={lab.id} />
-          <button type="submit" className="danger" style={{ width: 200, marginTop: 0 }}>
+          <ConfirmButton
+            type="submit"
+            className="danger"
+            style={{ width: 200, marginTop: 0 }}
+            confirm={`Destroy lab "${lab.name}"? This removes the container and ALL data (shared + every student), and deletes students that belong only to this lab. This cannot be undone.`}
+          >
             Destroy lab + data
-          </button>
+          </ConfirmButton>
         </form>
       </div>
     </>

--- a/controller/src/app/(app)/labs/actions.ts
+++ b/controller/src/app/(app)/labs/actions.ts
@@ -111,6 +111,10 @@ export async function destroyLabAction(formData: FormData) {
   const labId = Number(formData.get("labId"));
   destroyLab(labId, who);
   revalidatePath("/labs");
+  revalidatePath("/students");
+  // The lab detail page (/labs/[id]) no longer exists after destroy, so send the admin to the labs
+  // list rather than leaving them on a 404.
+  redirect("/labs");
 }
 
 export async function rescanAction(formData: FormData) {
@@ -181,4 +185,5 @@ export async function removeMemberAction(formData: FormData) {
   const deleteData = formData.get("deleteData") === "on";
   removeStudentFromLab(labId, studentId, deleteData, who);
   revalidatePath(`/labs/${labId}`);
+  revalidatePath("/students");
 }

--- a/controller/src/app/(app)/nodes/page.tsx
+++ b/controller/src/app/(app)/nodes/page.tsx
@@ -1,4 +1,5 @@
 import { db } from "@/lib/db";
+import { ConfirmButton } from "../_components/ConfirmButton";
 import {
   deleteNodeAction,
   provisionNodeAction,
@@ -206,13 +207,14 @@ export default async function NodesPage({
                       )}{" "}
                       <form action={deleteNodeAction} style={{ display: "inline" }}>
                         <input type="hidden" name="name" value={n.name} />
-                        <button
+                        <ConfirmButton
                           type="submit"
                           className="secondary"
                           style={{ width: "auto", padding: "6px 12px", color: "var(--warn)" }}
+                          confirm={`Delete node "${n.name}"? This removes it from the controller (it fails if any labs are still pinned to it).`}
                         >
                           Delete
-                        </button>
+                        </ConfirmButton>
                       </form>
                     </td>
                   </tr>

--- a/controller/src/app/(app)/students/actions.ts
+++ b/controller/src/app/(app)/students/actions.ts
@@ -1,9 +1,10 @@
 "use server";
 
 import { redirect } from "next/navigation";
+import { revalidatePath } from "next/cache";
 import { requireAdmin } from "@/lib/auth";
 import { applyMapping, parseCsv } from "@/lib/csv";
-import { addStudentToLab } from "@/lib/students";
+import { addStudentToLab, removeStudentFromLab } from "@/lib/students";
 
 // Upper bound on rows per import — prevents one POST from enqueuing thousands of root-agent useradd
 // tasks (H-06). Anything beyond this is rejected outright rather than silently truncated.
@@ -46,4 +47,15 @@ export async function importCsvAction(formData: FormData) {
     }
   }
   redirect(`/students?imported=${added}&skipped=${skipped}`);
+}
+
+export async function removeStudentAction(formData: FormData) {
+  const actor = (await requireAdmin()).email;
+  const labId = Number(formData.get("labId"));
+  const studentId = Number(formData.get("studentId"));
+  const deleteData = formData.get("deleteData") === "on";
+  removeStudentFromLab(labId, studentId, deleteData, actor);
+  revalidatePath("/students");
+  revalidatePath(`/labs/${labId}`);
+  redirect("/students");
 }

--- a/controller/src/app/(app)/students/page.tsx
+++ b/controller/src/app/(app)/students/page.tsx
@@ -1,6 +1,7 @@
 import { listLabs } from "@/lib/labs";
-import { listStudents } from "@/lib/students";
-import { importCsvAction } from "./actions";
+import { listMembers } from "@/lib/students";
+import { ConfirmButton } from "../_components/ConfirmButton";
+import { importCsvAction, removeStudentAction } from "./actions";
 
 export const dynamic = "force-dynamic";
 
@@ -10,8 +11,11 @@ export default async function StudentsPage({
   searchParams: Promise<{ imported?: string; skipped?: string; error?: string }>;
 }) {
   const { imported, skipped, error } = await searchParams;
-  const students = listStudents();
   const labs = listLabs();
+  // Students are shown grouped by the lab they belong to (a student can be in more than one lab and
+  // then appears under each).
+  const labsWithMembers = labs.map((l) => ({ lab: l, members: listMembers(l.id) }));
+  const totalMemberships = labsWithMembers.reduce((n, l) => n + l.members.length, 0);
 
   return (
     <>
@@ -79,32 +83,62 @@ export default async function StudentsPage({
       </div>
 
       <div className="card">
-        <h3 style={{ marginTop: 0 }}>All students</h3>
-        {students.length === 0 ? (
+        <h3 style={{ marginTop: 0 }}>Students by lab</h3>
+        {totalMemberships === 0 ? (
           <p className="muted">No students yet.</p>
         ) : (
-          <div className="table-wrap">
-          <table>
-            <thead>
-              <tr>
-                <th>Username</th>
-                <th>Email</th>
-                <th>Name</th>
-                <th>Student ID</th>
-              </tr>
-            </thead>
-            <tbody>
-              {students.map((s) => (
-                <tr key={s.id}>
-                  <td>{s.username}</td>
-                  <td>{s.email ?? "—"}</td>
-                  <td>{s.name ?? "—"}</td>
-                  <td>{s.student_id ?? "—"}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-          </div>
+          labsWithMembers
+            .filter((l) => l.members.length > 0)
+            .map(({ lab, members }) => (
+              <div key={lab.id} style={{ marginBottom: 20 }}>
+                <h4 style={{ margin: "8px 0" }}>
+                  <a href={`/labs/${lab.id}`}>{lab.name}</a>{" "}
+                  <span className="muted" style={{ fontWeight: 400 }}>
+                    · {lab.node_name} · {members.length} student{members.length === 1 ? "" : "s"}
+                  </span>
+                </h4>
+                <div className="table-wrap">
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>Username</th>
+                        <th>Email</th>
+                        <th>Name</th>
+                        <th>Student ID</th>
+                        <th></th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {members.map((m) => (
+                        <tr key={m.member_id}>
+                          <td>{m.username}</td>
+                          <td>{m.email ?? "—"}</td>
+                          <td>{m.name ?? "—"}</td>
+                          <td>{m.student_id ?? "—"}</td>
+                          <td style={{ textAlign: "right" }}>
+                            <form action={removeStudentAction} style={{ display: "inline-flex", gap: 6, alignItems: "center" }}>
+                              <input type="hidden" name="labId" value={lab.id} />
+                              <input type="hidden" name="studentId" value={m.id} />
+                              <label className="muted" style={{ margin: 0, display: "inline-flex", gap: 4, alignItems: "center" }}>
+                                <input type="checkbox" name="deleteData" style={{ width: "auto" }} /> delete data
+                              </label>
+                              <ConfirmButton
+                                type="submit"
+                                className="secondary"
+                                style={{ width: "auto", marginTop: 0, padding: "6px 10px" }}
+                                confirm={`Remove ${m.username} from ${lab.name}? If "delete data" is checked, their files are permanently erased.`}
+                              >
+                                Remove
+                              </ConfirmButton>
+                            </form>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            ))
         )}
       </div>
     </>

--- a/controller/src/lib/hub.ts
+++ b/controller/src/lib/hub.ts
@@ -14,6 +14,7 @@ import { WebSocketServer, type WebSocket } from "ws";
 import { alertNodeOffline, alertTaskFailed, maybeAlertOnLog } from "./alerts";
 import { db } from "./db";
 import { ingestTelemetry, storeOldfileScan } from "./ingest";
+import { markLabStatus } from "./labs";
 import { verifyNodeAuth } from "./nodes";
 import { ackTask, claimTask, markTaskState, retryTask } from "./queue";
 import { getSetting } from "./settings";
@@ -173,18 +174,30 @@ function handleResult(node: string, frame: any): void {
     frame.ok ? undefined : frame.error,
   );
   if (!changed) return;
-  if (!frame.ok) {
-    const t = db().prepare("SELECT node, action FROM task_log WHERE task_uuid = ?").get(frame.id) as
-      | { node: string; action: string }
-      | undefined;
-    if (t) alertTaskFailed(t.node, t.action, frame.error ?? "unknown error");
+  const t = db()
+    .prepare("SELECT node, action, params FROM task_log WHERE task_uuid = ?")
+    .get(frame.id) as { node: string; action: string; params: string | null } | undefined;
+  if (!frame.ok && t) {
+    alertTaskFailed(t.node, t.action, frame.error ?? "unknown error");
+  }
+  // Lab provisioning lifecycle: a lab is created in 'provisioning' and stays there until its
+  // lab.create task reports back. Flip it to 'active' on success or 'failed' on error so it no
+  // longer reads as permanently "provisioning". The lab name comes from the task params (the result
+  // payload also carries it, but params is always present even on failure).
+  if (t?.action === "lab.create") {
+    let labName: string | undefined = frame.result?.lab;
+    if (!labName && t.params) {
+      try {
+        labName = (JSON.parse(t.params) as { lab?: string }).lab;
+      } catch {
+        labName = undefined;
+      }
+    }
+    if (labName) markLabStatus(labName, frame.ok ? "active" : "failed");
   }
   // Persist scan results into the oldfile_scans table.
-  if (frame.ok && frame.result?.results && frame.result?.lab) {
-    const row = db().prepare("SELECT action FROM task_log WHERE task_uuid = ?").get(frame.id) as
-      | { action: string }
-      | undefined;
-    if (row?.action === "oldfiles.scan") storeOldfileScan(frame.result);
+  if (frame.ok && frame.result?.results && frame.result?.lab && t?.action === "oldfiles.scan") {
+    storeOldfileScan(frame.result);
   }
   if (frame.logs) {
     db()

--- a/controller/src/lib/labs.ts
+++ b/controller/src/lib/labs.ts
@@ -220,12 +220,38 @@ export function updateLabSettings(labId: number, input: UpdateLabSettingsInput, 
   return false;
 }
 
+/** Set a lab's textual status by name. Used by the result ingest path (provisioning -> active). */
+export function markLabStatus(name: string, status: string): void {
+  db().prepare("UPDATE labs SET status = ? WHERE name = ?").run(status, name);
+}
+
 export function destroyLab(labId: number, actor?: string): void {
   const lab = getLab(labId);
   if (!lab) return;
+  // The node's lab.destroy tears down the container and every dataset (shared + all students), so
+  // student *data* goes with the lab. Mark deleting, capture members for orphan cleanup, then enqueue.
+  db().prepare("UPDATE labs SET status = 'deleting' WHERE id = ?").run(labId);
+  const memberIds = (db()
+    .prepare("SELECT student_id FROM lab_members WHERE lab_id = ?")
+    .all(labId) as { student_id: number }[]).map((r) => r.student_id);
+
   enqueueTask(lab.node_name, "lab.destroy", { lab: lab.name }, actor);
+  // Deleting the lab row cascades lab_members (ON DELETE CASCADE), removing every membership.
   db().prepare("DELETE FROM labs WHERE id = ?").run(labId);
-  audit(actor, "lab.destroy", lab.name);
+
+  // Students belong to labs: drop any student that is now a member of no lab at all (a student kept
+  // in another lab is left untouched). This is what "students are deleted on lab delete" means.
+  let orphansRemoved = 0;
+  for (const sid of memberIds) {
+    const stillMember = db()
+      .prepare("SELECT 1 FROM lab_members WHERE student_id = ? LIMIT 1")
+      .get(sid);
+    if (!stillMember) {
+      db().prepare("DELETE FROM students WHERE id = ?").run(sid);
+      orphansRemoved++;
+    }
+  }
+  audit(actor, "lab.destroy", lab.name, orphansRemoved ? `${orphansRemoved} students removed` : undefined);
 }
 
 export function audit(actor: string | undefined, action: string, target?: string, detail?: string): void {

--- a/controller/tests/labs.test.ts
+++ b/controller/tests/labs.test.ts
@@ -148,4 +148,43 @@ describe("destroyLab", () => {
     labs.destroyLab(999999);
     expect(enqueueTask).not.toHaveBeenCalled();
   });
+
+  it("removes students that belonged only to the destroyed lab, keeps shared ones", () => {
+    const a = makeLab("alpha");
+    const b = makeLab("beta");
+    const db = dbmod.db();
+    // sole: only in alpha. shared: in both alpha and beta.
+    const sole = Number(
+      db.prepare("INSERT INTO students (username, created_at) VALUES ('sole', 0)").run().lastInsertRowid,
+    );
+    const shared = Number(
+      db.prepare("INSERT INTO students (username, created_at) VALUES ('shared', 0)").run().lastInsertRowid,
+    );
+    db.prepare("INSERT INTO lab_members (lab_id, student_id, created_at) VALUES (?, ?, 0)").run(a.id, sole);
+    db.prepare("INSERT INTO lab_members (lab_id, student_id, created_at) VALUES (?, ?, 0)").run(a.id, shared);
+    db.prepare("INSERT INTO lab_members (lab_id, student_id, created_at) VALUES (?, ?, 0)").run(b.id, shared);
+
+    labs.destroyLab(a.id, "admin");
+
+    // sole had no other membership -> deleted; shared still in beta -> kept.
+    expect(db.prepare("SELECT id FROM students WHERE id = ?").get(sole)).toBeUndefined();
+    expect(db.prepare("SELECT id FROM students WHERE id = ?").get(shared)).toBeTruthy();
+    // memberships in the destroyed lab are gone (ON DELETE CASCADE).
+    expect(db.prepare("SELECT 1 FROM lab_members WHERE lab_id = ?").get(a.id)).toBeUndefined();
+  });
+});
+
+describe("markLabStatus", () => {
+  it("transitions a provisioning lab to active (and to failed)", () => {
+    const lab = makeLab("statuslab");
+    expect(labs.getLab(lab.id)!.status).toBe("provisioning");
+    labs.markLabStatus("statuslab", "active");
+    expect(labs.getLab(lab.id)!.status).toBe("active");
+    labs.markLabStatus("statuslab", "failed");
+    expect(labs.getLab(lab.id)!.status).toBe("failed");
+  });
+
+  it("is a silent no-op for an unknown lab name", () => {
+    expect(() => labs.markLabStatus("nope", "active")).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Why

`student.add` failed with `chown: changing ownership of '/labusers/fast/<u>': Operation not permitted`, leaving labs stuck on **provisioning**. Root cause: under the Sysbox runtime (userns remap, no shiftfs on this kernel), the **per-student ZFS datasets** are nested mounts that the bind-mount's id-mapping never covers, so they appear inside the container owned by an unmapped UID (nobody) and container-root cannot `chown` them.

Separately, `lab.destroy` failed with **`dataset is busy`** because the container's bind mounts kept the datasets in use during `zfs destroy -r`.

## What changed

**Storage model — drop per-student datasets, enforce only the lab quota.** Each student is now a plain subdir of the lab's single fast/slow `users` dataset, created in-container by `add_user`. Subdirs under the already-shifted `users` mount chown fine. All usage is bounded by the one lab quota (no per-student quota).

### agent
- `studentops`: add/remove student no longer create/destroy per-student datasets.
- `users.remove_user`: wipes `/labusers/{fast,slow}/<u>` on `delete_data`.
- `labops.destroy_lab`: **removes the container before** `zfs destroy -r` (fixes "dataset is busy").
- `scan` + `coldstore.user_scan_dir`: resolve per-student dirs as subdirs of the `users` dataset mountpoint.
- Removed now-dead `coldstore.create_user/destroy_user`; `usagereport` still lists students via the docker-layer measurement.

### controller
- **Lab status lifecycle**: `lab.create` result flips `provisioning -> active` (or `failed`), so labs no longer read as permanently provisioning.
- `destroyLab`: redirects to `/labs` and deletes students that belonged **only** to the destroyed lab (kept if still in another lab).
- **Confirm dialog** on every destructive action (destroy lab, remove member, delete node, remove student) via a reusable `ConfirmButton`, with redirect back to the right page.
- **Students page** grouped by lab with per-student remove (+ delete data).

## Tests
- Agent: ruff + pytest (197 passing) — updated studentops/labops/users/scan/coldstore, added destroy-ordering + delete-data-dirs tests.
- Controller: eslint + tsc + vitest (136 passing) + `next build` — added `markLabStatus` and orphan-student-cleanup tests.

## Ops note
The wedged `test1` lab on `ubuntu-epyc` was cleaned up manually (container + datasets removed); its controller row is now safe to destroy from the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)