### PR TITLE
UI makeover (Tailwind v4 + shadcn) + editable GPU notification emails

### DIFF
--- a/controller/components.json
+++ b/controller/components.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/app/globals.css",
+    "baseColor": "slate",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "iconLibrary": "lucide",
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  }
+}

--- a/controller/package-lock.json
+++ b/controller/package-lock.json
@@ -8,18 +8,26 @@
       "name": "lab-controller",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.17",
+        "@radix-ui/react-slot": "^1.3.0",
         "@russellthehippo/honker-node": "^0.3.3",
         "bcryptjs": "^3.0.3",
         "better-sqlite3": "^12.11.1",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
         "jose": "^6.2.3",
+        "lucide-react": "^1.21.0",
         "next": "^16.2.9",
         "nodemailer": "^9.0.1",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
+        "tailwind-merge": "^3.6.0",
+        "tw-animate-css": "^1.4.0",
         "ws": "^8.18.0",
         "zod": "^4.4.3"
       },
       "devDependencies": {
+        "@tailwindcss/postcss": "^4.3.1",
         "@types/bcryptjs": "^3.0.0",
         "@types/better-sqlite3": "^7.6.11",
         "@types/node": "^26.0.0",
@@ -28,9 +36,23 @@
         "@types/ws": "^8.5.12",
         "eslint": "^9",
         "eslint-config-next": "^16.2.9",
+        "tailwindcss": "^4.3.1",
         "tsx": "^4.16.2",
         "typescript": "^6.0.3",
         "vitest": "^4.1.9"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1775,6 +1797,336 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
+      "integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
+      "integrity": "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.17.tgz",
+      "integrity": "sha512-TDTYmpdq8dI2+Xgvgj9AJ8Ghqq+Eph/TRVEdaFQPDItIY+6QSkU7MJMeevw1568Yw/2Ijz8BTphPSP2XejKphw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.13",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.10",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-portal": "1.1.12",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-slot": "1.3.0",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.13.tgz",
+      "integrity": "sha512-2v+zNAWWe0ySxgC0D0yeXMPQ23xZVgXZTerTz+JKlmdRj6gfTqmCcR29jb6d290DezXPGgruHWDX/vYUebtErg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-escape-keydown": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
+      "integrity": "sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.10.tgz",
+      "integrity": "sha512-Fas/lXQqhVvqwAb64s5RFeHiHYElZ6SUQbZaNd6EkfhP/Al7wTIQ9WIR4QVX475tlu5yFCEdDcJH6/UwsZjMWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-use-callback-ref": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.12.tgz",
+      "integrity": "sha512-m309havGzsjLHHaIX50G5PlvRs3xkgPCsGk/5PTvYm8D5q33yG0J7w/712PTOhid7NTaFETtnSXjngHQavvhVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz",
+      "integrity": "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.6.tgz",
+      "integrity": "sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+      "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.2.tgz",
+      "integrity": "sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
@@ -2165,6 +2517,289 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.1.tgz",
+      "integrity": "sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "5.21.6",
+        "jiti": "^2.7.0",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.1.tgz",
+      "integrity": "sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.1",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.1",
+        "@tailwindcss/oxide-darwin-x64": "4.3.1",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.1",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.1",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.1",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.1",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.1",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.1",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.1",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.1",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.1.tgz",
+      "integrity": "sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.1.tgz",
+      "integrity": "sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.1.tgz",
+      "integrity": "sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.1.tgz",
+      "integrity": "sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.1.tgz",
+      "integrity": "sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.1.tgz",
+      "integrity": "sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.1.tgz",
+      "integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.1.tgz",
+      "integrity": "sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.1.tgz",
+      "integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.1.tgz",
+      "integrity": "sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.1.tgz",
+      "integrity": "sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.1.tgz",
+      "integrity": "sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.1.tgz",
+      "integrity": "sha512-dNJuNbdEJT/SWRuXTYP1WSamelsz3ztkUsdtWQPjrexysrTpaEPM40P/71knXiXLYEojqPOEGitVLLpPMS5T6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.3.1",
+        "@tailwindcss/oxide": "4.3.1",
+        "postcss": "8.5.15",
+        "tailwindcss": "4.3.1"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -2260,7 +2895,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3077,6 +3712,18 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
@@ -3587,11 +4234,32 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -3646,7 +4314,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -3804,6 +4472,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3840,6 +4514,20 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.21.6",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
+      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/es-abstract": {
@@ -4894,6 +5582,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -5000,6 +5697,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -5646,6 +6350,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/jose": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
@@ -6109,6 +6823,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.21.0.tgz",
+      "integrity": "sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {
@@ -6834,6 +7557,75 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
@@ -7583,6 +8375,37 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
+      "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -7729,6 +8552,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/tw-animate-css": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
+      "integrity": "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Wombosvideo"
       }
     },
     "node_modules/type-check": {
@@ -7963,6 +8795,49 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/util-deprecate": {

--- a/controller/package.json
+++ b/controller/package.json
@@ -12,14 +12,21 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.17",
+    "@radix-ui/react-slot": "^1.3.0",
     "@russellthehippo/honker-node": "^0.3.3",
     "bcryptjs": "^3.0.3",
     "better-sqlite3": "^12.11.1",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "jose": "^6.2.3",
+    "lucide-react": "^1.21.0",
     "next": "^16.2.9",
     "nodemailer": "^9.0.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
+    "tailwind-merge": "^3.6.0",
+    "tw-animate-css": "^1.4.0",
     "ws": "^8.18.0",
     "zod": "^4.4.3"
   },
@@ -27,6 +34,7 @@
     "postcss": "^8.5.10"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.3.1",
     "@types/bcryptjs": "^3.0.0",
     "@types/better-sqlite3": "^7.6.11",
     "@types/node": "^26.0.0",
@@ -35,6 +43,7 @@
     "@types/ws": "^8.5.12",
     "eslint": "^9",
     "eslint-config-next": "^16.2.9",
+    "tailwindcss": "^4.3.1",
     "tsx": "^4.16.2",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"

--- a/controller/postcss.config.mjs
+++ b/controller/postcss.config.mjs
@@ -1,0 +1,7 @@
+const config = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};
+
+export default config;

--- a/controller/src/app/(app)/_components/ConfirmButton.tsx
+++ b/controller/src/app/(app)/_components/ConfirmButton.tsx
@@ -1,31 +1,65 @@
 "use client";
 
-import type { ButtonHTMLAttributes } from "react";
+import * as React from "react";
+import { Button, type ButtonProps } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 
-type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
+type Props = Omit<ButtonProps, "onClick"> & {
   /** Message shown in the confirmation dialog. Submitting only proceeds if the admin confirms. */
   confirm: string;
+  /** Heading for the dialog. */
+  title?: string;
 };
 
 /**
- * A submit button that pops a native confirmation dialog before letting its form's Server Action
- * run. Used for every destructive action (destroy lab, remove student, delete node) so a delete is
- * never a single mis-click. Cancelling preventDefaults the submit; the surrounding <form action=…>
- * (and any redirect the action performs) is otherwise untouched.
+ * A button that opens a styled confirmation dialog before submitting its surrounding form's Server
+ * Action. Used for every destructive action (destroy lab, remove student, delete node) so a delete is
+ * never a single mis-click. On confirm it calls requestSubmit() on the closest <form> — every
+ * destructive form carries its inputs as hidden fields, so no submitter value is needed.
  */
-export function ConfirmButton({ confirm: message, children, onClick, ...rest }: Props) {
+export function ConfirmButton({
+  confirm: message,
+  title = "Are you sure?",
+  children,
+  variant = "outline",
+  ...rest
+}: Props) {
+  const [open, setOpen] = React.useState(false);
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+
+  function onConfirm() {
+    setOpen(false);
+    triggerRef.current?.closest("form")?.requestSubmit();
+  }
+
   return (
-    <button
-      {...rest}
-      onClick={(e) => {
-        if (!window.confirm(message)) {
-          e.preventDefault();
-          return;
-        }
-        onClick?.(e);
-      }}
-    >
-      {children}
-    </button>
+    <>
+      <Button ref={triggerRef} type="button" variant={variant} onClick={() => setOpen(true)} {...rest}>
+        {children}
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{title}</DialogTitle>
+            <DialogDescription>{message}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="button" variant="destructive" onClick={onConfirm}>
+              Confirm
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/controller/src/app/(app)/_components/MobileNav.tsx
+++ b/controller/src/app/(app)/_components/MobileNav.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect, useState, type ReactNode } from "react";
+import { usePathname } from "next/navigation";
+import { Menu } from "lucide-react";
+import { Sheet, SheetContent, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
+
+/**
+ * Mobile-only top bar: a hamburger that opens the sidebar in a slide-in Sheet. The sidebar body is
+ * passed as children from the (server) layout. The drawer auto-closes whenever the route changes.
+ */
+export function MobileNav({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+
+  // Close the drawer whenever the route changes (a nav link was tapped).
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setOpen(false);
+  }, [pathname]);
+
+  return (
+    <header className="sticky top-0 z-30 flex h-14 items-center gap-3 border-b border-border bg-sidebar px-4 md:hidden">
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetTrigger
+          aria-label="Open menu"
+          className="flex h-9 w-9 items-center justify-center rounded-md border border-input hover:bg-accent hover:text-accent-foreground"
+        >
+          <Menu className="h-5 w-5" />
+        </SheetTrigger>
+        <SheetContent side="left" className="w-72 p-0">
+          <SheetTitle className="sr-only">Navigation</SheetTitle>
+          {children}
+        </SheetContent>
+      </Sheet>
+      <div className="flex items-center gap-2">
+        <span className="flex h-7 w-7 items-center justify-center rounded-md bg-primary text-sm font-bold text-primary-foreground">
+          L
+        </span>
+        <span className="text-sm font-semibold tracking-tight">Lab Manager</span>
+      </div>
+    </header>
+  );
+}

--- a/controller/src/app/(app)/_components/NavLinks.tsx
+++ b/controller/src/app/(app)/_components/NavLinks.tsx
@@ -1,27 +1,50 @@
 "use client";
 
 import { usePathname } from "next/navigation";
+import {
+  Bell,
+  Cpu,
+  FlaskConical,
+  HardDrive,
+  LayoutDashboard,
+  ScrollText,
+  Server,
+  Settings,
+  Users,
+  type LucideIcon,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
 
-const NAV: [string, string][] = [
-  ["/dashboard", "Dashboard"],
-  ["/nodes", "Nodes"],
-  ["/labs", "Labs"],
-  ["/students", "Students"],
-  ["/stats", "Stats"],
-  ["/gpu", "GPU"],
-  ["/logs", "Logs"],
-  ["/announcements", "Announce"],
-  ["/settings", "Settings"],
+const NAV: [string, string, LucideIcon][] = [
+  ["/dashboard", "Dashboard", LayoutDashboard],
+  ["/nodes", "Nodes", Server],
+  ["/labs", "Labs", FlaskConical],
+  ["/students", "Students", Users],
+  ["/stats", "Stats", HardDrive],
+  ["/gpu", "GPU", Cpu],
+  ["/logs", "Logs", ScrollText],
+  ["/announcements", "Announce", Bell],
+  ["/settings", "Settings", Settings],
 ];
 
 export function NavLinks() {
   const pathname = usePathname();
   return (
-    <nav>
-      {NAV.map(([href, label]) => {
+    <nav className="flex flex-col gap-0.5">
+      {NAV.map(([href, label, Icon]) => {
         const active = pathname === href || pathname.startsWith(`${href}/`);
         return (
-          <a key={href} href={href} className={active ? "active" : undefined}>
+          <a
+            key={href}
+            href={href}
+            className={cn(
+              "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors no-underline hover:bg-accent hover:text-accent-foreground",
+              active
+                ? "bg-primary/15 text-primary hover:bg-primary/15 hover:text-primary"
+                : "text-sidebar-foreground",
+            )}
+          >
+            <Icon className="h-4 w-4 shrink-0" />
             {label}
           </a>
         );

--- a/controller/src/app/(app)/_components/SidebarContent.tsx
+++ b/controller/src/app/(app)/_components/SidebarContent.tsx
@@ -1,0 +1,37 @@
+import { NavLinks } from "./NavLinks";
+import { ThemeToggle } from "./ThemeToggle";
+
+/** Shared sidebar body — rendered both in the fixed desktop rail and inside the mobile Sheet. */
+export function SidebarContent({
+  email,
+  logout,
+}: {
+  email: string;
+  logout: () => void | Promise<void>;
+}) {
+  return (
+    <div className="flex h-full flex-col gap-6 p-4">
+      <div className="flex items-center gap-2 px-2">
+        <span className="flex h-7 w-7 items-center justify-center rounded-md bg-primary text-sm font-bold text-primary-foreground">
+          L
+        </span>
+        <span className="text-sm font-semibold tracking-tight">Lab Manager</span>
+      </div>
+
+      <NavLinks />
+
+      <div className="mt-auto flex flex-col gap-3 border-t border-border pt-4">
+        <form action={logout}>
+          <button
+            type="submit"
+            className="w-full cursor-pointer rounded-md border border-input bg-transparent px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
+          >
+            Sign out
+          </button>
+        </form>
+        <ThemeToggle />
+        <p className="break-all px-1 text-xs text-muted-foreground">{email}</p>
+      </div>
+    </div>
+  );
+}

--- a/controller/src/app/(app)/_components/ThemeToggle.tsx
+++ b/controller/src/app/(app)/_components/ThemeToggle.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { Moon, Sun } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 type Theme = "dark" | "light";
 
@@ -28,11 +30,17 @@ export function ThemeToggle() {
     }
   }
 
-  // Render a stable label until the effect resolves the real theme.
-  const label = theme === "light" ? "🌙  Dark mode" : "☀️  Light mode";
   return (
-    <button type="button" className="theme-toggle" onClick={toggle} suppressHydrationWarning>
-      {theme === null ? "Theme" : label}
-    </button>
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className="w-full justify-center"
+      onClick={toggle}
+      suppressHydrationWarning
+    >
+      {theme === null ? null : theme === "light" ? <Moon /> : <Sun />}
+      {theme === null ? "Theme" : theme === "light" ? "Dark mode" : "Light mode"}
+    </Button>
   );
 }

--- a/controller/src/app/(app)/announcements/page.tsx
+++ b/controller/src/app/(app)/announcements/page.tsx
@@ -2,6 +2,12 @@ import { audienceCounts, recentAnnouncements } from "@/lib/announcements";
 import { isSmtpConfigured } from "@/lib/settings";
 import { ago } from "@/lib/format";
 import { sendAnnouncementAction } from "./actions";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 
 export const dynamic = "force-dynamic";
 
@@ -17,91 +23,102 @@ export default async function AnnouncementsPage({
   const smtpOk = isSmtpConfigured();
 
   return (
-    <>
-      <h2>Announcements</h2>
+    <div className="space-y-4">
+      <h1 className="text-2xl font-semibold tracking-tight">Announcements</h1>
 
       {msg && (
-        <div className="card" style={{ marginBottom: 16 }}>
-          <p className="muted">{msg}</p>
-        </div>
+        <Card>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">{msg}</p>
+          </CardContent>
+        </Card>
       )}
 
       {!smtpOk && (
-        <div className="card" style={{ borderColor: "var(--warn)", marginBottom: 16 }}>
-          <p style={{ color: "var(--warn)" }}>
-            SMTP is not configured, so announcements cannot be delivered. Set it up under{" "}
-            <a href="/settings">Settings → Email</a> first.
-          </p>
-        </div>
+        <Card className="border-warn/50">
+          <CardContent>
+            <p className="text-sm text-warn">
+              SMTP is not configured, so announcements cannot be delivered. Set it up under{" "}
+              <a href="/settings" className="underline">
+                Settings → Email
+              </a>{" "}
+              first.
+            </p>
+          </CardContent>
+        </Card>
       )}
 
-      <div className="card" style={{ marginBottom: 16 }}>
-        <h3 style={{ marginTop: 0 }}>Send a service announcement</h3>
-        <form action={sendAnnouncementAction}>
-          <label>
-            Subject
-            <input name="subject" required maxLength={200} placeholder="e.g. Scheduled maintenance Saturday" />
-          </label>
-          <label>
-            Message
-            <textarea name="body" required rows={6} placeholder="Write your announcement…" />
-          </label>
-          <fieldset style={{ border: "1px solid var(--border)", borderRadius: 6, padding: 12, margin: "12px 0" }}>
-            <legend className="muted" style={{ fontSize: 12 }}>Recipients</legend>
-            <label style={{ display: "inline-flex", alignItems: "center", gap: 6, marginRight: 20 }}>
-              <input type="checkbox" name="students" defaultChecked style={{ width: "auto" }} />
-              All users ({counts.students})
-            </label>
-            <label style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
-              <input type="checkbox" name="pis" style={{ width: "auto" }} />
-              All PIs ({counts.pis})
-            </label>
-          </fieldset>
-          <button type="submit" style={{ width: "auto" }}>Send announcement</button>
-        </form>
-        <p className="muted" style={{ fontSize: 12, marginTop: 8 }}>
-          Sent by email to the distinct addresses in the selected audiences. A PI who is also a user is
-          mailed once.
-        </p>
-      </div>
+      <Card>
+        <CardContent className="space-y-3">
+          <h3 className="text-base font-semibold">Send a service announcement</h3>
+          <form action={sendAnnouncementAction} className="space-y-3">
+            <div>
+              <Label>Subject</Label>
+              <Input name="subject" required maxLength={200} placeholder="e.g. Scheduled maintenance Saturday" />
+            </div>
+            <div>
+              <Label>Message</Label>
+              <Textarea name="body" required rows={6} placeholder="Write your announcement…" />
+            </div>
+            <fieldset className="rounded-md border border-border p-3">
+              <legend className="px-1 text-xs text-muted-foreground">Recipients</legend>
+              <div className="flex flex-wrap gap-x-6 gap-y-2">
+                <label className="flex items-center gap-1.5 text-sm">
+                  <input type="checkbox" name="students" defaultChecked className="accent-primary" />
+                  All users ({counts.students})
+                </label>
+                <label className="flex items-center gap-1.5 text-sm">
+                  <input type="checkbox" name="pis" className="accent-primary" />
+                  All PIs ({counts.pis})
+                </label>
+              </div>
+            </fieldset>
+            <Button type="submit">Send announcement</Button>
+          </form>
+          <p className="text-xs text-muted-foreground">
+            Sent by email to the distinct addresses in the selected audiences. A PI who is also a user
+            is mailed once.
+          </p>
+        </CardContent>
+      </Card>
 
-      <div className="card">
-        <h3 style={{ marginTop: 0 }}>Recent announcements</h3>
-        {history.length === 0 ? (
-          <p className="muted">Nothing sent yet.</p>
-        ) : (
-          <div className="table-wrap">
-            <table>
-              <thead>
-                <tr>
-                  <th>When</th>
-                  <th>By</th>
-                  <th>To</th>
-                  <th>Subject</th>
-                  <th>Delivered</th>
-                </tr>
-              </thead>
-              <tbody>
+      <Card>
+        <CardContent className="space-y-3">
+          <h3 className="text-base font-semibold">Recent announcements</h3>
+          {history.length === 0 ? (
+            <p className="text-sm text-muted-foreground">Nothing sent yet.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>When</TableHead>
+                  <TableHead>By</TableHead>
+                  <TableHead>To</TableHead>
+                  <TableHead>Subject</TableHead>
+                  <TableHead>Delivered</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
                 {history.map((a) => (
-                  <tr key={a.id}>
-                    <td className="muted">{ago(a.ts)}</td>
-                    <td>{a.actor ?? "—"}</td>
-                    <td>{a.audiences.replace("students", "users").replace(/,/g, ", ")}</td>
-                    <td>{a.subject}</td>
-                    <td>
+                  <TableRow key={a.id}>
+                    <TableCell className="whitespace-nowrap text-muted-foreground">{ago(a.ts)}</TableCell>
+                    <TableCell>{a.actor ?? "—"}</TableCell>
+                    <TableCell>{a.audiences.replace("students", "users").replace(/,/g, ", ")}</TableCell>
+                    <TableCell>{a.subject}</TableCell>
+                    <TableCell>
                       {a.skipped ? (
-                        <span style={{ color: "var(--warn)" }}>skipped (no SMTP)</span>
+                        <span className="text-warn">skipped (no SMTP)</span>
                       ) : (
                         `${a.sent}/${a.recipients}`
                       )}
-                    </td>
-                  </tr>
+                    </TableCell>
+                  </TableRow>
                 ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </div>
-    </>
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/controller/src/app/(app)/dashboard/page.tsx
+++ b/controller/src/app/(app)/dashboard/page.tsx
@@ -1,4 +1,5 @@
 import { db } from "@/lib/db";
+import { Card, CardContent } from "@/components/ui/card";
 
 export const dynamic = "force-dynamic";
 
@@ -13,29 +14,42 @@ export default function Dashboard() {
   const labs = count("SELECT COUNT(*) AS n FROM labs");
   const students = count("SELECT COUNT(*) AS n FROM students");
 
-  const stats = [
+  const stats: [string, string | number][] = [
     ["Nodes online", `${nodesOnline} / ${nodesTotal}`],
     ["Labs", labs],
     ["Students", students],
   ];
 
   return (
-    <>
-      <h2>Dashboard</h2>
-      <div style={{ display: "flex", gap: 16, flexWrap: "wrap" }}>
+    <div className="space-y-5">
+      <h1 className="text-2xl font-semibold tracking-tight">Dashboard</h1>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
         {stats.map(([label, value]) => (
-          <div className="card" key={label} style={{ minWidth: 160 }}>
-            <div className="muted" style={{ fontSize: 13 }}>{label}</div>
-            <div style={{ fontSize: 28, fontWeight: 700, marginTop: 6 }}>{value}</div>
-          </div>
+          <Card key={label}>
+            <CardContent>
+              <div className="text-sm text-muted-foreground">{label}</div>
+              <div className="mt-1.5 text-3xl font-bold tracking-tight">{value}</div>
+            </CardContent>
+          </Card>
         ))}
       </div>
-      <div className="card">
-        <p className="muted">
-          Connect an agent with <code>lab-agent install --controller … --token …</code>; it will
-          appear on the <a href="/nodes">Nodes</a> page once it dials in.
-        </p>
-      </div>
-    </>
+
+      <Card>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            Connect an agent with{" "}
+            <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground">
+              lab-agent install --controller … --token …
+            </code>
+            ; it will appear on the{" "}
+            <a href="/nodes" className="text-primary hover:underline">
+              Nodes
+            </a>{" "}
+            page once it dials in.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/controller/src/app/(app)/gpu/page.tsx
+++ b/controller/src/app/(app)/gpu/page.tsx
@@ -1,5 +1,7 @@
 import { db } from "@/lib/db";
 import { ago, fmtBytes } from "@/lib/format";
+import { Card, CardContent } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 
 export const dynamic = "force-dynamic";
 
@@ -31,80 +33,80 @@ export default function GpuPage() {
     .all() as EventRow[];
 
   return (
-    <>
-      <h2>GPU</h2>
+    <div className="space-y-4">
+      <h1 className="text-2xl font-semibold tracking-tight">GPU</h1>
 
-      <div className="card">
-        <h3 style={{ marginTop: 0 }}>Live processes</h3>
-        {snapshot.length === 0 ? (
-          <p className="muted">No GPU processes reported.</p>
-        ) : (
-          <div className="table-wrap">
-          <table>
-            <thead>
-              <tr>
-                <th>Node</th>
-                <th>PID</th>
-                <th>User</th>
-                <th>Lab</th>
-                <th>VRAM</th>
-                <th>Util %</th>
-              </tr>
-            </thead>
-            <tbody>
-              {snapshot.map((r) => (
-                <tr key={`${r.node}-${r.pid}`}>
-                  <td>{r.node}</td>
-                  <td>{r.pid}</td>
-                  <td>{r.user ?? "—"}</td>
-                  <td>{r.lab ?? "—"}</td>
-                  <td>{fmtBytes(r.vram_bytes)}</td>
-                  <td style={{ color: (r.util ?? 0) <= 5 ? "var(--warn)" : "var(--text)" }}>
-                    {r.util ?? "—"}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-          </div>
-        )}
-      </div>
+      <Card>
+        <CardContent className="space-y-3">
+          <h3 className="text-base font-semibold">Live processes</h3>
+          {snapshot.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No GPU processes reported.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Node</TableHead>
+                  <TableHead>PID</TableHead>
+                  <TableHead>User</TableHead>
+                  <TableHead>Lab</TableHead>
+                  <TableHead>VRAM</TableHead>
+                  <TableHead>Util %</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {snapshot.map((r) => (
+                  <TableRow key={`${r.node}-${r.pid}`}>
+                    <TableCell>{r.node}</TableCell>
+                    <TableCell>{r.pid}</TableCell>
+                    <TableCell>{r.user ?? "—"}</TableCell>
+                    <TableCell>{r.lab ?? "—"}</TableCell>
+                    <TableCell>{fmtBytes(r.vram_bytes)}</TableCell>
+                    <TableCell className={(r.util ?? 0) <= 5 ? "text-warn" : undefined}>
+                      {r.util ?? "—"}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
 
-      <div className="card">
-        <h3 style={{ marginTop: 0 }}>Recent idle-kill events</h3>
-        {events.length === 0 ? (
-          <p className="muted">No events yet.</p>
-        ) : (
-          <div className="table-wrap">
-          <table>
-            <thead>
-              <tr>
-                <th>When</th>
-                <th>Node</th>
-                <th>PID</th>
-                <th>User</th>
-                <th>Lab</th>
-                <th>State</th>
-              </tr>
-            </thead>
-            <tbody>
-              {events.map((e, i) => (
-                <tr key={i}>
-                  <td className="muted">{ago(e.ts)}</td>
-                  <td>{e.node}</td>
-                  <td>{e.pid ?? "—"}</td>
-                  <td>{e.user ?? "—"}</td>
-                  <td>{e.lab ?? "—"}</td>
-                  <td style={{ color: e.state === "killed" ? "var(--err)" : "var(--warn)" }}>
-                    {e.state}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-          </div>
-        )}
-      </div>
-    </>
+      <Card>
+        <CardContent className="space-y-3">
+          <h3 className="text-base font-semibold">Recent idle-kill events</h3>
+          {events.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No events yet.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>When</TableHead>
+                  <TableHead>Node</TableHead>
+                  <TableHead>PID</TableHead>
+                  <TableHead>User</TableHead>
+                  <TableHead>Lab</TableHead>
+                  <TableHead>State</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {events.map((e, i) => (
+                  <TableRow key={i}>
+                    <TableCell className="text-muted-foreground">{ago(e.ts)}</TableCell>
+                    <TableCell>{e.node}</TableCell>
+                    <TableCell>{e.pid ?? "—"}</TableCell>
+                    <TableCell>{e.user ?? "—"}</TableCell>
+                    <TableCell>{e.lab ?? "—"}</TableCell>
+                    <TableCell className={e.state === "killed" ? "text-err" : "text-warn"}>
+                      {e.state}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/controller/src/app/(app)/labs/[id]/page.tsx
+++ b/controller/src/app/(app)/labs/[id]/page.tsx
@@ -6,6 +6,12 @@ import { ago, fmtBytes, pct } from "@/lib/format";
 import { containerOptionsOf, getLab } from "@/lib/labs";
 import { listMembers } from "@/lib/students";
 import { TIB } from "@/lib/settings";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import {
   addMemberAction,
   destroyLabAction,
@@ -43,7 +49,7 @@ function dockerByStudent(labId: number): Map<string, number> {
 }
 
 function Sparkline({ values }: { values: number[] }) {
-  if (values.length < 2) return <span className="muted">not enough history</span>;
+  if (values.length < 2) return <span className="text-sm text-muted-foreground">not enough history</span>;
   const w = 240;
   const h = 40;
   const max = Math.max(...values, 1);
@@ -51,8 +57,8 @@ function Sparkline({ values }: { values: number[] }) {
     .map((v, i) => `${(i / (values.length - 1)) * w},${h - (v / max) * h}`)
     .join(" ");
   return (
-    <svg width={w} height={h} style={{ display: "block" }}>
-      <polyline points={pts} fill="none" stroke="var(--accent)" strokeWidth="2" />
+    <svg viewBox={`0 0 ${w} ${h}`} className="block h-10 w-full max-w-[240px]">
+      <polyline points={pts} fill="none" stroke="var(--primary)" strokeWidth="2" />
     </svg>
   );
 }
@@ -91,248 +97,248 @@ export default async function LabDetail({
   const lastScan = scans[0]?.scanned_at;
 
   return (
-    <>
-      <h2>
-        Lab: {lab.name}{" "}
-        <span className={`badge ${lab.online ? "online" : "offline"}`}>
-          {lab.online ? "online" : "offline"}
-        </span>
-      </h2>
+    <div className="space-y-4">
+      <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight">
+        Lab: {lab.name}
+        <Badge variant={lab.online ? "ok" : "err"}>{lab.online ? "online" : "offline"}</Badge>
+      </h1>
 
       {savedMsg && (
-        <div className="card" style={{ borderColor: "var(--accent)" }}>
-          <p style={{ margin: 0, color: "var(--accent)" }}>{savedMsg}</p>
-        </div>
+        <Card className="border-primary/50">
+          <CardContent>
+            <p className="text-sm text-primary">{savedMsg}</p>
+          </CardContent>
+        </Card>
       )}
 
-      <div className="card">
-        <p style={{ margin: 0 }}>
-          Node <b>{lab.node_name}</b> · PI {lab.pi_email ?? "—"} · image {lab.image} · SSH port{" "}
-          {lab.ssh_port ?? "—"} · status {lab.status}
-        </p>
-      </div>
-
-      <div style={{ display: "flex", gap: 16, flexWrap: "wrap" }}>
-        <div className="card" style={{ flex: 1, minWidth: 280 }}>
-          <h3 style={{ marginTop: 0 }}>Fast pool</h3>
-          <p>
-            {fmtBytes(fastNow?.used_bytes ?? 0)} / {fmtBytes(lab.fast_quota_bytes)}
-            {fastNow && pct(fastNow.used_bytes, lab.fast_quota_bytes) !== null
-              ? ` · ${pct(fastNow.used_bytes, lab.fast_quota_bytes)}%`
-              : ""}
+      <Card>
+        <CardContent>
+          <p className="text-sm">
+            Node <b>{lab.node_name}</b> · PI {lab.pi_email ?? "—"} · image {lab.image} · SSH port{" "}
+            {lab.ssh_port ?? "—"} · status {lab.status}
           </p>
-          <Sparkline values={fast.map((s) => s.used_bytes)} />
-        </div>
-        <div className="card" style={{ flex: 1, minWidth: 280 }}>
-          <h3 style={{ marginTop: 0 }}>Slow pool</h3>
-          <p>
-            {fmtBytes(slowNow?.used_bytes ?? 0)} / {fmtBytes(lab.slow_quota_bytes)}
-          </p>
-          <Sparkline values={slow.map((s) => s.used_bytes)} />
-        </div>
+        </CardContent>
+      </Card>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <Card>
+          <CardContent className="space-y-2">
+            <h3 className="text-base font-semibold">Fast pool</h3>
+            <p className="text-sm">
+              {fmtBytes(fastNow?.used_bytes ?? 0)} / {fmtBytes(lab.fast_quota_bytes)}
+              {fastNow && pct(fastNow.used_bytes, lab.fast_quota_bytes) !== null
+                ? ` · ${pct(fastNow.used_bytes, lab.fast_quota_bytes)}%`
+                : ""}
+            </p>
+            <Sparkline values={fast.map((s) => s.used_bytes)} />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="space-y-2">
+            <h3 className="text-base font-semibold">Slow pool</h3>
+            <p className="text-sm">
+              {fmtBytes(slowNow?.used_bytes ?? 0)} / {fmtBytes(lab.slow_quota_bytes)}
+            </p>
+            <Sparkline values={slow.map((s) => s.used_bytes)} />
+          </CardContent>
+        </Card>
       </div>
 
-      <div className="card">
-        <h3 style={{ marginTop: 0 }}>Quota (applies live)</h3>
-        <form action={setQuotaAction} style={{ display: "flex", gap: 12, alignItems: "end" }}>
-          <input type="hidden" name="labId" value={lab.id} />
-          <div>
-            <label>Fast (TB)</label>
-            <input name="fastTb" type="number" step="0.5" defaultValue={lab.fast_quota_bytes / TIB} />
-          </div>
-          <div>
-            <label>Slow (TB)</label>
-            <input name="slowTb" type="number" step="0.5" defaultValue={lab.slow_quota_bytes / TIB} />
-          </div>
-          <button type="submit" style={{ width: 140, marginTop: 0 }}>
-            Apply
-          </button>
-        </form>
-      </div>
+      <Card>
+        <CardContent className="space-y-3">
+          <h3 className="text-base font-semibold">Quota (applies live)</h3>
+          <form action={setQuotaAction} className="flex flex-wrap items-end gap-3">
+            <input type="hidden" name="labId" value={lab.id} />
+            <div>
+              <Label>Fast (TB)</Label>
+              <Input name="fastTb" type="number" step="0.5" defaultValue={lab.fast_quota_bytes / TIB} className="w-32" />
+            </div>
+            <div>
+              <Label>Slow (TB)</Label>
+              <Input name="slowTb" type="number" step="0.5" defaultValue={lab.slow_quota_bytes / TIB} className="w-32" />
+            </div>
+            <Button type="submit">Apply</Button>
+          </form>
+        </CardContent>
+      </Card>
 
-      <div className="card">
-        <h3 style={{ marginTop: 0 }}>Lab settings</h3>
-        <p className="muted" style={{ fontSize: 12, marginTop: 0 }}>
-          PI email is metadata. Changing the image or any container option recreates the container
-          (student data on the fast/slow pools is preserved). The node and SSH port can&apos;t change.
-        </p>
-        <form action={updateLabSettingsAction} style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12, maxWidth: 720 }}>
-          <input type="hidden" name="labId" value={lab.id} />
-          <div>
-            <label>PI email</label>
-            <input name="piEmail" type="email" defaultValue={lab.pi_email ?? ""} placeholder="pi@uga.edu" />
+      <Card>
+        <CardContent className="space-y-3">
+          <div className="space-y-1">
+            <h3 className="text-base font-semibold">Lab settings</h3>
+            <p className="text-xs text-muted-foreground">
+              PI email is metadata. Changing the image or any container option recreates the container
+              (student data on the fast/slow pools is preserved). The node and SSH port can&apos;t change.
+            </p>
           </div>
-          <div>
-            <label>Base image</label>
-            <input name="image" defaultValue={lab.image} />
-          </div>
-          <div></div>
-          <div>
-            <label>CPUs</label>
-            <input name="cpus" defaultValue={opts.cpus} />
-          </div>
-          <div>
-            <label>RAM</label>
-            <input name="memory" defaultValue={opts.memory} />
-          </div>
-          <div>
-            <label>Shared memory</label>
-            <input name="shmSize" defaultValue={opts.shm_size} />
-          </div>
-          <div>
-            <label>Image size quota</label>
-            <input name="imageQuota" defaultValue={opts.image_quota} />
-          </div>
-          <div>
-            <label>Restart policy</label>
-            <input name="restart" defaultValue={opts.restart} />
-          </div>
-          <div style={{ display: "flex", alignItems: "end" }}>
-            <button type="submit" style={{ width: 160, marginTop: 0 }}>
-              Save settings
-            </button>
-          </div>
-        </form>
-      </div>
+          <form action={updateLabSettingsAction} className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            <input type="hidden" name="labId" value={lab.id} />
+            <div>
+              <Label>PI email</Label>
+              <Input name="piEmail" type="email" defaultValue={lab.pi_email ?? ""} placeholder="pi@uga.edu" />
+            </div>
+            <div>
+              <Label>Base image</Label>
+              <Input name="image" defaultValue={lab.image} />
+            </div>
+            <div className="hidden lg:block" />
+            <div>
+              <Label>CPUs</Label>
+              <Input name="cpus" defaultValue={opts.cpus} />
+            </div>
+            <div>
+              <Label>RAM</Label>
+              <Input name="memory" defaultValue={opts.memory} />
+            </div>
+            <div>
+              <Label>Shared memory</Label>
+              <Input name="shmSize" defaultValue={opts.shm_size} />
+            </div>
+            <div>
+              <Label>Image size quota</Label>
+              <Input name="imageQuota" defaultValue={opts.image_quota} />
+            </div>
+            <div>
+              <Label>Restart policy</Label>
+              <Input name="restart" defaultValue={opts.restart} />
+            </div>
+            <div className="flex items-end">
+              <Button type="submit">Save settings</Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
 
-      <div className="card">
-        <h3 style={{ marginTop: 0 }}>Members</h3>
-        {newuser && pw && (
-          <div
-            style={{
-              background: "var(--panel-2)",
-              border: "1px solid var(--accent)",
-              borderRadius: 7,
-              padding: "10px 12px",
-              marginBottom: 12,
-            }}
-          >
-            Added <b>{newuser}</b> — password <code>{pw}</code>{" "}
-            <span className="muted">
-              (shown once{emailed ? "; also emailed" : "; SMTP not configured, not emailed"})
+      <Card>
+        <CardContent className="space-y-3">
+          <h3 className="text-base font-semibold">Members</h3>
+          {newuser && pw && (
+            <div className="rounded-md border border-primary/50 bg-primary/10 px-3 py-2.5 text-sm">
+              Added <b>{newuser}</b> — password{" "}
+              <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">{pw}</code>{" "}
+              <span className="text-muted-foreground">
+                (shown once{emailed ? "; also emailed" : "; SMTP not configured, not emailed"})
+              </span>
+            </div>
+          )}
+          <form action={addMemberAction} className="flex flex-wrap items-end gap-3">
+            <input type="hidden" name="labId" value={lab.id} />
+            <div>
+              <Label>Username</Label>
+              <Input name="username" required placeholder="alice" />
+            </div>
+            <div>
+              <Label>Email</Label>
+              <Input name="email" type="email" placeholder="alice@uga.edu" />
+            </div>
+            <div>
+              <Label>Name</Label>
+              <Input name="name" placeholder="Alice A." />
+            </div>
+            <Button type="submit">Add student</Button>
+          </form>
+          {members.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No students yet.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Username</TableHead>
+                  <TableHead>Email</TableHead>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Installed (container)</TableHead>
+                  <TableHead></TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {members.map((m) => (
+                  <TableRow key={m.member_id}>
+                    <TableCell>{m.username}</TableCell>
+                    <TableCell>{m.email ?? "—"}</TableCell>
+                    <TableCell>{m.name ?? "—"}</TableCell>
+                    <TableCell>{dockerUsed.has(m.username) ? fmtBytes(dockerUsed.get(m.username)!) : "—"}</TableCell>
+                    <TableCell className="text-right">
+                      <form action={removeMemberAction} className="flex items-center justify-end gap-2">
+                        <input type="hidden" name="labId" value={lab.id} />
+                        <input type="hidden" name="studentId" value={m.id} />
+                        <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                          <input type="checkbox" name="deleteData" className="accent-primary" /> delete data
+                        </label>
+                        <ConfirmButton
+                          variant="secondary"
+                          size="sm"
+                          confirm={`Remove ${m.username} from ${lab.name}? If "delete data" is checked, their files are permanently erased.`}
+                        >
+                          Remove
+                        </ConfirmButton>
+                      </form>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="space-y-3">
+          <h3 className="text-base font-semibold">Old files</h3>
+          <form action={rescanAction} className="flex items-center gap-3">
+            <input type="hidden" name="labId" value={lab.id} />
+            <Button type="submit">Rescan now</Button>
+            <span className="text-sm text-muted-foreground">
+              {lastScan ? `scanned ${ago(lastScan)}` : "never scanned"}
             </span>
-          </div>
-        )}
-        <form action={addMemberAction} style={{ display: "flex", gap: 10, alignItems: "end", marginBottom: 14, flexWrap: "wrap" }}>
-          <input type="hidden" name="labId" value={lab.id} />
-          <div>
-            <label>Username</label>
-            <input name="username" required placeholder="alice" />
-          </div>
-          <div>
-            <label>Email</label>
-            <input name="email" type="email" placeholder="alice@uga.edu" />
-          </div>
-          <div>
-            <label>Name</label>
-            <input name="name" placeholder="Alice A." />
-          </div>
-          <button type="submit" style={{ width: 130, marginTop: 0 }}>
-            Add student
-          </button>
-        </form>
-        {members.length === 0 ? (
-          <p className="muted">No students yet.</p>
-        ) : (
-          <table>
-            <thead>
-              <tr>
-                <th>Username</th>
-                <th>Email</th>
-                <th>Name</th>
-                <th>Installed (container)</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {members.map((m) => (
-                <tr key={m.member_id}>
-                  <td>{m.username}</td>
-                  <td>{m.email ?? "—"}</td>
-                  <td>{m.name ?? "—"}</td>
-                  <td>{dockerUsed.has(m.username) ? fmtBytes(dockerUsed.get(m.username)!) : "—"}</td>
-                  <td style={{ textAlign: "right" }}>
-                    <form action={removeMemberAction} style={{ display: "inline-flex", gap: 6, alignItems: "center" }}>
-                      <input type="hidden" name="labId" value={lab.id} />
-                      <input type="hidden" name="studentId" value={m.id} />
-                      <label className="muted" style={{ margin: 0, display: "inline-flex", gap: 4, alignItems: "center" }}>
-                        <input type="checkbox" name="deleteData" style={{ width: "auto" }} /> delete data
-                      </label>
-                      <ConfirmButton
-                        type="submit"
-                        className="secondary"
-                        style={{ width: "auto", marginTop: 0, padding: "6px 10px" }}
-                        confirm={`Remove ${m.username} from ${lab.name}? If "delete data" is checked, their files are permanently erased.`}
-                      >
-                        Remove
-                      </ConfirmButton>
-                    </form>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-      </div>
+          </form>
+          {scans.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No scan results yet.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Scope</TableHead>
+                  <TableHead>Old by atime</TableHead>
+                  <TableHead>Old by mtime</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {scans.map((s) => (
+                  <TableRow key={s.id}>
+                    <TableCell>{s.username ?? "lab"}</TableCell>
+                    <TableCell>
+                      {s.atime_count} files · {fmtBytes(s.atime_bytes)}
+                    </TableCell>
+                    <TableCell>
+                      {s.mtime_count} files · {fmtBytes(s.mtime_bytes)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
 
-      <div className="card">
-        <h3 style={{ marginTop: 0 }}>Old files</h3>
-        <form action={rescanAction} style={{ marginBottom: 12 }}>
-          <input type="hidden" name="labId" value={lab.id} />
-          <button type="submit" style={{ width: 140, marginTop: 0 }}>
-            Rescan now
-          </button>
-          <span className="muted" style={{ marginLeft: 12 }}>
-            {lastScan ? `scanned ${ago(lastScan)}` : "never scanned"}
-          </span>
-        </form>
-        {scans.length === 0 ? (
-          <p className="muted">No scan results yet.</p>
-        ) : (
-          <table>
-            <thead>
-              <tr>
-                <th>Scope</th>
-                <th>Old by atime</th>
-                <th>Old by mtime</th>
-              </tr>
-            </thead>
-            <tbody>
-              {scans.map((s) => (
-                <tr key={s.id}>
-                  <td>{s.username ?? "lab"}</td>
-                  <td>
-                    {s.atime_count} files · {fmtBytes(s.atime_bytes)}
-                  </td>
-                  <td>
-                    {s.mtime_count} files · {fmtBytes(s.mtime_bytes)}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-      </div>
-
-      <div className="card" style={{ display: "flex", gap: 12 }}>
-        <form action={recreateContainerAction}>
-          <input type="hidden" name="labId" value={lab.id} />
-          <button type="submit" className="secondary" style={{ width: 200, marginTop: 0 }}>
-            Recreate container
-          </button>
-        </form>
-        <form action={destroyLabAction}>
-          <input type="hidden" name="labId" value={lab.id} />
-          <ConfirmButton
-            type="submit"
-            className="danger"
-            style={{ width: 200, marginTop: 0 }}
-            confirm={`Destroy lab "${lab.name}"? This removes the container and ALL data (shared + every student), and deletes students that belong only to this lab. This cannot be undone.`}
-          >
-            Destroy lab + data
-          </ConfirmButton>
-        </form>
-      </div>
-    </>
+      <Card>
+        <CardContent className="flex flex-wrap gap-3">
+          <form action={recreateContainerAction}>
+            <input type="hidden" name="labId" value={lab.id} />
+            <Button type="submit" variant="secondary">
+              Recreate container
+            </Button>
+          </form>
+          <form action={destroyLabAction}>
+            <input type="hidden" name="labId" value={lab.id} />
+            <ConfirmButton
+              variant="destructive"
+              confirm={`Destroy lab "${lab.name}"? This removes the container and ALL data (shared + every student), and deletes students that belong only to this lab. This cannot be undone.`}
+            >
+              Destroy lab + data
+            </ConfirmButton>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/controller/src/app/(app)/labs/_components/CreateLabForm.tsx
+++ b/controller/src/app/(app)/labs/_components/CreateLabForm.tsx
@@ -1,6 +1,10 @@
 "use client";
 
 import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select } from "@/components/ui/select";
 
 export interface NodeOpt {
   id: number;
@@ -59,12 +63,12 @@ export function CreateLabForm({ nodes, labs, defaultFastTb, defaultSlowTb, actio
   const set = (patch: Partial<typeof cfg>) => setCfg((c) => ({ ...c, ...patch }));
 
   return (
-    <form action={action} style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12 }}>
+    <form action={action} className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {labs.length > 0 && (
-        <div style={{ gridColumn: "1 / -1", display: "flex", gap: 16, alignItems: "end", flexWrap: "wrap" }}>
-          <div style={{ flex: 1, minWidth: 220 }}>
-            <label>Copy configuration from</label>
-            <select
+        <div className="flex flex-wrap items-end gap-4 sm:col-span-2 lg:col-span-3">
+          <div className="min-w-[220px] flex-1">
+            <Label>Copy configuration from</Label>
+            <Select
               name="copyFromLabId"
               value={copyFrom}
               onChange={(e) => onCopyFromChange(Number(e.target.value))}
@@ -75,25 +79,24 @@ export function CreateLabForm({ nodes, labs, defaultFastTb, defaultSlowTb, actio
                   {l.name}
                 </option>
               ))}
-            </select>
+            </Select>
           </div>
           <label
-            className="muted"
-            style={{ margin: 0, display: "inline-flex", gap: 6, alignItems: "center", opacity: copyFrom ? 1 : 0.5 }}
+            className={`flex items-center gap-2 text-sm text-muted-foreground ${copyFrom ? "" : "opacity-50"}`}
           >
-            <input type="checkbox" name="copyStudents" disabled={!copyFrom} style={{ width: "auto" }} />
+            <input type="checkbox" name="copyStudents" disabled={!copyFrom} className="accent-primary" />
             Also enroll the same students
           </label>
         </div>
       )}
 
       <div>
-        <label>Name</label>
-        <input name="name" required placeholder="bio-x" />
+        <Label>Name</Label>
+        <Input name="name" required placeholder="bio-x" />
       </div>
       <div>
-        <label>Node</label>
-        <select name="nodeId" required defaultValue="">
+        <Label>Node</Label>
+        <Select name="nodeId" required defaultValue="">
           <option value="" disabled>
             Select node…
           </option>
@@ -102,19 +105,19 @@ export function CreateLabForm({ nodes, labs, defaultFastTb, defaultSlowTb, actio
               {n.name} {n.online ? "(online)" : "(offline)"}
             </option>
           ))}
-        </select>
+        </Select>
       </div>
       <div>
-        <label>PI email</label>
-        <input name="piEmail" type="email" placeholder="pi@uga.edu" />
+        <Label>PI email</Label>
+        <Input name="piEmail" type="email" placeholder="pi@uga.edu" />
       </div>
       <div>
-        <label>Base image</label>
-        <input name="image" value={cfg.image} onChange={(e) => set({ image: e.target.value })} />
+        <Label>Base image</Label>
+        <Input name="image" value={cfg.image} onChange={(e) => set({ image: e.target.value })} />
       </div>
       <div>
-        <label>Fast quota (TB)</label>
-        <input
+        <Label>Fast quota (TB)</Label>
+        <Input
           name="fastTb"
           type="number"
           step="0.5"
@@ -123,8 +126,8 @@ export function CreateLabForm({ nodes, labs, defaultFastTb, defaultSlowTb, actio
         />
       </div>
       <div>
-        <label>Slow quota (TB)</label>
-        <input
+        <Label>Slow quota (TB)</Label>
+        <Input
           name="slowTb"
           type="number"
           step="0.5"
@@ -132,36 +135,34 @@ export function CreateLabForm({ nodes, labs, defaultFastTb, defaultSlowTb, actio
           onChange={(e) => set({ slowTb: Number(e.target.value) })}
         />
       </div>
-      <div style={{ gridColumn: "1 / -1", marginTop: 4 }}>
-        <span className="muted" style={{ fontSize: 12 }}>
+      <div className="sm:col-span-2 lg:col-span-3">
+        <span className="text-xs text-muted-foreground">
           Container options below are set at creation; changing them later (from the lab page)
           recreates the container with data preserved. All GPUs are always attached.
         </span>
       </div>
       <div>
-        <label>CPUs</label>
-        <input name="cpus" value={cfg.cpus} onChange={(e) => set({ cpus: e.target.value })} />
+        <Label>CPUs</Label>
+        <Input name="cpus" value={cfg.cpus} onChange={(e) => set({ cpus: e.target.value })} />
       </div>
       <div>
-        <label>RAM</label>
-        <input name="memory" value={cfg.memory} onChange={(e) => set({ memory: e.target.value })} />
+        <Label>RAM</Label>
+        <Input name="memory" value={cfg.memory} onChange={(e) => set({ memory: e.target.value })} />
       </div>
       <div>
-        <label>Shared memory</label>
-        <input name="shmSize" value={cfg.shmSize} onChange={(e) => set({ shmSize: e.target.value })} />
+        <Label>Shared memory</Label>
+        <Input name="shmSize" value={cfg.shmSize} onChange={(e) => set({ shmSize: e.target.value })} />
       </div>
       <div>
-        <label>Image size quota</label>
-        <input name="imageQuota" value={cfg.imageQuota} onChange={(e) => set({ imageQuota: e.target.value })} />
+        <Label>Image size quota</Label>
+        <Input name="imageQuota" value={cfg.imageQuota} onChange={(e) => set({ imageQuota: e.target.value })} />
       </div>
       <div>
-        <label>Restart policy</label>
-        <input name="restart" value={cfg.restart} onChange={(e) => set({ restart: e.target.value })} />
+        <Label>Restart policy</Label>
+        <Input name="restart" value={cfg.restart} onChange={(e) => set({ restart: e.target.value })} />
       </div>
-      <div style={{ gridColumn: "1 / -1" }}>
-        <button type="submit" style={{ width: 160 }}>
-          Create lab
-        </button>
+      <div className="sm:col-span-2 lg:col-span-3">
+        <Button type="submit">Create lab</Button>
       </div>
     </form>
   );

--- a/controller/src/app/(app)/labs/page.tsx
+++ b/controller/src/app/(app)/labs/page.tsx
@@ -5,6 +5,9 @@ import { containerOptionsOf, listLabs } from "@/lib/labs";
 import { getSettings, TIB } from "@/lib/settings";
 import { createLabAction } from "./actions";
 import { CreateLabForm, type LabTemplate, type NodeOpt } from "./_components/CreateLabForm";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 
 export const dynamic = "force-dynamic";
 
@@ -46,80 +49,88 @@ export default async function LabsPage({
   });
 
   return (
-    <>
-      <h2>Labs</h2>
+    <div className="space-y-4">
+      <h1 className="text-2xl font-semibold tracking-tight">Labs</h1>
 
       {importedMsg && (
-        <div className="card" style={{ borderColor: "var(--accent)", marginBottom: 16 }}>
-          <p style={{ margin: 0, color: "var(--accent)" }}>{importedMsg}</p>
-        </div>
+        <Card className="border-primary/50">
+          <CardContent>
+            <p className="text-sm text-primary">{importedMsg}</p>
+          </CardContent>
+        </Card>
       )}
 
-      <div className="card">
-        <h3 style={{ marginTop: 0 }}>Create lab</h3>
-        {nodes.length === 0 ? (
-          <p className="muted">Connect a node first — a lab is pinned to one node.</p>
-        ) : (
-          <CreateLabForm
-            nodes={nodes}
-            labs={templates}
-            defaultFastTb={settings.fastQuotaDefaultBytes / TIB}
-            defaultSlowTb={settings.slowQuotaDefaultBytes / TIB}
-            action={createLabAction}
-          />
-        )}
-      </div>
+      <Card>
+        <CardContent className="space-y-3">
+          <h3 className="text-base font-semibold">Create lab</h3>
+          {nodes.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              Connect a node first — a lab is pinned to one node.
+            </p>
+          ) : (
+            <CreateLabForm
+              nodes={nodes}
+              labs={templates}
+              defaultFastTb={settings.fastQuotaDefaultBytes / TIB}
+              defaultSlowTb={settings.slowQuotaDefaultBytes / TIB}
+              action={createLabAction}
+            />
+          )}
+        </CardContent>
+      </Card>
 
-      <div className="card">
-        {labs.length === 0 ? (
-          <p className="muted">No labs yet.</p>
-        ) : (
-          <div className="table-wrap">
-          <table>
-            <thead>
-              <tr>
-                <th>Lab</th>
-                <th>Node</th>
-                <th>Fast</th>
-                <th>Slow</th>
-                <th>SSH</th>
-                <th>Status</th>
-              </tr>
-            </thead>
-            <tbody>
-              {labs.map((lab) => {
-                const fast = latestUsage(lab.id, "fast");
-                const slow = latestUsage(lab.id, "slow");
-                return (
-                  <tr key={lab.id}>
-                    <td>
-                      <a href={`/labs/${lab.id}`}>{lab.name}</a>
-                    </td>
-                    <td>
-                      {lab.node_name}{" "}
-                      <span className={`badge ${lab.online ? "online" : "offline"}`}>
-                        {lab.online ? "online" : "offline"}
-                      </span>
-                    </td>
-                    <td>
-                      {fmtBytes(fast?.used ?? 0)} / {fmtBytes(lab.fast_quota_bytes)}
-                      {fast && pct(fast.used, lab.fast_quota_bytes) !== null
-                        ? ` (${pct(fast.used, lab.fast_quota_bytes)}%)`
-                        : ""}
-                    </td>
-                    <td>
-                      {fmtBytes(slow?.used ?? 0)} / {fmtBytes(lab.slow_quota_bytes)}
-                    </td>
-                    <td>{lab.ssh_port ?? "—"}</td>
-                    <td>{lab.status}</td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-          </div>
-        )}
-      </div>
-    </>
+      <Card>
+        <CardContent>
+          {labs.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No labs yet.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Lab</TableHead>
+                  <TableHead>Node</TableHead>
+                  <TableHead>Fast</TableHead>
+                  <TableHead>Slow</TableHead>
+                  <TableHead>SSH</TableHead>
+                  <TableHead>Status</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {labs.map((lab) => {
+                  const fast = latestUsage(lab.id, "fast");
+                  const slow = latestUsage(lab.id, "slow");
+                  return (
+                    <TableRow key={lab.id}>
+                      <TableCell>
+                        <a href={`/labs/${lab.id}`} className="font-medium text-primary hover:underline">
+                          {lab.name}
+                        </a>
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap">
+                        {lab.node_name}{" "}
+                        <Badge variant={lab.online ? "ok" : "err"}>
+                          {lab.online ? "online" : "offline"}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap">
+                        {fmtBytes(fast?.used ?? 0)} / {fmtBytes(lab.fast_quota_bytes)}
+                        {fast && pct(fast.used, lab.fast_quota_bytes) !== null
+                          ? ` (${pct(fast.used, lab.fast_quota_bytes)}%)`
+                          : ""}
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap">
+                        {fmtBytes(slow?.used ?? 0)} / {fmtBytes(lab.slow_quota_bytes)}
+                      </TableCell>
+                      <TableCell>{lab.ssh_port ?? "—"}</TableCell>
+                      <TableCell>{lab.status}</TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/controller/src/app/(app)/layout.tsx
+++ b/controller/src/app/(app)/layout.tsx
@@ -1,8 +1,8 @@
 import { redirect } from "next/navigation";
 import type { ReactNode } from "react";
 import { clearSessionCookie, currentAdmin } from "@/lib/auth";
-import { NavLinks } from "./_components/NavLinks";
-import { ThemeToggle } from "./_components/ThemeToggle";
+import { MobileNav } from "./_components/MobileNav";
+import { SidebarContent } from "./_components/SidebarContent";
 
 // Authed pages read cookies/DB per request — never statically prerender them.
 export const dynamic = "force-dynamic";
@@ -17,23 +17,20 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
   const admin = await currentAdmin();
   if (!admin) redirect("/login");
   return (
-    <div className="layout">
-      <aside className="sidebar">
-        <h1>Lab Manager</h1>
-        <NavLinks />
-        <div className="sidebar-footer">
-          <form action={logout}>
-            <button type="submit" className="secondary">
-              Sign out
-            </button>
-          </form>
-          <ThemeToggle />
-          <p className="muted" style={{ marginTop: 16, fontSize: 12, wordBreak: "break-all" }}>
-            {admin.email}
-          </p>
-        </div>
+    <div className="min-h-screen">
+      {/* Fixed sidebar on desktop */}
+      <aside className="fixed inset-y-0 left-0 z-30 hidden w-64 border-r border-border bg-sidebar md:block">
+        <SidebarContent email={admin.email} logout={logout} />
       </aside>
-      <main className="content">{children}</main>
+
+      <div className="flex min-h-screen flex-col md:pl-64">
+        {/* Hamburger top bar on mobile; the same sidebar body slides in as a Sheet */}
+        <MobileNav>
+          <SidebarContent email={admin.email} logout={logout} />
+        </MobileNav>
+
+        <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-6 sm:px-6 lg:px-8">{children}</main>
+      </div>
     </div>
   );
 }

--- a/controller/src/app/(app)/logs/page.tsx
+++ b/controller/src/app/(app)/logs/page.tsx
@@ -1,5 +1,11 @@
 import { db } from "@/lib/db";
 import { ago } from "@/lib/format";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select } from "@/components/ui/select";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 
 export const dynamic = "force-dynamic";
 
@@ -52,93 +58,97 @@ export default async function LogsPage({
   }[]).map((r) => r.node);
 
   const color = (lvl: string) =>
-    lvl === "ERROR" ? "var(--err)" : lvl === "WARN" ? "var(--warn)" : "var(--muted)";
+    lvl === "ERROR" ? "text-err" : lvl === "WARN" ? "text-warn" : "text-muted-foreground";
 
   return (
-    <>
-      <h2>Logs</h2>
-      <div className="card">
-        <form method="get" style={{ display: "flex", gap: 10, alignItems: "end", flexWrap: "wrap" }}>
-          <div>
-            <label>Level</label>
-            <select name="level" defaultValue={level}>
-              {LEVELS.map((l) => (
-                <option key={l} value={l}>
-                  {l || "all"}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div>
-            <label>Node</label>
-            <select name="node" defaultValue={node}>
-              <option value="">all</option>
-              {nodes.map((n) => (
-                <option key={n} value={n}>
-                  {n}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div>
-            <label>Search</label>
-            <input name="q" defaultValue={q} placeholder="message / source" />
-          </div>
-          {task && <input type="hidden" name="task" value={task} />}
-          <button type="submit" style={{ width: 110, marginTop: 0 }}>
-            Filter
-          </button>
-          {(level || node || q || task) && (
-            <a href="/logs" style={{ marginBottom: 9 }}>
-              clear
-            </a>
-          )}
-        </form>
-        {task && <p className="muted">Filtered to task {task}</p>}
-      </div>
+    <div className="space-y-4">
+      <h1 className="text-2xl font-semibold tracking-tight">Logs</h1>
+      <Card>
+        <CardContent className="space-y-2">
+          <form method="get" className="flex flex-wrap items-end gap-3">
+            <div>
+              <Label>Level</Label>
+              <Select name="level" defaultValue={level} className="w-32">
+                {LEVELS.map((l) => (
+                  <option key={l} value={l}>
+                    {l || "all"}
+                  </option>
+                ))}
+              </Select>
+            </div>
+            <div>
+              <Label>Node</Label>
+              <Select name="node" defaultValue={node} className="w-40">
+                <option value="">all</option>
+                {nodes.map((n) => (
+                  <option key={n} value={n}>
+                    {n}
+                  </option>
+                ))}
+              </Select>
+            </div>
+            <div>
+              <Label>Search</Label>
+              <Input name="q" defaultValue={q} placeholder="message / source" />
+            </div>
+            {task && <input type="hidden" name="task" value={task} />}
+            <Button type="submit">Filter</Button>
+            {(level || node || q || task) && (
+              <a href="/logs" className="pb-2 text-sm text-primary hover:underline">
+                clear
+              </a>
+            )}
+          </form>
+          {task && <p className="text-sm text-muted-foreground">Filtered to task {task}</p>}
+        </CardContent>
+      </Card>
 
-      <div className="card">
-        {logs.length === 0 ? (
-          <p className="muted">No matching logs.</p>
-        ) : (
-          <div className="table-wrap">
-          <table>
-            <thead>
-              <tr>
-                <th>Time</th>
-                <th>Level</th>
-                <th>Node</th>
-                <th>Source</th>
-                <th>Message</th>
-                <th>Task</th>
-              </tr>
-            </thead>
-            <tbody>
-              {logs.map((l, i) => (
-                <tr key={i}>
-                  <td className="muted" title={new Date(l.ts).toISOString()}>
-                    {ago(l.ts)}
-                  </td>
-                  <td style={{ color: color(l.level), fontWeight: 600 }}>{l.level}</td>
-                  <td>{l.node ?? "—"}</td>
-                  <td>{l.source ?? "—"}</td>
-                  <td>{l.msg}</td>
-                  <td>
-                    {l.task_id ? (
-                      <a href={`/tasks/${encodeURIComponent(l.task_id)}`} title={l.task_id}>
-                        {l.task_id.slice(0, 8)}
-                      </a>
-                    ) : (
-                      "—"
-                    )}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-          </div>
-        )}
-      </div>
-    </>
+      <Card>
+        <CardContent>
+          {logs.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No matching logs.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Time</TableHead>
+                  <TableHead>Level</TableHead>
+                  <TableHead>Node</TableHead>
+                  <TableHead>Source</TableHead>
+                  <TableHead>Message</TableHead>
+                  <TableHead>Task</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {logs.map((l, i) => (
+                  <TableRow key={i}>
+                    <TableCell className="whitespace-nowrap text-muted-foreground" title={new Date(l.ts).toISOString()}>
+                      {ago(l.ts)}
+                    </TableCell>
+                    <TableCell className={`font-semibold ${color(l.level)}`}>{l.level}</TableCell>
+                    <TableCell>{l.node ?? "—"}</TableCell>
+                    <TableCell>{l.source ?? "—"}</TableCell>
+                    <TableCell>{l.msg}</TableCell>
+                    <TableCell>
+                      {l.task_id ? (
+                        <a
+                          href={`/tasks/${encodeURIComponent(l.task_id)}`}
+                          title={l.task_id}
+                          className="text-primary hover:underline"
+                        >
+                          {l.task_id.slice(0, 8)}
+                        </a>
+                      ) : (
+                        "—"
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/controller/src/app/(app)/nodes/page.tsx
+++ b/controller/src/app/(app)/nodes/page.tsx
@@ -1,5 +1,11 @@
 import { db } from "@/lib/db";
 import { ConfirmButton } from "../_components/ConfirmButton";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import {
   deleteNodeAction,
   provisionNodeAction,
@@ -94,168 +100,180 @@ export default async function NodesPage({
     .all() as NodeRow[];
 
   return (
-    <>
-      <h2>Nodes</h2>
+    <div className="space-y-4">
+      <h1 className="text-2xl font-semibold tracking-tight">Nodes</h1>
 
       {error && (
-        <div className="card" style={{ borderColor: "var(--warn)", marginBottom: 16 }}>
-          <p style={{ color: "var(--warn)" }}>{error}</p>
-        </div>
+        <Card className="border-warn/50">
+          <CardContent>
+            <p className="text-sm text-warn">{error}</p>
+          </CardContent>
+        </Card>
       )}
 
       {deleted && (
-        <div className="card" style={{ marginBottom: 16 }}>
-          <p className="muted">Node “{deleted}” was deleted.</p>
-        </div>
+        <Card>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">Node “{deleted}” was deleted.</p>
+          </CardContent>
+        </Card>
       )}
 
       {provisioned && token && (
-        <div className="card" style={{ borderColor: "var(--accent, #5fa0c2)", marginBottom: 16 }}>
-          <h3>Token for node “{provisioned}”</h3>
-          <p className="muted">Shown once. Run this on the node, then the agent reconnects automatically:</p>
-          <pre style={{ overflowX: "auto", padding: 12, background: "var(--panel-2)" }}>
-            <code>sudo lab-agent set-token {token}</code>
-          </pre>
-          <p className="muted" style={{ fontSize: 12 }}>
-            (Equivalent to writing the token into <code>/etc/lab-agent/config.toml</code> and running
-            <code> systemctl restart lab-agent</code>.)
-          </p>
-        </div>
+        <Card className="border-primary/50">
+          <CardContent className="space-y-2">
+            <h3 className="text-base font-semibold">Token for node “{provisioned}”</h3>
+            <p className="text-sm text-muted-foreground">
+              Shown once. Run this on the node, then the agent reconnects automatically:
+            </p>
+            <pre className="overflow-x-auto rounded-md bg-muted p-3 text-sm">
+              <code>sudo lab-agent set-token {token}</code>
+            </pre>
+            <p className="text-xs text-muted-foreground">
+              (Equivalent to writing the token into <code>/etc/lab-agent/config.toml</code> and running
+              <code> systemctl restart lab-agent</code>.)
+            </p>
+          </CardContent>
+        </Card>
       )}
 
-      <div className="card" style={{ marginBottom: 16 }}>
-        <h3>Register a node</h3>
-        <form action={provisionNodeAction} style={{ display: "flex", gap: 8, alignItems: "center" }}>
-          <input name="name" placeholder="node name (e.g. gpu-01)" required pattern="[a-z0-9][a-z0-9\-]{0,62}" />
-          <button type="submit">Provision token</button>
-        </form>
-        <p className="muted" style={{ fontSize: 12, marginTop: 8 }}>
-          Adds the node to the allow-list and issues a per-node token. Only allow-listed nodes may connect.
-        </p>
-      </div>
+      <Card>
+        <CardContent className="space-y-2">
+          <h3 className="text-base font-semibold">Register a node</h3>
+          <form action={provisionNodeAction} className="flex flex-wrap items-center gap-2">
+            <Input
+              name="name"
+              placeholder="node name (e.g. gpu-01)"
+              required
+              pattern="[a-z0-9][a-z0-9\-]{0,62}"
+              className="w-full sm:w-64"
+            />
+            <Button type="submit">Provision token</Button>
+          </form>
+          <p className="text-xs text-muted-foreground">
+            Adds the node to the allow-list and issues a per-node token. Only allow-listed nodes may
+            connect.
+          </p>
+        </CardContent>
+      </Card>
 
-      <div className="card">
-        {nodes.length === 0 ? (
-          <p className="muted">No nodes have connected yet.</p>
-        ) : (
-          <div className="table-wrap">
-          <table>
-            <thead>
-              <tr>
-                <th>Node</th>
-                <th>Status</th>
-                <th>Auth</th>
-                <th>GPUs</th>
-                <th>Pools</th>
-                <th>Cold storage</th>
-                <th>Scrub</th>
-                <th>Issues</th>
-                <th>Last seen</th>
-                <th>Token</th>
-              </tr>
-            </thead>
-            <tbody>
-              {nodes.map((n) => {
-                const caps = n.capabilities ? JSON.parse(n.capabilities) : {};
-                const pools = n.pools ? JSON.parse(n.pools) : [];
-                const scrub = scrubSummary(n.scrub_status);
-                const coldText =
-                  caps.slow_backend === "smb"
-                    ? `SMB${caps.slow_shared ? " (shared)" : ""}`
-                    : "ZFS";
-                return (
-                  <tr key={n.name}>
-                    <td>
-                      {n.alias ? (
-                        <>
-                          <div>{n.alias}</div>
-                          <div className="muted" style={{ fontSize: 12 }}>{n.name}</div>
-                        </>
-                      ) : (
-                        n.name
-                      )}
-                      <form
-                        action={setNodeAliasAction}
-                        style={{ display: "flex", gap: 4, marginTop: 6 }}
-                      >
-                        <input type="hidden" name="name" value={n.name} />
-                        <input
-                          name="alias"
-                          defaultValue={n.alias ?? ""}
-                          placeholder="alias"
-                          maxLength={64}
-                          style={{ width: 110, padding: "2px 6px", fontSize: 12 }}
-                        />
-                        <button
-                          type="submit"
-                          className="secondary"
-                          style={{ width: "auto", padding: "2px 8px", fontSize: 12 }}
-                        >
-                          Save
-                        </button>
-                      </form>
-                    </td>
-                    <td>
-                      <span className={`badge ${n.online ? "online" : "offline"}`}>
-                        {n.online ? "online" : "offline"}
-                      </span>
-                    </td>
-                    <td style={n.allowed !== 1 ? { color: "var(--warn)" } : undefined}>{authLabel(n)}</td>
-                    <td>{caps.gpu_count ?? 0}</td>
-                    <td>
-                      {pools.length === 0
-                        ? "—"
-                        : pools.map((p: any) => `${p.name}: ${fmtBytes(p.free)} free`).join(", ")}
-                    </td>
-                    <td>{coldText}</td>
-                    <td style={scrub.bad ? { color: "var(--warn)" } : undefined}>{scrub.text}</td>
-                    <td>
-                      {caps.issues && caps.issues.length > 0 ? (
-                        <span style={{ color: "var(--warn)" }}>{caps.issues.length}</span>
-                      ) : (
-                        "—"
-                      )}
-                    </td>
-                    <td className="muted">{ago(n.last_seen)}</td>
-                    <td style={{ whiteSpace: "nowrap" }}>
-                      <form action={rotateNodeTokenAction} style={{ display: "inline" }}>
-                        <input type="hidden" name="name" value={n.name} />
-                        <button type="submit" className="secondary" style={{ width: "auto", padding: "6px 12px" }}>
-                          Rotate
-                        </button>
-                      </form>{" "}
-                      {n.allowed === 1 && (
-                        <form action={revokeNodeAction} style={{ display: "inline" }}>
+      <Card>
+        <CardContent>
+          {nodes.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No nodes have connected yet.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Node</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Auth</TableHead>
+                  <TableHead>GPUs</TableHead>
+                  <TableHead>Pools</TableHead>
+                  <TableHead>Cold storage</TableHead>
+                  <TableHead>Scrub</TableHead>
+                  <TableHead>Issues</TableHead>
+                  <TableHead>Last seen</TableHead>
+                  <TableHead>Token</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {nodes.map((n) => {
+                  const caps = n.capabilities ? JSON.parse(n.capabilities) : {};
+                  const pools = n.pools ? JSON.parse(n.pools) : [];
+                  const scrub = scrubSummary(n.scrub_status);
+                  const coldText =
+                    caps.slow_backend === "smb"
+                      ? `SMB${caps.slow_shared ? " (shared)" : ""}`
+                      : "ZFS";
+                  return (
+                    <TableRow key={n.name}>
+                      <TableCell>
+                        {n.alias ? (
+                          <>
+                            <div>{n.alias}</div>
+                            <div className="text-xs text-muted-foreground">{n.name}</div>
+                          </>
+                        ) : (
+                          n.name
+                        )}
+                        <form action={setNodeAliasAction} className="mt-1.5 flex gap-1">
                           <input type="hidden" name="name" value={n.name} />
-                          <button
-                            type="submit"
-                            className="secondary"
-                            style={{ width: "auto", padding: "6px 12px", color: "var(--warn)" }}
-                          >
-                            Revoke
-                          </button>
+                          <Input
+                            name="alias"
+                            defaultValue={n.alias ?? ""}
+                            placeholder="alias"
+                            maxLength={64}
+                            className="h-7 w-28 text-xs"
+                          />
+                          <Button type="submit" variant="secondary" size="sm" className="h-7">
+                            Save
+                          </Button>
                         </form>
-                      )}{" "}
-                      <form action={deleteNodeAction} style={{ display: "inline" }}>
-                        <input type="hidden" name="name" value={n.name} />
-                        <ConfirmButton
-                          type="submit"
-                          className="secondary"
-                          style={{ width: "auto", padding: "6px 12px", color: "var(--warn)" }}
-                          confirm={`Delete node "${n.name}"? This removes it from the controller (it fails if any labs are still pinned to it).`}
-                        >
-                          Delete
-                        </ConfirmButton>
-                      </form>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-          </div>
-        )}
-      </div>
-    </>
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant={n.online ? "ok" : "err"}>
+                          {n.online ? "online" : "offline"}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className={n.allowed !== 1 ? "text-warn" : undefined}>
+                        {authLabel(n)}
+                      </TableCell>
+                      <TableCell>{caps.gpu_count ?? 0}</TableCell>
+                      <TableCell>
+                        {pools.length === 0
+                          ? "—"
+                          : pools.map((p: any) => `${p.name}: ${fmtBytes(p.free)} free`).join(", ")}
+                      </TableCell>
+                      <TableCell>{coldText}</TableCell>
+                      <TableCell className={scrub.bad ? "text-warn" : undefined}>{scrub.text}</TableCell>
+                      <TableCell>
+                        {caps.issues && caps.issues.length > 0 ? (
+                          <span className="text-warn">{caps.issues.length}</span>
+                        ) : (
+                          "—"
+                        )}
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap text-muted-foreground">
+                        {ago(n.last_seen)}
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap">
+                        <div className="flex gap-1.5">
+                          <form action={rotateNodeTokenAction}>
+                            <input type="hidden" name="name" value={n.name} />
+                            <Button type="submit" variant="secondary" size="sm">
+                              Rotate
+                            </Button>
+                          </form>
+                          {n.allowed === 1 && (
+                            <form action={revokeNodeAction}>
+                              <input type="hidden" name="name" value={n.name} />
+                              <Button type="submit" variant="secondary" size="sm" className="text-warn">
+                                Revoke
+                              </Button>
+                            </form>
+                          )}
+                          <form action={deleteNodeAction}>
+                            <input type="hidden" name="name" value={n.name} />
+                            <ConfirmButton
+                              variant="secondary"
+                              size="sm"
+                              className="text-err"
+                              confirm={`Delete node "${n.name}"? This removes it from the controller (it fails if any labs are still pinned to it).`}
+                            >
+                              Delete
+                            </ConfirmButton>
+                          </form>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/controller/src/app/(app)/settings/actions.ts
+++ b/controller/src/app/(app)/settings/actions.ts
@@ -108,6 +108,16 @@ export async function saveGpuPolicyAction(formData: FormData) {
   revalidatePath("/settings");
 }
 
+export async function saveGpuEmailsAction(formData: FormData) {
+  await requireAdmin();
+  // Empty falls back to the built-in default at render time, so store the trimmed value as-is.
+  setSetting("gpuWarnEmailSubject", String(formData.get("gpuWarnEmailSubject") ?? "").trim());
+  setSetting("gpuWarnEmailBody", String(formData.get("gpuWarnEmailBody") ?? ""));
+  setSetting("gpuKillEmailSubject", String(formData.get("gpuKillEmailSubject") ?? "").trim());
+  setSetting("gpuKillEmailBody", String(formData.get("gpuKillEmailBody") ?? ""));
+  revalidatePath("/settings");
+}
+
 export async function saveScrubSettingsAction(formData: FormData) {
   await requireAdmin();
   setSetting("scrubEnabled", formData.get("scrubEnabled") === "on");

--- a/controller/src/app/(app)/settings/page.tsx
+++ b/controller/src/app/(app)/settings/page.tsx
@@ -1,5 +1,5 @@
 import { listBackups } from "@/lib/backup";
-import { getSettings, isWebdavConfigured, TIB, WELCOME_EMAIL_VARS } from "@/lib/settings";
+import { getSettings, GPU_EMAIL_VARS, isWebdavConfigured, TIB, WELCOME_EMAIL_VARS } from "@/lib/settings";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -11,6 +11,7 @@ import {
   backupNowAction,
   restoreAction,
   saveAlertSettingsAction,
+  saveGpuEmailsAction,
   saveGpuPolicyAction,
   saveScrubSettingsAction,
   saveSmtpSettingsAction,
@@ -222,6 +223,50 @@ export default async function SettingsPage({
             </div>
             <div className="sm:col-span-2">
               <Button type="submit">Save &amp; push to nodes</Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="space-y-3">
+          <div className="space-y-1">
+            <h3 className="text-base font-semibold">GPU notification emails</h3>
+            <p className="text-xs text-muted-foreground">
+              Emailed to a student (with an email on file) when the idle killer warns about or
+              terminates their GPU process. Use <code>{"{placeholder}"}</code> tokens below; unknown
+              tokens are left as-is. Leave a field blank to use the built-in default.
+            </p>
+          </div>
+          <form action={saveGpuEmailsAction} className="grid max-w-2xl gap-3">
+            <div>
+              <Label>Warning email subject</Label>
+              <Input name="gpuWarnEmailSubject" defaultValue={s.gpuWarnEmailSubject} />
+            </div>
+            <div>
+              <Label>Warning email body</Label>
+              <Textarea name="gpuWarnEmailBody" rows={8} defaultValue={s.gpuWarnEmailBody} className="font-mono text-xs" />
+            </div>
+            <div>
+              <Label>Termination email subject</Label>
+              <Input name="gpuKillEmailSubject" defaultValue={s.gpuKillEmailSubject} />
+            </div>
+            <div>
+              <Label>Termination email body</Label>
+              <Textarea name="gpuKillEmailBody" rows={8} defaultValue={s.gpuKillEmailBody} className="font-mono text-xs" />
+            </div>
+            <div>
+              <Label>Available variables</Label>
+              <ul className="m-0 list-disc pl-5 text-xs text-muted-foreground">
+                {GPU_EMAIL_VARS.map((v) => (
+                  <li key={v.key}>
+                    <code>{`{${v.key}}`}</code> — {v.desc}
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <Button type="submit">Save GPU emails</Button>
             </div>
           </form>
         </CardContent>

--- a/controller/src/app/(app)/settings/page.tsx
+++ b/controller/src/app/(app)/settings/page.tsx
@@ -1,5 +1,12 @@
 import { listBackups } from "@/lib/backup";
 import { getSettings, isWebdavConfigured, TIB, WELCOME_EMAIL_VARS } from "@/lib/settings";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import {
   backupNowAction,
   restoreAction,
@@ -47,329 +54,326 @@ export default async function SettingsPage({
     }
   }
   return (
-    <>
-      <h2>Settings</h2>
+    <div className="space-y-4">
+      <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
 
-      <div className="card">
-        <h3 style={{ marginTop: 0 }}>Storage & ports</h3>
-        <form action={saveStorageSettingsAction} style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 12, maxWidth: 520 }}>
-          <div>
-            <label>Default fast quota (TB)</label>
-            <input name="fastTb" type="number" step="0.5" defaultValue={s.fastQuotaDefaultBytes / TIB} />
-          </div>
-          <div>
-            <label>Default slow quota (TB)</label>
-            <input name="slowTb" type="number" step="0.5" defaultValue={s.slowQuotaDefaultBytes / TIB} />
-          </div>
-          <div>
-            <label>SSH port range start</label>
-            <input name="sshPortStart" type="number" defaultValue={s.sshPortStart} />
-          </div>
-          <div>
-            <label>SSH port range end</label>
-            <input name="sshPortEnd" type="number" defaultValue={s.sshPortEnd} />
-          </div>
-          <div>
-            <label>Old-file threshold (days)</label>
-            <input name="oldFileThresholdDays" type="number" defaultValue={s.oldFileThresholdDays} />
-          </div>
-          <div>
-            <label>Old-file scan interval (days)</label>
-            <input name="oldFileScanIntervalDays" type="number" defaultValue={s.oldFileScanIntervalDays} />
-          </div>
-          <div style={{ gridColumn: "1 / -1" }}>
-            <label style={{ display: "inline-flex", gap: 6, alignItems: "center" }}>
-              <input
-                type="checkbox"
-                name="oldFileScanEnabled"
-                defaultChecked={s.oldFileScanEnabled}
-                style={{ width: "auto" }}
-              />
-              Run nightly old-file scans automatically
-            </label>
-          </div>
-          <div style={{ gridColumn: "1 / -1" }}>
-            <button type="submit" style={{ width: 140 }}>
-              Save
-            </button>
-          </div>
-        </form>
-      </div>
+      <Card>
+        <CardContent className="space-y-3">
+          <h3 className="text-base font-semibold">Storage &amp; ports</h3>
+          <form action={saveStorageSettingsAction} className="grid max-w-xl grid-cols-1 gap-3 sm:grid-cols-2">
+            <div>
+              <Label>Default fast quota (TB)</Label>
+              <Input name="fastTb" type="number" step="0.5" defaultValue={s.fastQuotaDefaultBytes / TIB} />
+            </div>
+            <div>
+              <Label>Default slow quota (TB)</Label>
+              <Input name="slowTb" type="number" step="0.5" defaultValue={s.slowQuotaDefaultBytes / TIB} />
+            </div>
+            <div>
+              <Label>SSH port range start</Label>
+              <Input name="sshPortStart" type="number" defaultValue={s.sshPortStart} />
+            </div>
+            <div>
+              <Label>SSH port range end</Label>
+              <Input name="sshPortEnd" type="number" defaultValue={s.sshPortEnd} />
+            </div>
+            <div>
+              <Label>Old-file threshold (days)</Label>
+              <Input name="oldFileThresholdDays" type="number" defaultValue={s.oldFileThresholdDays} />
+            </div>
+            <div>
+              <Label>Old-file scan interval (days)</Label>
+              <Input name="oldFileScanIntervalDays" type="number" defaultValue={s.oldFileScanIntervalDays} />
+            </div>
+            <div className="sm:col-span-2">
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  name="oldFileScanEnabled"
+                  defaultChecked={s.oldFileScanEnabled}
+                  className="accent-primary"
+                />
+                Run nightly old-file scans automatically
+              </label>
+            </div>
+            <div className="sm:col-span-2">
+              <Button type="submit">Save</Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
 
-      <div className="card">
-        <h3 style={{ marginTop: 0 }}>Email (external SMTP)</h3>
-        {smtp && <p style={{ color: "var(--accent)" }}>{smtp}</p>}
-        <form action={saveSmtpSettingsAction} style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 12, maxWidth: 520 }}>
-          <div>
-            <label>SMTP host</label>
-            <input name="smtpHost" defaultValue={s.smtpHost} placeholder="https://smtp.uga.edu:465" />
-            <small style={{ color: "var(--muted)" }}>
-              Use https:// (or port 465) for implicit TLS; http:// for STARTTLS.
-            </small>
-          </div>
-          <div>
-            <label>Port</label>
-            <input name="smtpPort" type="number" defaultValue={s.smtpPort} />
-          </div>
-          <div>
-            <label>Username</label>
-            <input name="smtpUser" defaultValue={s.smtpUser} />
-          </div>
-          <div>
-            <label>Password</label>
-            <input name="smtpPass" type="password" placeholder={s.smtpPass ? "•••••• (unchanged)" : ""} />
-          </div>
-          <div>
-            <label>From address</label>
-            <input name="smtpFrom" defaultValue={s.smtpFrom} placeholder="labs@uga.edu" />
-          </div>
-          <div>
-            <label>SSH host override (optional)</label>
-            <input name="sshHostOverride" defaultValue={s.sshHostOverride} placeholder="gpu.uga.edu" />
-          </div>
-          <div style={{ gridColumn: "1 / -1" }}>
-            <button type="submit" style={{ width: 140 }}>
-              Save SMTP
-            </button>
-          </div>
-        </form>
-        <form action={testEmailAction} style={{ display: "flex", gap: 10, alignItems: "end", marginTop: 12 }}>
-          <div>
-            <label>Send test email to</label>
-            <input name="to" type="email" placeholder="you@uga.edu" />
-          </div>
-          <button type="submit" className="secondary" style={{ width: 140, marginTop: 0 }}>
-            Send test
-          </button>
-        </form>
-      </div>
+      <Card>
+        <CardContent className="space-y-3">
+          <h3 className="text-base font-semibold">Email (external SMTP)</h3>
+          {smtp && <p className="text-sm text-primary">{smtp}</p>}
+          <form action={saveSmtpSettingsAction} className="grid max-w-xl grid-cols-1 gap-3 sm:grid-cols-2">
+            <div>
+              <Label>SMTP host</Label>
+              <Input name="smtpHost" defaultValue={s.smtpHost} placeholder="https://smtp.uga.edu:465" />
+              <small className="text-xs text-muted-foreground">
+                Use https:// (or port 465) for implicit TLS; http:// for STARTTLS.
+              </small>
+            </div>
+            <div>
+              <Label>Port</Label>
+              <Input name="smtpPort" type="number" defaultValue={s.smtpPort} />
+            </div>
+            <div>
+              <Label>Username</Label>
+              <Input name="smtpUser" defaultValue={s.smtpUser} />
+            </div>
+            <div>
+              <Label>Password</Label>
+              <Input name="smtpPass" type="password" placeholder={s.smtpPass ? "•••••• (unchanged)" : ""} />
+            </div>
+            <div>
+              <Label>From address</Label>
+              <Input name="smtpFrom" defaultValue={s.smtpFrom} placeholder="labs@uga.edu" />
+            </div>
+            <div>
+              <Label>SSH host override (optional)</Label>
+              <Input name="sshHostOverride" defaultValue={s.sshHostOverride} placeholder="gpu.uga.edu" />
+            </div>
+            <div className="sm:col-span-2">
+              <Button type="submit">Save SMTP</Button>
+            </div>
+          </form>
+          <form action={testEmailAction} className="flex flex-wrap items-end gap-3">
+            <div>
+              <Label>Send test email to</Label>
+              <Input name="to" type="email" placeholder="you@uga.edu" />
+            </div>
+            <Button type="submit" variant="secondary">
+              Send test
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
 
-      <div className="card">
-        <h3 style={{ marginTop: 0 }}>Welcome email template</h3>
-        <p className="muted" style={{ fontSize: 12, marginTop: 0 }}>
-          Sent to a student (with an email on file) when they are added to a lab. Use{" "}
-          <code>{"{placeholder}"}</code> tokens below; unknown tokens are left as-is. Leave a field
-          blank to use the built-in default.
-        </p>
-        <form action={saveWelcomeEmailAction} style={{ display: "grid", gap: 12, maxWidth: 640 }}>
-          <div>
-            <label>Subject</label>
-            <input name="welcomeEmailSubject" defaultValue={s.welcomeEmailSubject} />
-          </div>
-          <div>
-            <label>Body</label>
-            <textarea
-              name="welcomeEmailBody"
-              rows={16}
-              defaultValue={s.welcomeEmailBody}
-              style={{ fontFamily: "var(--font-mono, monospace)", fontSize: 13, width: "100%" }}
-            />
-          </div>
-          <div>
-            <label style={{ marginBottom: 4 }}>Available variables</label>
-            <ul style={{ margin: 0, paddingLeft: 18, fontSize: 12, color: "var(--muted)" }}>
-              {WELCOME_EMAIL_VARS.map((v) => (
-                <li key={v.key}>
-                  <code>{`{${v.key}}`}</code> — {v.desc}
-                </li>
-              ))}
-            </ul>
-          </div>
-          <div>
-            <button type="submit" style={{ width: 180 }}>
-              Save template
-            </button>
-          </div>
-        </form>
-      </div>
-
-      <div className="card">
-        <h3 style={{ marginTop: 0 }}>GPU idle policy</h3>
-        <form action={saveGpuPolicyAction} style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 12, maxWidth: 520 }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <input type="checkbox" name="gpuEnabled" defaultChecked={s.gpuEnabled} style={{ width: "auto" }} />
-            <label style={{ margin: 0 }}>Enable idle killer</label>
-          </div>
-          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <input type="checkbox" name="gpuImmediate" defaultChecked={s.gpuImmediate} style={{ width: "auto" }} />
-            <label style={{ margin: 0 }}>Kill immediately (no grace)</label>
-          </div>
-          <div>
-            <label>Idle util threshold (%)</label>
-            <input name="gpuUtilThreshold" type="number" defaultValue={s.gpuUtilThreshold} />
-          </div>
-          <div>
-            <label>Idle minutes before warning</label>
-            <input name="gpuIdleMinutes" type="number" defaultValue={s.gpuIdleMinutes} />
-          </div>
-          <div>
-            <label>Grace minutes before kill</label>
-            <input name="gpuGraceMinutes" type="number" defaultValue={s.gpuGraceMinutes} />
-          </div>
-          <div></div>
-          <div>
-            <label>Whitelist users (comma-sep)</label>
-            <input name="gpuWhitelistUsers" defaultValue={s.gpuWhitelistUsers} placeholder="alice,bob" />
-          </div>
-          <div>
-            <label>Whitelist labs (comma-sep)</label>
-            <input name="gpuWhitelistLabs" defaultValue={s.gpuWhitelistLabs} placeholder="bio,chem" />
-          </div>
-          <div style={{ gridColumn: "1 / -1" }}>
-            <button type="submit" style={{ width: 200 }}>
-              Save & push to nodes
-            </button>
-          </div>
-        </form>
-      </div>
-
-      <div className="card">
-        <h3 style={{ marginTop: 0 }}>Alerts & logs</h3>
-        <form action={saveAlertSettingsAction} style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 12, maxWidth: 520 }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <input type="checkbox" name="alertsEnabled" defaultChecked={s.alertsEnabled} style={{ width: "auto" }} />
-            <label style={{ margin: 0 }}>Email admins on alerts</label>
-          </div>
-          <div>
-            <label>Alert at log level</label>
-            <select name="alertLevel" defaultValue={s.alertLevel}>
-              <option value="WARN">WARN and above</option>
-              <option value="ERROR">ERROR only</option>
-            </select>
-          </div>
-          <div>
-            <label>Dedup window (minutes)</label>
-            <input name="alertDedupMinutes" type="number" defaultValue={s.alertDedupMinutes} />
-          </div>
-          <div>
-            <label>Quota alert at (%)</label>
-            <input name="quotaAlertPct" type="number" defaultValue={s.quotaAlertPct} />
-          </div>
-          <div>
-            <label>Node offline grace (seconds)</label>
-            <input name="nodeOfflineGraceSeconds" type="number" min={0} defaultValue={s.nodeOfflineGraceSeconds} />
-          </div>
-          <div>
-            <label>Log retention (days)</label>
-            <input name="logRetentionDays" type="number" defaultValue={s.logRetentionDays} />
-          </div>
-          <div style={{ gridColumn: "1 / -1" }}>
-            <button type="submit" style={{ width: 140 }}>
-              Save alerts
-            </button>
-          </div>
-        </form>
-      </div>
-
-      <div className="card">
-        <h3 style={{ marginTop: 0 }}>ZFS scrub</h3>
-        {scrub && <p style={{ color: "var(--accent)" }}>{scrub}</p>}
-        <p className="muted" style={{ fontSize: 12, marginTop: 0 }}>
-          Scrubs run on ZFS-capable nodes. Cold storage on an SMB mount is the share owner&apos;s
-          responsibility and is never scrubbed. Errors found during a scrub raise an admin alert.
-        </p>
-        <form action={saveScrubSettingsAction} style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 12, maxWidth: 520 }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <input type="checkbox" name="scrubEnabled" defaultChecked={s.scrubEnabled} style={{ width: "auto" }} />
-            <label style={{ margin: 0 }}>Enable scheduled scrubs</label>
-          </div>
-          <div>
-            <label>Scrub every (days)</label>
-            <input name="scrubIntervalDays" type="number" defaultValue={s.scrubIntervalDays} />
-          </div>
-          <div>
-            <label>Start at hour (0–23)</label>
-            <input name="scrubHour" type="number" min={0} max={23} defaultValue={s.scrubHour} />
-          </div>
-          <div>
-            <label>Timezone</label>
-            <input name="scrubTimezone" defaultValue={s.scrubTimezone} list="scrub-tz-list" placeholder="UTC" />
-            <datalist id="scrub-tz-list">
-              {COMMON_TIMEZONES.map((tz) => (
-                <option key={tz} value={tz} />
-              ))}
-            </datalist>
-          </div>
-          <div style={{ gridColumn: "1 / -1" }}>
-            <button type="submit" style={{ width: 140 }}>
-              Save scrub
-            </button>
-          </div>
-        </form>
-        <form action={scrubNowAction} style={{ marginTop: 12 }}>
-          <button type="submit" className="secondary" style={{ width: 140, marginTop: 0 }}>
-            Scrub now
-          </button>
-        </form>
-      </div>
-
-      <div className="card">
-        <h3 style={{ marginTop: 0 }}>WebDAV backup</h3>
-        {backup && <p style={{ color: "var(--accent)" }}>{backup}</p>}
-        <form action={saveWebdavSettingsAction} style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 12, maxWidth: 520 }}>
-          <div style={{ gridColumn: "1 / -1" }}>
-            <label>WebDAV base URL</label>
-            <input name="webdavUrl" defaultValue={s.webdavUrl} placeholder="https://dav.example.com/labmgr" />
-          </div>
-          <div>
-            <label>Username</label>
-            <input name="webdavUser" defaultValue={s.webdavUser} />
-          </div>
-          <div>
-            <label>Password</label>
-            <input name="webdavPass" type="password" placeholder={s.webdavPass ? "•••••• (unchanged)" : ""} />
-          </div>
-          <div>
-            <label>Keep last N backups</label>
-            <input name="webdavRetention" type="number" defaultValue={s.webdavRetention} />
-          </div>
-          <div>
-            <label>Backup every (hours, 0=off)</label>
-            <input name="backupIntervalHours" type="number" defaultValue={s.backupIntervalHours} />
-          </div>
-          <div style={{ gridColumn: "1 / -1" }}>
-            <button type="submit" style={{ width: 140 }}>
-              Save WebDAV
-            </button>
-          </div>
-        </form>
-        <form action={backupNowAction} style={{ marginTop: 12 }}>
-          <button type="submit" className="secondary" style={{ width: 140, marginTop: 0 }}>
-            Back up now
-          </button>
-        </form>
-        {backups.length > 0 && (
-          <div style={{ marginTop: 14 }}>
-            <h4 style={{ margin: "0 0 6px" }}>Restore</h4>
-            <table>
-              <thead>
-                <tr>
-                  <th>Backup</th>
-                  <th></th>
-                </tr>
-              </thead>
-              <tbody>
-                {backups.map((b) => (
-                  <tr key={b}>
-                    <td>{b}</td>
-                    <td style={{ textAlign: "right" }}>
-                      <form action={restoreAction}>
-                        <input type="hidden" name="name" value={b} />
-                        <button type="submit" className="secondary" style={{ width: "auto", marginTop: 0, padding: "6px 10px" }}>
-                          Stage restore
-                        </button>
-                      </form>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-            <p className="muted" style={{ fontSize: 12 }}>
-              Staging a restore takes effect after the controller restarts.
+      <Card>
+        <CardContent className="space-y-3">
+          <div className="space-y-1">
+            <h3 className="text-base font-semibold">Welcome email template</h3>
+            <p className="text-xs text-muted-foreground">
+              Sent to a student (with an email on file) when they are added to a lab. Use{" "}
+              <code>{"{placeholder}"}</code> tokens below; unknown tokens are left as-is. Leave a field
+              blank to use the built-in default.
             </p>
           </div>
-        )}
-      </div>
-    </>
+          <form action={saveWelcomeEmailAction} className="grid max-w-2xl gap-3">
+            <div>
+              <Label>Subject</Label>
+              <Input name="welcomeEmailSubject" defaultValue={s.welcomeEmailSubject} />
+            </div>
+            <div>
+              <Label>Body</Label>
+              <Textarea name="welcomeEmailBody" rows={16} defaultValue={s.welcomeEmailBody} className="font-mono text-xs" />
+            </div>
+            <div>
+              <Label>Available variables</Label>
+              <ul className="m-0 list-disc pl-5 text-xs text-muted-foreground">
+                {WELCOME_EMAIL_VARS.map((v) => (
+                  <li key={v.key}>
+                    <code>{`{${v.key}}`}</code> — {v.desc}
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <Button type="submit">Save template</Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="space-y-3">
+          <h3 className="text-base font-semibold">GPU idle policy</h3>
+          <form action={saveGpuPolicyAction} className="grid max-w-xl grid-cols-1 gap-3 sm:grid-cols-2">
+            <label className="flex items-center gap-2 text-sm">
+              <input type="checkbox" name="gpuEnabled" defaultChecked={s.gpuEnabled} className="accent-primary" />
+              Enable idle killer
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input type="checkbox" name="gpuImmediate" defaultChecked={s.gpuImmediate} className="accent-primary" />
+              Kill immediately (no grace)
+            </label>
+            <div>
+              <Label>Idle util threshold (%)</Label>
+              <Input name="gpuUtilThreshold" type="number" defaultValue={s.gpuUtilThreshold} />
+            </div>
+            <div>
+              <Label>Idle minutes before warning</Label>
+              <Input name="gpuIdleMinutes" type="number" defaultValue={s.gpuIdleMinutes} />
+            </div>
+            <div>
+              <Label>Grace minutes before kill</Label>
+              <Input name="gpuGraceMinutes" type="number" defaultValue={s.gpuGraceMinutes} />
+            </div>
+            <div />
+            <div>
+              <Label>Whitelist users (comma-sep)</Label>
+              <Input name="gpuWhitelistUsers" defaultValue={s.gpuWhitelistUsers} placeholder="alice,bob" />
+            </div>
+            <div>
+              <Label>Whitelist labs (comma-sep)</Label>
+              <Input name="gpuWhitelistLabs" defaultValue={s.gpuWhitelistLabs} placeholder="bio,chem" />
+            </div>
+            <div className="sm:col-span-2">
+              <Button type="submit">Save &amp; push to nodes</Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="space-y-3">
+          <h3 className="text-base font-semibold">Alerts &amp; logs</h3>
+          <form action={saveAlertSettingsAction} className="grid max-w-xl grid-cols-1 gap-3 sm:grid-cols-2">
+            <label className="flex items-center gap-2 text-sm">
+              <input type="checkbox" name="alertsEnabled" defaultChecked={s.alertsEnabled} className="accent-primary" />
+              Email admins on alerts
+            </label>
+            <div>
+              <Label>Alert at log level</Label>
+              <Select name="alertLevel" defaultValue={s.alertLevel}>
+                <option value="WARN">WARN and above</option>
+                <option value="ERROR">ERROR only</option>
+              </Select>
+            </div>
+            <div>
+              <Label>Dedup window (minutes)</Label>
+              <Input name="alertDedupMinutes" type="number" defaultValue={s.alertDedupMinutes} />
+            </div>
+            <div>
+              <Label>Quota alert at (%)</Label>
+              <Input name="quotaAlertPct" type="number" defaultValue={s.quotaAlertPct} />
+            </div>
+            <div>
+              <Label>Node offline grace (seconds)</Label>
+              <Input name="nodeOfflineGraceSeconds" type="number" min={0} defaultValue={s.nodeOfflineGraceSeconds} />
+            </div>
+            <div>
+              <Label>Log retention (days)</Label>
+              <Input name="logRetentionDays" type="number" defaultValue={s.logRetentionDays} />
+            </div>
+            <div className="sm:col-span-2">
+              <Button type="submit">Save alerts</Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="space-y-3">
+          <h3 className="text-base font-semibold">ZFS scrub</h3>
+          {scrub && <p className="text-sm text-primary">{scrub}</p>}
+          <p className="text-xs text-muted-foreground">
+            Scrubs run on ZFS-capable nodes. Cold storage on an SMB mount is the share owner&apos;s
+            responsibility and is never scrubbed. Errors found during a scrub raise an admin alert.
+          </p>
+          <form action={saveScrubSettingsAction} className="grid max-w-xl grid-cols-1 gap-3 sm:grid-cols-2">
+            <label className="flex items-center gap-2 text-sm">
+              <input type="checkbox" name="scrubEnabled" defaultChecked={s.scrubEnabled} className="accent-primary" />
+              Enable scheduled scrubs
+            </label>
+            <div>
+              <Label>Scrub every (days)</Label>
+              <Input name="scrubIntervalDays" type="number" defaultValue={s.scrubIntervalDays} />
+            </div>
+            <div>
+              <Label>Start at hour (0–23)</Label>
+              <Input name="scrubHour" type="number" min={0} max={23} defaultValue={s.scrubHour} />
+            </div>
+            <div>
+              <Label>Timezone</Label>
+              <Input name="scrubTimezone" defaultValue={s.scrubTimezone} list="scrub-tz-list" placeholder="UTC" />
+              <datalist id="scrub-tz-list">
+                {COMMON_TIMEZONES.map((tz) => (
+                  <option key={tz} value={tz} />
+                ))}
+              </datalist>
+            </div>
+            <div className="sm:col-span-2">
+              <Button type="submit">Save scrub</Button>
+            </div>
+          </form>
+          <form action={scrubNowAction}>
+            <Button type="submit" variant="secondary">
+              Scrub now
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="space-y-3">
+          <h3 className="text-base font-semibold">WebDAV backup</h3>
+          {backup && <p className="text-sm text-primary">{backup}</p>}
+          <form action={saveWebdavSettingsAction} className="grid max-w-xl grid-cols-1 gap-3 sm:grid-cols-2">
+            <div className="sm:col-span-2">
+              <Label>WebDAV base URL</Label>
+              <Input name="webdavUrl" defaultValue={s.webdavUrl} placeholder="https://dav.example.com/labmgr" />
+            </div>
+            <div>
+              <Label>Username</Label>
+              <Input name="webdavUser" defaultValue={s.webdavUser} />
+            </div>
+            <div>
+              <Label>Password</Label>
+              <Input name="webdavPass" type="password" placeholder={s.webdavPass ? "•••••• (unchanged)" : ""} />
+            </div>
+            <div>
+              <Label>Keep last N backups</Label>
+              <Input name="webdavRetention" type="number" defaultValue={s.webdavRetention} />
+            </div>
+            <div>
+              <Label>Backup every (hours, 0=off)</Label>
+              <Input name="backupIntervalHours" type="number" defaultValue={s.backupIntervalHours} />
+            </div>
+            <div className="sm:col-span-2">
+              <Button type="submit">Save WebDAV</Button>
+            </div>
+          </form>
+          <form action={backupNowAction}>
+            <Button type="submit" variant="secondary">
+              Back up now
+            </Button>
+          </form>
+          {backups.length > 0 && (
+            <div className="space-y-2 pt-2">
+              <h4 className="text-sm font-semibold">Restore</h4>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Backup</TableHead>
+                    <TableHead></TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {backups.map((b) => (
+                    <TableRow key={b}>
+                      <TableCell>{b}</TableCell>
+                      <TableCell className="text-right">
+                        <form action={restoreAction}>
+                          <input type="hidden" name="name" value={b} />
+                          <Button type="submit" variant="secondary" size="sm">
+                            Stage restore
+                          </Button>
+                        </form>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+              <p className="text-xs text-muted-foreground">
+                Staging a restore takes effect after the controller restarts.
+              </p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/controller/src/app/(app)/stats/page.tsx
+++ b/controller/src/app/(app)/stats/page.tsx
@@ -1,16 +1,19 @@
 import { fmtBytes, pct } from "@/lib/format";
 import { buildStats } from "@/lib/stats";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 
 export const dynamic = "force-dynamic";
 
 function quotaCell(used: number | null, quota: number | null) {
-  if (used === null) return <span className="muted">—</span>;
+  if (used === null) return <span className="text-muted-foreground">—</span>;
   const p = quota ? pct(used, quota) : null;
   return (
     <>
       {fmtBytes(used)}
       {quota ? (
-        <span className="muted">
+        <span className="text-muted-foreground">
           {" "}/ {fmtBytes(quota)}
           {p !== null && ` (${p}%)`}
         </span>
@@ -24,89 +27,102 @@ export default async function StatsPage() {
   const totalLabs = nodes.reduce((n, x) => n + x.labs.length, 0);
 
   return (
-    <>
-      <h2>Storage stats</h2>
-      <p className="muted" style={{ marginTop: -6 }}>
-        Per-student storage by node and lab. <strong>Image</strong> is a student&apos;s writable-layer
-        (overlayfs) usage; <strong>Fast</strong> is scratch; <strong>Cold</strong> is cold storage.
-        Fast/Cold are usually reported only at the lab level (the lab quota covers all students).
-        Numbers come from the latest agent usage report.
-      </p>
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold tracking-tight">Storage stats</h1>
+        <p className="text-sm text-muted-foreground">
+          Per-student storage by node and lab. <strong className="text-foreground">Image</strong> is a
+          student&apos;s writable-layer (overlayfs) usage; <strong className="text-foreground">Fast</strong>{" "}
+          is scratch; <strong className="text-foreground">Cold</strong> is cold storage. Fast/Cold are
+          usually reported only at the lab level (the lab quota covers all students). Numbers come from
+          the latest agent usage report.
+        </p>
+      </div>
 
       {totalLabs === 0 ? (
-        <div className="card">
-          <p className="muted">No labs yet.</p>
-        </div>
+        <Card>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">No labs yet.</p>
+          </CardContent>
+        </Card>
       ) : (
         nodes.map((node) => (
-          <div className="card" key={node.node}>
-            <h3 style={{ marginTop: 0 }}>
-              {node.node}{" "}
-              <span className={`badge ${node.online ? "online" : "offline"}`}>
-                {node.online ? "online" : "offline"}
-              </span>
-              <span className="muted" style={{ fontWeight: 400, fontSize: 13 }}>
-                {" "}· whole-image usage on this node: {fmtBytes(node.totalImageBytes)}
-              </span>
-            </h3>
+          <Card key={node.node}>
+            <CardContent className="space-y-4">
+              <h3 className="text-base font-semibold">
+                {node.node}{" "}
+                <Badge variant={node.online ? "ok" : "err"}>
+                  {node.online ? "online" : "offline"}
+                </Badge>
+                <span className="text-sm font-normal text-muted-foreground">
+                  {" "}· whole-image usage on this node: {fmtBytes(node.totalImageBytes)}
+                </span>
+              </h3>
 
-            {node.labs.map((lab) => (
-              <div key={lab.labId} style={{ marginBottom: 22 }}>
-                <h4 style={{ margin: "8px 0" }}>
-                  <a href={`/labs/${lab.labId}`}>{lab.labName}</a>{" "}
-                  <span className="muted" style={{ fontWeight: 400 }}>
-                    · image {lab.image} · {lab.students.length} student
-                    {lab.students.length === 1 ? "" : "s"}
-                  </span>
-                </h4>
-                <div className="table-wrap">
-                  <table>
-                    <thead>
-                      <tr>
-                        <th>Student</th>
-                        <th>Image (overlay)</th>
-                        <th>Fast</th>
-                        <th>Cold</th>
-                      </tr>
-                    </thead>
-                    <tbody>
+              {node.labs.map((lab) => (
+                <div key={lab.labId} className="space-y-2">
+                  <h4 className="text-sm font-semibold">
+                    <a href={`/labs/${lab.labId}`} className="text-primary hover:underline">
+                      {lab.labName}
+                    </a>{" "}
+                    <span className="font-normal text-muted-foreground">
+                      · image {lab.image} · {lab.students.length} student
+                      {lab.students.length === 1 ? "" : "s"}
+                    </span>
+                  </h4>
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Student</TableHead>
+                        <TableHead>Image (overlay)</TableHead>
+                        <TableHead>Fast</TableHead>
+                        <TableHead>Cold</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
                       {lab.students.length === 0 ? (
-                        <tr>
-                          <td colSpan={4} className="muted">
+                        <TableRow>
+                          <TableCell colSpan={4} className="text-muted-foreground">
                             No students enrolled.
-                          </td>
-                        </tr>
+                          </TableCell>
+                        </TableRow>
                       ) : (
                         lab.students.map((s) => (
-                          <tr key={s.studentId}>
-                            <td>
+                          <TableRow key={s.studentId}>
+                            <TableCell>
                               {s.username}
                               {s.name && (
-                                <span className="muted" style={{ fontSize: 12 }}>
-                                  {" "}· {s.name}
-                                </span>
+                                <span className="text-xs text-muted-foreground"> · {s.name}</span>
                               )}
-                            </td>
-                            <td>{s.docker === null ? <span className="muted">—</span> : fmtBytes(s.docker)}</td>
-                            <td>{s.fast === null ? <span className="muted">—</span> : fmtBytes(s.fast)}</td>
-                            <td>{s.slow === null ? <span className="muted">—</span> : fmtBytes(s.slow)}</td>
-                          </tr>
+                            </TableCell>
+                            <TableCell>
+                              {s.docker === null ? <span className="text-muted-foreground">—</span> : fmtBytes(s.docker)}
+                            </TableCell>
+                            <TableCell>
+                              {s.fast === null ? <span className="text-muted-foreground">—</span> : fmtBytes(s.fast)}
+                            </TableCell>
+                            <TableCell>
+                              {s.slow === null ? <span className="text-muted-foreground">—</span> : fmtBytes(s.slow)}
+                            </TableCell>
+                          </TableRow>
                         ))
                       )}
-                      <tr style={{ fontWeight: 600, borderTop: "2px solid var(--border)" }}>
-                        <td>Lab total (whole image)</td>
-                        <td>{lab.aggregate.docker === null ? <span className="muted">—</span> : fmtBytes(lab.aggregate.docker)}</td>
-                        <td>{quotaCell(lab.aggregate.fast.used, lab.aggregate.fast.quota)}</td>
-                        <td>{quotaCell(lab.aggregate.slow.used, lab.aggregate.slow.quota)}</td>
-                      </tr>
-                    </tbody>
-                  </table>
+                      <TableRow className="border-t-2 border-border font-semibold">
+                        <TableCell>Lab total (whole image)</TableCell>
+                        <TableCell>
+                          {lab.aggregate.docker === null ? <span className="text-muted-foreground">—</span> : fmtBytes(lab.aggregate.docker)}
+                        </TableCell>
+                        <TableCell>{quotaCell(lab.aggregate.fast.used, lab.aggregate.fast.quota)}</TableCell>
+                        <TableCell>{quotaCell(lab.aggregate.slow.used, lab.aggregate.slow.quota)}</TableCell>
+                      </TableRow>
+                    </TableBody>
+                  </Table>
                 </div>
-              </div>
-            ))}
-          </div>
+              ))}
+            </CardContent>
+          </Card>
         ))
       )}
-    </>
+    </div>
   );
 }

--- a/controller/src/app/(app)/students/_components/ImportStudentsForm.tsx
+++ b/controller/src/app/(app)/students/_components/ImportStudentsForm.tsx
@@ -4,6 +4,12 @@ import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { applyMapping, parseCsv, type ImportRow } from "@/lib/csv";
 import type { ImportResult } from "../actions";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 
 export interface LabOpt {
   id: number;
@@ -88,14 +94,14 @@ export function ImportStudentsForm({ labs, importAction }: Props) {
     }
   }
 
-  if (labs.length === 0) return <p className="muted">Create a lab first.</p>;
+  if (labs.length === 0) return <p className="text-sm text-muted-foreground">Create a lab first.</p>;
 
   return (
-    <div>
-      <div style={{ display: "flex", gap: 12, flexWrap: "wrap", marginBottom: 10 }}>
+    <div className="space-y-3">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-5">
         <div>
-          <label>Target lab</label>
-          <select value={labId} onChange={(e) => setLabId(Number(e.target.value))}>
+          <Label>Target lab</Label>
+          <Select value={labId} onChange={(e) => setLabId(Number(e.target.value))}>
             <option value={0} disabled>
               Select lab…
             </option>
@@ -104,23 +110,23 @@ export function ImportStudentsForm({ labs, importAction }: Props) {
                 {l.name}
               </option>
             ))}
-          </select>
+          </Select>
         </div>
         <div>
-          <label>Username column</label>
-          <input value={cols.username} onChange={(e) => set({ username: e.target.value })} />
+          <Label>Username column</Label>
+          <Input value={cols.username} onChange={(e) => set({ username: e.target.value })} />
         </div>
         <div>
-          <label>Email column</label>
-          <input value={cols.email} onChange={(e) => set({ email: e.target.value })} />
+          <Label>Email column</Label>
+          <Input value={cols.email} onChange={(e) => set({ email: e.target.value })} />
         </div>
         <div>
-          <label>Name column</label>
-          <input value={cols.name} onChange={(e) => set({ name: e.target.value })} />
+          <Label>Name column</Label>
+          <Input value={cols.name} onChange={(e) => set({ name: e.target.value })} />
         </div>
         <div>
-          <label>Student ID column</label>
-          <input
+          <Label>Student ID column</Label>
+          <Input
             value={cols.studentId}
             placeholder="(optional)"
             onChange={(e) => set({ studentId: e.target.value })}
@@ -128,77 +134,71 @@ export function ImportStudentsForm({ labs, importAction }: Props) {
         </div>
       </div>
 
-      <div style={{ display: "flex", gap: 16, alignItems: "center", flexWrap: "wrap" }}>
+      <div className="flex flex-wrap items-center gap-4">
         <div>
-          <label>CSV file</label>
-          <input type="file" accept=".csv,text/csv,text/plain" onChange={(e) => onFile(e.target.files?.[0])} />
+          <Label>CSV file</Label>
+          <Input type="file" accept=".csv,text/csv,text/plain" onChange={(e) => onFile(e.target.files?.[0])} />
         </div>
-        {fileName && <span className="muted" style={{ fontSize: 12 }}>{fileName}</span>}
+        {fileName && <span className="text-xs text-muted-foreground">{fileName}</span>}
       </div>
 
-      <label style={{ marginTop: 10 }}>…or paste CSV (first row = headers)</label>
-      <textarea
-        value={csvText}
-        onChange={(e) => {
-          setCsvText(e.target.value);
-          setResult(null);
-        }}
-        rows={6}
-        style={{
-          width: "100%",
-          fontFamily: "monospace",
-          background: "var(--panel-2)",
-          color: "var(--text)",
-          border: "1px solid var(--border)",
-          borderRadius: 7,
-          padding: 10,
-        }}
-        placeholder={"username,email,name\nalice,alice@uga.edu,Alice A."}
-      />
+      <div>
+        <Label>…or paste CSV (first row = headers)</Label>
+        <Textarea
+          value={csvText}
+          onChange={(e) => {
+            setCsvText(e.target.value);
+            setResult(null);
+          }}
+          rows={6}
+          className="font-mono"
+          placeholder={"username,email,name\nalice,alice@uga.edu,Alice A."}
+        />
+      </div>
 
       {rows.length > 0 && (
-        <div style={{ marginTop: 10 }}>
-          <p style={{ margin: "6px 0" }}>
+        <div className="space-y-2">
+          <p className="text-sm">
             <strong>{validRows.length}</strong> valid
             {invalidCount > 0 && (
               <>
-                , <span style={{ color: "var(--danger, #e06)" }}>{invalidCount}</span> will be skipped
+                , <span className="text-err">{invalidCount}</span> will be skipped
               </>
             )}
             {headers.length > 0 && (
-              <span className="muted" style={{ fontSize: 12 }}>
+              <span className="text-xs text-muted-foreground">
                 {" "}· detected columns: {headers.join(", ")}
               </span>
             )}
           </p>
-          <div className="table-wrap" style={{ maxHeight: 320, overflow: "auto" }}>
-            <table>
-              <thead>
-                <tr>
-                  <th>Username</th>
-                  <th>Email</th>
-                  <th>Name</th>
-                  <th>Student ID</th>
-                  <th>Status</th>
-                </tr>
-              </thead>
-              <tbody>
+          <div className="max-h-80 overflow-auto rounded-md border border-border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Username</TableHead>
+                  <TableHead>Email</TableHead>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Student ID</TableHead>
+                  <TableHead>Status</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
                 {rows.slice(0, PREVIEW_LIMIT).map((r, i) => (
-                  <tr key={i} style={r.issues.length ? { opacity: 0.6 } : undefined}>
-                    <td>{r.username || "—"}</td>
-                    <td>{r.email ?? "—"}</td>
-                    <td>{r.name ?? "—"}</td>
-                    <td>{r.studentId ?? "—"}</td>
-                    <td style={{ color: r.issues.length ? "var(--danger, #e06)" : "var(--ok)" }}>
+                  <TableRow key={i} className={r.issues.length ? "opacity-60" : undefined}>
+                    <TableCell>{r.username || "—"}</TableCell>
+                    <TableCell>{r.email ?? "—"}</TableCell>
+                    <TableCell>{r.name ?? "—"}</TableCell>
+                    <TableCell>{r.studentId ?? "—"}</TableCell>
+                    <TableCell className={r.issues.length ? "text-err" : "text-ok"}>
                       {r.issues.length ? r.issues.join("; ") : "ok"}
-                    </td>
-                  </tr>
+                    </TableCell>
+                  </TableRow>
                 ))}
-              </tbody>
-            </table>
+              </TableBody>
+            </Table>
           </div>
           {rows.length > PREVIEW_LIMIT && (
-            <p className="muted" style={{ fontSize: 12 }}>
+            <p className="text-xs text-muted-foreground">
               Showing first {PREVIEW_LIMIT} of {rows.length} rows.
             </p>
           )}
@@ -206,20 +206,19 @@ export function ImportStudentsForm({ labs, importAction }: Props) {
       )}
 
       {result && (
-        <p style={{ color: result.error ? "var(--danger, #e06)" : "var(--ok)" }}>
+        <p className={`text-sm ${result.error ? "text-err" : "text-ok"}`}>
           {result.error ? result.error : `Imported ${result.added}, skipped ${result.skipped}.`}
         </p>
       )}
 
-      <button
+      <Button
         type="button"
         onClick={onImport}
         disabled={submitting || validRows.length === 0 || !labId}
-        style={{ width: 200, marginTop: 8 }}
       >
         {submitting ? "Importing…" : `Import ${validRows.length} student${validRows.length === 1 ? "" : "s"}`}
-      </button>
-      <p className="muted" style={{ fontSize: 12 }}>
+      </Button>
+      <p className="text-xs text-muted-foreground">
         The CSV is parsed in your browser; only the rows above are sent. Rows with a
         missing/invalid/duplicate username (or missing email when an email column is given) are skipped.
       </p>

--- a/controller/src/app/(app)/students/page.tsx
+++ b/controller/src/app/(app)/students/page.tsx
@@ -3,6 +3,8 @@ import { listMembers } from "@/lib/students";
 import { ConfirmButton } from "../_components/ConfirmButton";
 import { ImportStudentsForm } from "./_components/ImportStudentsForm";
 import { importStudentsAction, removeStudentAction } from "./actions";
+import { Card, CardContent } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 
 export const dynamic = "force-dynamic";
 
@@ -14,76 +16,79 @@ export default async function StudentsPage() {
   const totalMemberships = labsWithMembers.reduce((n, l) => n + l.members.length, 0);
 
   return (
-    <>
-      <h2>Students</h2>
+    <div className="space-y-4">
+      <h1 className="text-2xl font-semibold tracking-tight">Students</h1>
 
-      <div className="card">
-        <h3 style={{ marginTop: 0 }}>Import from CSV</h3>
-        <ImportStudentsForm
-          labs={labs.map((l) => ({ id: l.id, name: l.name }))}
-          importAction={importStudentsAction}
-        />
-      </div>
+      <Card>
+        <CardContent className="space-y-3">
+          <h3 className="text-base font-semibold">Import from CSV</h3>
+          <ImportStudentsForm
+            labs={labs.map((l) => ({ id: l.id, name: l.name }))}
+            importAction={importStudentsAction}
+          />
+        </CardContent>
+      </Card>
 
-      <div className="card">
-        <h3 style={{ marginTop: 0 }}>Students by lab</h3>
-        {totalMemberships === 0 ? (
-          <p className="muted">No students yet.</p>
-        ) : (
-          labsWithMembers
-            .filter((l) => l.members.length > 0)
-            .map(({ lab, members }) => (
-              <div key={lab.id} style={{ marginBottom: 20 }}>
-                <h4 style={{ margin: "8px 0" }}>
-                  <a href={`/labs/${lab.id}`}>{lab.name}</a>{" "}
-                  <span className="muted" style={{ fontWeight: 400 }}>
-                    · {lab.node_name} · {members.length} student{members.length === 1 ? "" : "s"}
-                  </span>
-                </h4>
-                <div className="table-wrap">
-                  <table>
-                    <thead>
-                      <tr>
-                        <th>Username</th>
-                        <th>Email</th>
-                        <th>Name</th>
-                        <th>Student ID</th>
-                        <th></th>
-                      </tr>
-                    </thead>
-                    <tbody>
+      <Card>
+        <CardContent className="space-y-4">
+          <h3 className="text-base font-semibold">Students by lab</h3>
+          {totalMemberships === 0 ? (
+            <p className="text-sm text-muted-foreground">No students yet.</p>
+          ) : (
+            labsWithMembers
+              .filter((l) => l.members.length > 0)
+              .map(({ lab, members }) => (
+                <div key={lab.id} className="space-y-2">
+                  <h4 className="text-sm font-semibold">
+                    <a href={`/labs/${lab.id}`} className="text-primary hover:underline">
+                      {lab.name}
+                    </a>{" "}
+                    <span className="font-normal text-muted-foreground">
+                      · {lab.node_name} · {members.length} student{members.length === 1 ? "" : "s"}
+                    </span>
+                  </h4>
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Username</TableHead>
+                        <TableHead>Email</TableHead>
+                        <TableHead>Name</TableHead>
+                        <TableHead>Student ID</TableHead>
+                        <TableHead></TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
                       {members.map((m) => (
-                        <tr key={m.member_id}>
-                          <td>{m.username}</td>
-                          <td>{m.email ?? "—"}</td>
-                          <td>{m.name ?? "—"}</td>
-                          <td>{m.student_id ?? "—"}</td>
-                          <td style={{ textAlign: "right" }}>
-                            <form action={removeStudentAction} style={{ display: "inline-flex", gap: 6, alignItems: "center" }}>
+                        <TableRow key={m.member_id}>
+                          <TableCell>{m.username}</TableCell>
+                          <TableCell>{m.email ?? "—"}</TableCell>
+                          <TableCell>{m.name ?? "—"}</TableCell>
+                          <TableCell>{m.student_id ?? "—"}</TableCell>
+                          <TableCell className="text-right">
+                            <form action={removeStudentAction} className="flex items-center justify-end gap-2">
                               <input type="hidden" name="labId" value={lab.id} />
                               <input type="hidden" name="studentId" value={m.id} />
-                              <label className="muted" style={{ margin: 0, display: "inline-flex", gap: 4, alignItems: "center" }}>
-                                <input type="checkbox" name="deleteData" style={{ width: "auto" }} /> delete data
+                              <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                                <input type="checkbox" name="deleteData" className="accent-primary" /> delete data
                               </label>
                               <ConfirmButton
-                                type="submit"
-                                className="secondary"
-                                style={{ width: "auto", marginTop: 0, padding: "6px 10px" }}
+                                variant="secondary"
+                                size="sm"
                                 confirm={`Remove ${m.username} from ${lab.name}? If "delete data" is checked, their files are permanently erased.`}
                               >
                                 Remove
                               </ConfirmButton>
                             </form>
-                          </td>
-                        </tr>
+                          </TableCell>
+                        </TableRow>
                       ))}
-                    </tbody>
-                  </table>
+                    </TableBody>
+                  </Table>
                 </div>
-              </div>
-            ))
-        )}
-      </div>
-    </>
+              ))
+          )}
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/controller/src/app/(app)/tasks/[id]/page.tsx
+++ b/controller/src/app/(app)/tasks/[id]/page.tsx
@@ -1,6 +1,8 @@
 import { db } from "@/lib/db";
 import { ago } from "@/lib/format";
 import { getTask } from "@/lib/queue";
+import { Card, CardContent } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 
 export const dynamic = "force-dynamic";
 
@@ -26,27 +28,18 @@ function prettyJson(raw: string | null): string | null {
 }
 
 const STATE_COLOR: Record<string, string> = {
-  ok: "var(--ok)",
-  failed: "var(--err)",
-  queued: "var(--muted)",
-  sent: "var(--warn)",
+  ok: "text-ok",
+  failed: "text-err",
+  queued: "text-muted-foreground",
+  sent: "text-warn",
 };
 
 function fullTime(ts: number): string {
   return new Date(ts).toISOString().replace("T", " ").replace(/\.\d+Z$/, " UTC");
 }
 
-const preStyle: React.CSSProperties = {
-  background: "var(--panel-2)",
-  border: "1px solid var(--border)",
-  borderRadius: 7,
-  padding: 12,
-  overflow: "auto",
-  fontSize: 13,
-  margin: 0,
-  whiteSpace: "pre-wrap",
-  wordBreak: "break-word",
-};
+const PRE_CLASS =
+  "m-0 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border bg-muted p-3 text-[13px]";
 
 export default async function TaskDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
@@ -54,15 +47,19 @@ export default async function TaskDetailPage({ params }: { params: Promise<{ id:
 
   if (!task) {
     return (
-      <>
-        <h2>Task</h2>
-        <div className="card">
-          <p className="muted">No task found with id {id}.</p>
-          <p>
-            <a href="/logs">← Back to logs</a>
-          </p>
-        </div>
-      </>
+      <div className="space-y-4">
+        <h1 className="text-2xl font-semibold tracking-tight">Task</h1>
+        <Card>
+          <CardContent className="space-y-2">
+            <p className="text-sm text-muted-foreground">No task found with id {id}.</p>
+            <p>
+              <a href="/logs" className="text-primary hover:underline">
+                ← Back to logs
+              </a>
+            </p>
+          </CardContent>
+        </Card>
+      </div>
     );
   }
 
@@ -74,14 +71,19 @@ export default async function TaskDetailPage({ params }: { params: Promise<{ id:
   const result = prettyJson(task.result);
   const durationMs = task.updated_at - task.created_at;
   const color = (lvl: string) =>
-    lvl === "ERROR" ? "var(--err)" : lvl === "WARN" ? "var(--warn)" : "var(--muted)";
+    lvl === "ERROR" ? "text-err" : lvl === "WARN" ? "text-warn" : "text-muted-foreground";
 
   const meta: [string, React.ReactNode][] = [
     ["Action", <code key="a">{task.action}</code>],
-    ["State", <span key="s" style={{ color: STATE_COLOR[task.state] ?? "var(--text)", fontWeight: 600 }}>{task.state}</span>],
+    [
+      "State",
+      <span key="s" className={`font-semibold ${STATE_COLOR[task.state] ?? ""}`}>
+        {task.state}
+      </span>,
+    ],
     ["Node", task.node],
     ["Requested by", task.requested_by ?? "—"],
-    ["Task ID", <code key="id" style={{ fontSize: 12 }}>{task.task_uuid}</code>],
+    ["Task ID", <code key="id" className="text-xs">{task.task_uuid}</code>],
     ["Queue job", task.job_id ?? "—"],
     ["Created", `${fullTime(task.created_at)} (${ago(task.created_at)})`],
     ["Updated", `${fullTime(task.updated_at)} (${ago(task.updated_at)})`],
@@ -89,90 +91,105 @@ export default async function TaskDetailPage({ params }: { params: Promise<{ id:
   ];
 
   return (
-    <>
-      <h2>
-        Task: <code>{task.action}</code>{" "}
-        <span style={{ color: STATE_COLOR[task.state] ?? "var(--text)", fontSize: 16 }}>{task.state}</span>
-      </h2>
-      <p>
-        <a href="/logs">← Back to logs</a> ·{" "}
-        <a href={`/logs?task=${encodeURIComponent(task.task_uuid)}`}>filter logs to this task</a>
+    <div className="space-y-4">
+      <h1 className="flex flex-wrap items-center gap-2 text-2xl font-semibold tracking-tight">
+        Task: <code>{task.action}</code>
+        <span className={`text-base ${STATE_COLOR[task.state] ?? ""}`}>{task.state}</span>
+      </h1>
+      <p className="text-sm">
+        <a href="/logs" className="text-primary hover:underline">
+          ← Back to logs
+        </a>{" "}
+        ·{" "}
+        <a href={`/logs?task=${encodeURIComponent(task.task_uuid)}`} className="text-primary hover:underline">
+          filter logs to this task
+        </a>
       </p>
 
-      <div className="card">
-        <h3 style={{ marginTop: 0 }}>Overview</h3>
-        <table>
-          <tbody>
-            {meta.map(([k, v]) => (
-              <tr key={k}>
-                <td className="muted" style={{ width: 140, verticalAlign: "top" }}>{k}</td>
-                <td>{v}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+      <Card>
+        <CardContent className="space-y-3">
+          <h3 className="text-base font-semibold">Overview</h3>
+          <table className="text-sm">
+            <tbody>
+              {meta.map(([k, v]) => (
+                <tr key={k as string}>
+                  <td className="w-36 py-1 align-top text-muted-foreground">{k}</td>
+                  <td className="py-1">{v}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
 
       {task.error && (
-        <div className="card">
-          <h3 style={{ marginTop: 0, color: "var(--err)" }}>Error</h3>
-          <pre style={{ ...preStyle, color: "var(--err)" }}>{task.error}</pre>
-        </div>
+        <Card>
+          <CardContent className="space-y-3">
+            <h3 className="text-base font-semibold text-err">Error</h3>
+            <pre className={`${PRE_CLASS} text-err`}>{task.error}</pre>
+          </CardContent>
+        </Card>
       )}
 
-      <div className="card">
-        <h3 style={{ marginTop: 0 }}>Parameters</h3>
-        {params2 ? <pre style={preStyle}>{params2}</pre> : <p className="muted">No parameters.</p>}
-      </div>
+      <Card>
+        <CardContent className="space-y-3">
+          <h3 className="text-base font-semibold">Parameters</h3>
+          {params2 ? <pre className={PRE_CLASS}>{params2}</pre> : <p className="text-sm text-muted-foreground">No parameters.</p>}
+        </CardContent>
+      </Card>
 
-      <div className="card">
-        <h3 style={{ marginTop: 0 }}>Result</h3>
-        {result ? (
-          <pre style={preStyle}>{result}</pre>
-        ) : (
-          <p className="muted">
-            {task.state === "ok" ? "Completed with no result payload." : "No result yet."}
-          </p>
-        )}
-      </div>
+      <Card>
+        <CardContent className="space-y-3">
+          <h3 className="text-base font-semibold">Result</h3>
+          {result ? (
+            <pre className={PRE_CLASS}>{result}</pre>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              {task.state === "ok" ? "Completed with no result payload." : "No result yet."}
+            </p>
+          )}
+        </CardContent>
+      </Card>
 
-      <div className="card">
-        <h3 style={{ marginTop: 0 }}>Log entries ({logs.length})</h3>
-        {logs.length === 0 ? (
-          <p className="muted">No log entries reference this task.</p>
-        ) : (
-          <div className="table-wrap">
-            <table>
-              <thead>
-                <tr>
-                  <th>Time</th>
-                  <th>Level</th>
-                  <th>Source</th>
-                  <th>Message</th>
-                </tr>
-              </thead>
-              <tbody>
+      <Card>
+        <CardContent className="space-y-3">
+          <h3 className="text-base font-semibold">Log entries ({logs.length})</h3>
+          {logs.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No log entries reference this task.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Time</TableHead>
+                  <TableHead>Level</TableHead>
+                  <TableHead>Source</TableHead>
+                  <TableHead>Message</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
                 {logs.map((l, i) => (
-                  <tr key={i}>
-                    <td className="muted" title={fullTime(l.ts)}>{ago(l.ts)}</td>
-                    <td style={{ color: color(l.level), fontWeight: 600 }}>{l.level}</td>
-                    <td>{l.source ?? "—"}</td>
-                    <td>
+                  <TableRow key={i}>
+                    <TableCell className="whitespace-nowrap text-muted-foreground" title={fullTime(l.ts)}>
+                      {ago(l.ts)}
+                    </TableCell>
+                    <TableCell className={`font-semibold ${color(l.level)}`}>{l.level}</TableCell>
+                    <TableCell>{l.source ?? "—"}</TableCell>
+                    <TableCell>
                       {l.msg}
                       {l.detail && (
-                        <details style={{ marginTop: 4 }}>
-                          <summary className="muted" style={{ cursor: "pointer", fontSize: 12 }}>detail</summary>
-                          <pre style={{ ...preStyle, marginTop: 4 }}>{l.detail}</pre>
+                        <details className="mt-1">
+                          <summary className="cursor-pointer text-xs text-muted-foreground">detail</summary>
+                          <pre className={`${PRE_CLASS} mt-1`}>{l.detail}</pre>
                         </details>
                       )}
-                    </td>
-                  </tr>
+                    </TableCell>
+                  </TableRow>
                 ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </div>
-    </>
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/controller/src/app/globals.css
+++ b/controller/src/app/globals.css
@@ -1,113 +1,127 @@
-/* Dark is the default theme; it applies when no data-theme is set and when it is "dark".
-   An inline script in the root layout sets data-theme before paint to avoid a flash. */
+@import "tailwindcss";
+@import "tw-animate-css";
+
+/* Dark is the default theme; an inline script in the root layout sets data-theme before paint.
+   shadcn `dark:` utilities key off the same data-theme attribute. */
+@custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
+
+/* ── Slate + Violet, dark-first ───────────────────────────────────────────────
+   :root carries the dark palette (the default). [data-theme="light"] overrides it.
+   shadcn primitives consume the semantic tokens; pages use them via @theme below. */
 :root,
 :root[data-theme="dark"] {
-  --bg: #0f1115;
-  --panel: #1a1d24;
-  --panel-2: #232732;
-  --border: #2c313c;
-  --text: #e6e8eb;
-  --muted: #9aa3b2;
-  --accent: #4f9dff;
-  --ok: #3fb950;
-  --warn: #d29922;
-  --err: #f85149;
-  --shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+  --background: #0b0e14;
+  --foreground: #e7ebf2;
+  --card: #151a23;
+  --card-foreground: #e7ebf2;
+  --popover: #151a23;
+  --popover-foreground: #e7ebf2;
+  --primary: #7c6cff;
+  --primary-foreground: #ffffff;
+  --secondary: #1e2430;
+  --secondary-foreground: #e7ebf2;
+  --muted: #1e2430;
+  --muted-foreground: #99a3b7;
+  --accent: #262e3d;
+  --accent-foreground: #f3f5fa;
+  --destructive: #fb7185;
+  --destructive-foreground: #1a0d10;
+  --border: #232b38;
+  --input: #2a3342;
+  --ring: #7c6cff;
+
+  --ok: #34d399;
+  --warn: #fbbf24;
+  --err: #fb7185;
+
+  --sidebar: #0d111a;
+  --sidebar-foreground: #cdd4e0;
+
+  --radius: 0.65rem;
 }
 
 :root[data-theme="light"] {
-  --bg: #f4f5f7;
-  --panel: #ffffff;
-  --panel-2: #eceef1;
-  --border: #d7dbe0;
-  --text: #1c2128;
-  --muted: #5a6472;
-  --accent: #2f6fed;
-  --ok: #1a7f37;
-  --warn: #9a6700;
-  --err: #cf222e;
-  --shadow: 0 1px 3px rgba(27, 33, 40, 0.08);
+  --background: #f6f7fa;
+  --foreground: #0b0e14;
+  --card: #ffffff;
+  --card-foreground: #0b0e14;
+  --popover: #ffffff;
+  --popover-foreground: #0b0e14;
+  --primary: #6d5cf0;
+  --primary-foreground: #ffffff;
+  --secondary: #eceef4;
+  --secondary-foreground: #1c2433;
+  --muted: #eceef4;
+  --muted-foreground: #5a6478;
+  --accent: #e9ebf5;
+  --accent-foreground: #1c2433;
+  --destructive: #e11d48;
+  --destructive-foreground: #ffffff;
+  --border: #e2e5ec;
+  --input: #d6dae3;
+  --ring: #6d5cf0;
+
+  --ok: #16a34a;
+  --warn: #b45309;
+  --err: #e11d48;
+
+  --sidebar: #ffffff;
+  --sidebar-foreground: #2b3445;
 }
 
-* { box-sizing: border-box; }
+/* Map CSS variables to Tailwind theme tokens so utilities like bg-card, text-muted-foreground,
+   border-border, text-ok work everywhere. */
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
 
-html { color-scheme: dark; }
-html[data-theme="light"] { color-scheme: light; }
+  --color-ok: var(--ok);
+  --color-warn: var(--warn);
+  --color-err: var(--err);
 
-body {
-  margin: 0;
-  background: var(--bg);
-  color: var(--text);
-  font: 14px/1.5 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+
+  --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
 }
 
-a { color: var(--accent); text-decoration: none; }
-a:hover { text-decoration: underline; }
-
-.layout { display: flex; min-height: 100vh; }
-.sidebar {
-  width: 220px; flex-shrink: 0; background: var(--panel);
-  border-right: 1px solid var(--border); padding: 20px 12px;
-  display: flex; flex-direction: column;
-  position: sticky; top: 0; align-self: flex-start; height: 100vh;
+@layer base {
+  * {
+    border-color: var(--border);
+  }
+  html {
+    color-scheme: dark;
+  }
+  html[data-theme="light"] {
+    color-scheme: light;
+  }
+  body {
+    background: var(--background);
+    color: var(--foreground);
+    font-family: var(--font-sans);
+    -webkit-font-smoothing: antialiased;
+  }
 }
-.sidebar h1 { font-size: 15px; margin: 0 0 18px 8px; }
-.sidebar nav { display: flex; flex-direction: column; gap: 2px; }
-.sidebar nav a {
-  display: block; padding: 8px 10px; border-radius: 6px; color: var(--text);
-}
-.sidebar nav a:hover { background: var(--panel-2); text-decoration: none; }
-.sidebar nav a.active {
-  background: var(--panel-2); color: var(--accent); font-weight: 600;
-  box-shadow: inset 2px 0 0 var(--accent);
-}
-.sidebar-footer { margin-top: auto; padding-top: 16px; }
-.content { flex: 1; min-width: 0; padding: 28px 32px; max-width: 1180px; }
-
-.card {
-  background: var(--panel); border: 1px solid var(--border);
-  border-radius: 10px; padding: 18px 20px; margin-bottom: 18px; box-shadow: var(--shadow);
-}
-h2 { font-size: 18px; margin: 0 0 14px; }
-
-/* Wide tables (e.g. Nodes) scroll horizontally inside their card instead of overflowing. */
-.table-wrap { overflow-x: auto; margin: 0 -4px; }
-table { width: 100%; border-collapse: collapse; }
-th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--border); }
-tbody tr:last-child td { border-bottom: 0; }
-th { color: var(--muted); font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: .04em; white-space: nowrap; }
-
-.badge { display: inline-block; padding: 2px 8px; border-radius: 99px; font-size: 12px; font-weight: 600; }
-.badge.online { background: rgba(63,185,80,.15); color: var(--ok); }
-.badge.offline { background: rgba(248,81,73,.15); color: var(--err); }
-
-.auth-wrap { display: flex; align-items: center; justify-content: center; min-height: 100vh; }
-.auth-card { width: 360px; }
-label { display: block; margin: 12px 0 4px; color: var(--muted); font-size: 13px; }
-input {
-  width: 100%; padding: 9px 11px; border-radius: 7px; border: 1px solid var(--border);
-  background: var(--panel-2); color: var(--text); font-size: 14px;
-}
-button {
-  margin-top: 16px; width: 100%; padding: 10px; border: 0; border-radius: 7px;
-  background: var(--accent); color: #fff; font-weight: 600; cursor: pointer; font-size: 14px;
-}
-button:hover { filter: brightness(1.08); }
-/* Secondary/danger buttons must set an explicit text color so they stay legible in light mode
-   (the base rule's white-on-accent would otherwise leave white text on a light panel). */
-button.secondary { background: var(--panel-2); color: var(--text); border: 1px solid var(--border); }
-button.danger { background: var(--err); color: #fff; }
-select {
-  width: 100%; padding: 9px 11px; border-radius: 7px; border: 1px solid var(--border);
-  background: var(--panel-2); color: var(--text); font-size: 14px;
-}
-.error { color: var(--err); margin-top: 12px; font-size: 13px; }
-.muted { color: var(--muted); }
-
-.theme-toggle {
-  margin-top: 8px; width: 100%; padding: 8px 10px; border-radius: 7px;
-  border: 1px solid var(--border); background: var(--panel-2); color: var(--text);
-  font-size: 13px; font-weight: 600; cursor: pointer;
-  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
-}
-.theme-toggle:hover { filter: brightness(1.08); }

--- a/controller/src/app/login/page.tsx
+++ b/controller/src/app/login/page.tsx
@@ -1,6 +1,10 @@
 import { redirect } from "next/navigation";
 import { adminCount, setSessionCookie, verifyLogin } from "@/lib/auth";
 import { AUTH_LIMIT, clientIp, consume } from "@/lib/ratelimit";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 
 export const dynamic = "force-dynamic";
 
@@ -24,26 +28,47 @@ export default async function LoginPage({ searchParams }: { searchParams: Promis
   const { error } = await searchParams;
   const noAdmins = adminCount() === 0;
   return (
-    <div className="auth-wrap">
-      <div className="card auth-card">
-        <h2>Sign in</h2>
-        {noAdmins && (
-          <p className="muted">
-            No admins yet. <a href="/signup">Create the first account</a> using the signup token.
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <Card className="w-full max-w-sm">
+        <CardContent className="space-y-4">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <span className="flex h-7 w-7 items-center justify-center rounded-md bg-primary text-sm font-bold text-primary-foreground">
+                L
+              </span>
+              <h1 className="text-xl font-semibold tracking-tight">Sign in</h1>
+            </div>
+            {noAdmins && (
+              <p className="text-sm text-muted-foreground">
+                No admins yet.{" "}
+                <a href="/signup" className="text-primary hover:underline">
+                  Create the first account
+                </a>{" "}
+                using the signup token.
+              </p>
+            )}
+          </div>
+          <form action={login} className="space-y-4">
+            <div>
+              <Label htmlFor="email">Email</Label>
+              <Input id="email" name="email" type="email" required />
+            </div>
+            <div>
+              <Label htmlFor="password">Password</Label>
+              <Input id="password" name="password" type="password" required />
+            </div>
+            <Button type="submit" className="w-full">
+              Sign in
+            </Button>
+          </form>
+          {error && <p className="text-sm text-err">{error}</p>}
+          <p className="text-sm text-muted-foreground">
+            <a href="/signup" className="text-primary hover:underline">
+              Register a new admin
+            </a>
           </p>
-        )}
-        <form action={login}>
-          <label htmlFor="email">Email</label>
-          <input id="email" name="email" type="email" required />
-          <label htmlFor="password">Password</label>
-          <input id="password" name="password" type="password" required />
-          <button type="submit">Sign in</button>
-        </form>
-        {error && <p className="error">{error}</p>}
-        <p className="muted" style={{ marginTop: 16 }}>
-          <a href="/signup">Register a new admin</a>
-        </p>
-      </div>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/controller/src/app/signup/page.tsx
+++ b/controller/src/app/signup/page.tsx
@@ -1,6 +1,10 @@
 import { redirect } from "next/navigation";
 import { createAdmin, setSessionCookie } from "@/lib/auth";
 import { AUTH_LIMIT, clientIp, consume } from "@/lib/ratelimit";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 
 export const dynamic = "force-dynamic";
 
@@ -28,26 +32,49 @@ async function signup(formData: FormData) {
 export default async function SignupPage({ searchParams }: { searchParams: Promise<{ error?: string }> }) {
   const { error } = await searchParams;
   return (
-    <div className="auth-wrap">
-      <div className="card auth-card">
-        <h2>Register admin</h2>
-        <p className="muted">Requires the signup token configured on the controller.</p>
-        <form action={signup}>
-          <label htmlFor="name">Name</label>
-          <input id="name" name="name" required />
-          <label htmlFor="email">Email</label>
-          <input id="email" name="email" type="email" required />
-          <label htmlFor="password">Password</label>
-          <input id="password" name="password" type="password" required minLength={8} />
-          <label htmlFor="token">Signup token</label>
-          <input id="token" name="token" required />
-          <button type="submit">Create account</button>
-        </form>
-        {error && <p className="error">{error}</p>}
-        <p className="muted" style={{ marginTop: 16 }}>
-          <a href="/login">Back to sign in</a>
-        </p>
-      </div>
+    <div className="flex min-h-screen items-center justify-center px-4 py-8">
+      <Card className="w-full max-w-sm">
+        <CardContent className="space-y-4">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <span className="flex h-7 w-7 items-center justify-center rounded-md bg-primary text-sm font-bold text-primary-foreground">
+                L
+              </span>
+              <h1 className="text-xl font-semibold tracking-tight">Register admin</h1>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Requires the signup token configured on the controller.
+            </p>
+          </div>
+          <form action={signup} className="space-y-4">
+            <div>
+              <Label htmlFor="name">Name</Label>
+              <Input id="name" name="name" required />
+            </div>
+            <div>
+              <Label htmlFor="email">Email</Label>
+              <Input id="email" name="email" type="email" required />
+            </div>
+            <div>
+              <Label htmlFor="password">Password</Label>
+              <Input id="password" name="password" type="password" required minLength={8} />
+            </div>
+            <div>
+              <Label htmlFor="token">Signup token</Label>
+              <Input id="token" name="token" required />
+            </div>
+            <Button type="submit" className="w-full">
+              Create account
+            </Button>
+          </form>
+          {error && <p className="text-sm text-err">{error}</p>}
+          <p className="text-sm text-muted-foreground">
+            <a href="/login" className="text-primary hover:underline">
+              Back to sign in
+            </a>
+          </p>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/controller/src/components/ui/badge.tsx
+++ b/controller/src/components/ui/badge.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent bg-primary/15 text-primary",
+        secondary: "border-transparent bg-secondary text-secondary-foreground",
+        outline: "border-border text-foreground",
+        ok: "border-transparent bg-ok/15 text-ok",
+        warn: "border-transparent bg-warn/15 text-warn",
+        err: "border-transparent bg-err/15 text-err",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLSpanElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return <span className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { Badge, badgeVariants };

--- a/controller/src/components/ui/button.tsx
+++ b/controller/src/components/ui/button.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 [&_svg]:size-4 [&_svg]:shrink-0 cursor-pointer",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline: "border border-input bg-transparent hover:bg-accent hover:text-accent-foreground",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-md px-3 text-xs",
+        lg: "h-10 rounded-md px-6",
+        icon: "h-9 w-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />;
+  },
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/controller/src/components/ui/card.tsx
+++ b/controller/src/components/ui/card.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+function Card({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-border bg-card text-card-foreground shadow-sm",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("flex flex-col gap-1.5 p-5 pb-0", className)} {...props} />;
+}
+
+function CardTitle({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+  return <h3 className={cn("text-base font-semibold leading-none tracking-tight", className)} {...props} />;
+}
+
+function CardDescription({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) {
+  return <p className={cn("text-sm text-muted-foreground", className)} {...props} />;
+}
+
+function CardContent({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("p-5", className)} {...props} />;
+}
+
+export { Card, CardHeader, CardTitle, CardDescription, CardContent };

--- a/controller/src/components/ui/dialog.tsx
+++ b/controller/src/components/ui/dialog.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogPortal = DialogPrimitive.Portal;
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-1/2 top-1/2 z-50 grid w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl border border-border bg-card p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("flex flex-col gap-1.5 text-left", className)} {...props} />;
+}
+
+function DialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)}
+      {...props}
+    />
+  );
+}
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTrigger,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+};

--- a/controller/src/components/ui/input.tsx
+++ b/controller/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        ref={ref}
+        className={cn(
+          "flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+Input.displayName = "Input";
+
+export { Input };

--- a/controller/src/components/ui/label.tsx
+++ b/controller/src/components/ui/label.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Label = React.forwardRef<HTMLLabelElement, React.LabelHTMLAttributes<HTMLLabelElement>>(
+  ({ className, ...props }, ref) => (
+    <label
+      ref={ref}
+      className={cn(
+        "block text-xs font-medium text-muted-foreground mb-1.5 peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Label.displayName = "Label";
+
+export { Label };

--- a/controller/src/components/ui/select.tsx
+++ b/controller/src/components/ui/select.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * A lightly-styled native <select>. Native (not Radix) so it keeps working with plain
+ * server-action <form> submits and `name`/`defaultValue` semantics across the admin pages.
+ */
+const Select = React.forwardRef<HTMLSelectElement, React.SelectHTMLAttributes<HTMLSelectElement>>(
+  ({ className, children, ...props }, ref) => {
+    return (
+      <select
+        ref={ref}
+        className={cn(
+          "flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </select>
+    );
+  },
+);
+Select.displayName = "Select";
+
+export { Select };

--- a/controller/src/components/ui/sheet.tsx
+++ b/controller/src/components/ui/sheet.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import * as React from "react";
+import * as SheetPrimitive from "@radix-ui/react-dialog";
+import { cva, type VariantProps } from "class-variance-authority";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const Sheet = SheetPrimitive.Root;
+const SheetTrigger = SheetPrimitive.Trigger;
+const SheetClose = SheetPrimitive.Close;
+const SheetPortal = SheetPrimitive.Portal;
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+  />
+));
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
+
+const sheetVariants = cva(
+  "fixed z-50 gap-4 bg-sidebar text-sidebar-foreground shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  {
+    variants: {
+      side: {
+        top: "inset-x-0 top-0 border-b border-border data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        bottom:
+          "inset-x-0 bottom-0 border-t border-border data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-72 border-r border-border data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left",
+        right:
+          "inset-y-0 right-0 h-full w-72 border-l border-border data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right",
+      },
+    },
+    defaultVariants: { side: "right" },
+  },
+);
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ side = "left", className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+      {children}
+    </SheetPrimitive.Content>
+  </SheetPortal>
+));
+SheetContent.displayName = SheetPrimitive.Content.displayName;
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title ref={ref} className={cn("text-base font-semibold", className)} {...props} />
+));
+SheetTitle.displayName = SheetPrimitive.Title.displayName;
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+));
+SheetDescription.displayName = SheetPrimitive.Description.displayName;
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetTitle,
+  SheetDescription,
+};

--- a/controller/src/components/ui/table.tsx
+++ b/controller/src/components/ui/table.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+/** Table wrapped in a horizontal-scroll container so wide tables never break the mobile layout. */
+function Table({ className, ...props }: React.HTMLAttributes<HTMLTableElement>) {
+  return (
+    <div className="relative w-full overflow-x-auto">
+      <table className={cn("w-full caption-bottom text-sm", className)} {...props} />
+    </div>
+  );
+}
+
+function TableHeader({ className, ...props }: React.HTMLAttributes<HTMLTableSectionElement>) {
+  return <thead className={cn("[&_tr]:border-b [&_tr]:border-border", className)} {...props} />;
+}
+
+function TableBody({ className, ...props }: React.HTMLAttributes<HTMLTableSectionElement>) {
+  return <tbody className={cn("[&_tr:last-child]:border-0", className)} {...props} />;
+}
+
+function TableRow({ className, ...props }: React.HTMLAttributes<HTMLTableRowElement>) {
+  return (
+    <tr
+      className={cn("border-b border-border transition-colors hover:bg-muted/40", className)}
+      {...props}
+    />
+  );
+}
+
+function TableHead({ className, ...props }: React.ThHTMLAttributes<HTMLTableCellElement>) {
+  return (
+    <th
+      className={cn(
+        "h-10 whitespace-nowrap px-3 text-left align-middle text-xs font-semibold uppercase tracking-wide text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCell({ className, ...props }: React.TdHTMLAttributes<HTMLTableCellElement>) {
+  return <td className={cn("px-3 py-2.5 align-middle", className)} {...props} />;
+}
+
+export { Table, TableHeader, TableBody, TableRow, TableHead, TableCell };

--- a/controller/src/components/ui/textarea.tsx
+++ b/controller/src/components/ui/textarea.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, React.TextareaHTMLAttributes<HTMLTextAreaElement>>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        ref={ref}
+        className={cn(
+          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/controller/src/lib/hub.ts
+++ b/controller/src/lib/hub.ts
@@ -319,12 +319,14 @@ async function emailGpuEvent(
   const { sendGpuKillEmail, sendGpuWarningEmail } = await import("./mailer");
   if (p.state === "warned") {
     await sendGpuWarningEmail(row.email, {
+      username: p.user,
       lab: p.lab,
       pid: p.pid,
+      node,
       graceMinutes: getSetting("gpuGraceMinutes"),
     });
   } else {
-    await sendGpuKillEmail(row.email, { lab: p.lab, pid: p.pid });
+    await sendGpuKillEmail(row.email, { username: p.user, lab: p.lab, pid: p.pid, node });
   }
 }
 

--- a/controller/src/lib/mailer.ts
+++ b/controller/src/lib/mailer.ts
@@ -6,6 +6,10 @@
 
 import nodemailer from "nodemailer";
 import {
+  DEFAULT_GPU_KILL_BODY,
+  DEFAULT_GPU_KILL_SUBJECT,
+  DEFAULT_GPU_WARN_BODY,
+  DEFAULT_GPU_WARN_SUBJECT,
   DEFAULT_WELCOME_BODY,
   DEFAULT_WELCOME_SUBJECT,
   getSetting,
@@ -83,31 +87,49 @@ export interface CredentialEmail {
   studentId?: string | null;
 }
 
-export async function sendGpuWarningEmail(
-  to: string,
-  opts: { lab: string | null; pid: number | null; graceMinutes: number },
-): Promise<SendResult> {
-  return sendMail(
-    to,
-    "Idle GPU process warning",
-    `One of your processes (PID ${opts.pid ?? "?"}${opts.lab ? `, lab ${opts.lab}` : ""}) is holding GPU` +
-      ` memory but is not using the GPU.\n\nIf it stays idle it will be terminated in about ` +
-      `${opts.graceMinutes} minutes to free the GPU for others. If you still need it, start using ` +
-      `the GPU again or contact an admin.\n\n— Lab Manager`,
-  );
+export interface GpuEmailOpts {
+  username: string;
+  lab: string | null;
+  pid: number | null;
+  node: string;
+  graceMinutes?: number;
 }
 
-export async function sendGpuKillEmail(
-  to: string,
-  opts: { lab: string | null; pid: number | null },
-): Promise<SendResult> {
-  return sendMail(
-    to,
-    "Idle GPU process terminated",
-    `Your idle process (PID ${opts.pid ?? "?"}${opts.lab ? `, lab ${opts.lab}` : ""}) was terminated ` +
-      `because it held GPU memory without using the GPU. Please checkpoint long-running work and ` +
-      `keep the GPU active, or ask an admin to whitelist your job.\n\n— Lab Manager`,
-  );
+/** Build the {placeholder} substitution map shared by both GPU notification templates. */
+export function gpuEmailVars(opts: GpuEmailOpts): Record<string, string | number> {
+  return {
+    username: opts.username,
+    pid: opts.pid ?? "",
+    lab: opts.lab ?? "",
+    node: opts.node,
+    grace_minutes: opts.graceMinutes ?? "",
+  };
+}
+
+/** Render the GPU idle-warning email from the admin-editable template (or its default). */
+export function renderGpuWarningEmail(opts: GpuEmailOpts): { subject: string; body: string } {
+  const vars = gpuEmailVars(opts);
+  const subject = getSetting("gpuWarnEmailSubject").trim() || DEFAULT_GPU_WARN_SUBJECT;
+  const body = getSetting("gpuWarnEmailBody").trim() || DEFAULT_GPU_WARN_BODY;
+  return { subject: renderTemplate(subject, vars), body: renderTemplate(body, vars) };
+}
+
+/** Render the GPU termination email from the admin-editable template (or its default). */
+export function renderGpuKillEmail(opts: GpuEmailOpts): { subject: string; body: string } {
+  const vars = gpuEmailVars(opts);
+  const subject = getSetting("gpuKillEmailSubject").trim() || DEFAULT_GPU_KILL_SUBJECT;
+  const body = getSetting("gpuKillEmailBody").trim() || DEFAULT_GPU_KILL_BODY;
+  return { subject: renderTemplate(subject, vars), body: renderTemplate(body, vars) };
+}
+
+export async function sendGpuWarningEmail(to: string, opts: GpuEmailOpts): Promise<SendResult> {
+  const { subject, body } = renderGpuWarningEmail(opts);
+  return sendMail(to, subject, body);
+}
+
+export async function sendGpuKillEmail(to: string, opts: GpuEmailOpts): Promise<SendResult> {
+  const { subject, body } = renderGpuKillEmail(opts);
+  return sendMail(to, subject, body);
 }
 
 export interface QuotaEmail {

--- a/controller/src/lib/settings.ts
+++ b/controller/src/lib/settings.ts
@@ -45,6 +45,13 @@ export interface Settings {
   gpuImmediate: boolean;
   gpuWhitelistUsers: string; // comma-separated
   gpuWhitelistLabs: string; // comma-separated
+  // Emails sent to a student when their idle GPU process is warned / terminated. Both support
+  // {placeholder} substitution (see GPU_EMAIL_VARS / renderGpu*Email in lib/mailer.ts). Empty
+  // falls back to the built-in default.
+  gpuWarnEmailSubject: string;
+  gpuWarnEmailBody: string;
+  gpuKillEmailSubject: string;
+  gpuKillEmailBody: string;
   // Alerting + logs.
   alertsEnabled: boolean;
   alertLevel: "WARN" | "ERROR"; // minimum log level that triggers an admin alert
@@ -98,6 +105,35 @@ Please change your password after first login (run: passwd).
 
 — Lab Manager`;
 
+/** Placeholders the GPU notification templates understand, shown to the admin in the settings UI. */
+export const GPU_EMAIL_VARS: { key: string; desc: string }[] = [
+  { key: "username", desc: "owner's login username" },
+  { key: "pid", desc: "process id (may be blank)" },
+  { key: "lab", desc: "lab name (may be blank)" },
+  { key: "node", desc: "node the process runs on" },
+  { key: "grace_minutes", desc: "minutes before termination (warning email only)" },
+];
+
+export const DEFAULT_GPU_WARN_SUBJECT = "Idle GPU process warning";
+
+export const DEFAULT_GPU_WARN_BODY = `Hello {username},
+
+One of your processes (PID {pid}) on node {node} is holding GPU memory but is not using the GPU.
+
+If it stays idle it will be terminated in about {grace_minutes} minutes to free the GPU for others. If you still need it, start using the GPU again or contact an admin.
+
+— Lab Manager`;
+
+export const DEFAULT_GPU_KILL_SUBJECT = "Idle GPU process terminated";
+
+export const DEFAULT_GPU_KILL_BODY = `Hello {username},
+
+Your idle process (PID {pid}) on node {node} was terminated because it held GPU memory without using the GPU.
+
+Please checkpoint long-running work and keep the GPU active, or ask an admin to whitelist your job.
+
+— Lab Manager`;
+
 export const DEFAULT_SETTINGS: Settings = {
   fastQuotaDefaultBytes: 2 * TIB,
   slowQuotaDefaultBytes: 3 * TIB,
@@ -122,6 +158,10 @@ export const DEFAULT_SETTINGS: Settings = {
   gpuImmediate: false,
   gpuWhitelistUsers: "",
   gpuWhitelistLabs: "",
+  gpuWarnEmailSubject: DEFAULT_GPU_WARN_SUBJECT,
+  gpuWarnEmailBody: DEFAULT_GPU_WARN_BODY,
+  gpuKillEmailSubject: DEFAULT_GPU_KILL_SUBJECT,
+  gpuKillEmailBody: DEFAULT_GPU_KILL_BODY,
   alertsEnabled: true,
   alertLevel: "ERROR",
   alertDedupMinutes: 15,

--- a/controller/src/lib/utils.ts
+++ b/controller/src/lib/utils.ts
@@ -1,0 +1,7 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+/** Merge conditional class names and de-dupe conflicting Tailwind utilities. */
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/controller/tests/mailer.test.ts
+++ b/controller/tests/mailer.test.ts
@@ -127,11 +127,20 @@ describe("templated emails", () => {
   });
 
   it("gpu warning and kill emails mention the pid", async () => {
-    await mailer.sendGpuWarningEmail("a@uga.edu", { lab: "bio", pid: 42, graceMinutes: 10 });
+    await mailer.sendGpuWarningEmail("a@uga.edu", { username: "alice", lab: "bio", pid: 42, node: "gpu-01", graceMinutes: 10 });
     expect(sent[0].text).toContain("PID 42");
     expect(sent[0].text).toContain("10 minutes");
-    await mailer.sendGpuKillEmail("a@uga.edu", { lab: null, pid: 7 });
+    await mailer.sendGpuKillEmail("a@uga.edu", { username: "bob", lab: null, pid: 7, node: "gpu-01" });
     expect(sent[1].text).toContain("PID 7");
+  });
+
+  it("gpu emails render the admin-editable template", async () => {
+    configureSmtp();
+    settings.setSetting("gpuWarnEmailSubject", "Heads up {username}");
+    settings.setSetting("gpuWarnEmailBody", "PID {pid} on {node} — {grace_minutes}m left");
+    await mailer.sendGpuWarningEmail("a@uga.edu", { username: "alice", lab: "bio", pid: 42, node: "gpu-01", graceMinutes: 15 });
+    expect(sent[0].subject).toBe("Heads up alice");
+    expect(sent[0].text).toBe("PID 42 on gpu-01 — 15m left");
   });
 
   it("removal email distinguishes deleted vs retained data", async () => {


### PR DESCRIPTION
## Summary

Two related changes to the controller admin dashboard:

### 1. Full UI makeover — Tailwind v4 + shadcn/ui (slate + violet, dark-first)
Replaces the hand-rolled CSS / `data-theme` system and all inline `style={{}}` objects with a responsive, mobile-first design system.

- **Foundation:** Tailwind v4 + PostCSS, `lib/utils` (`cn`), `components.json`, shadcn primitives (button, card, badge, input, textarea, label, select, table, dialog, sheet).
- **Theme:** new slate + violet palette as semantic CSS-variable tokens (dark default, light variant), wired to Tailwind via `@theme`; the theme toggle + no-flash script are preserved.
- **Responsive shell:** fixed desktop sidebar collapses into a hamburger Sheet drawer on mobile (auto-closes on route change); nav links gain lucide icons.
- `ConfirmButton` now uses a styled Dialog instead of `window.confirm`.
- **All pages migrated** (auth, dashboard, nodes, labs + detail, students, stats, gpu, logs, announcements, settings, task detail) plus the CreateLab / ImportStudents client forms. Wide tables scroll horizontally inside cards; forms wrap on small screens.
- Native `<select>`/checkboxes kept (lightly styled) so plain server-action form submits work unchanged.

### 2. Editable GPU notification email templates
The idle-GPU **warning** and **termination** emails were hardcoded in `mailer.ts`. They're now admin-editable in **Settings → GPU notification emails**, mirroring the welcome-email template.

- New settings: `gpuWarnEmail{Subject,Body}`, `gpuKillEmail{Subject,Body}` with defaults derived from the old copy.
- Rendered via `renderTemplate` with `{username,pid,lab,node,grace_minutes}` placeholders.

## Verification
- ✅ `lint` (0 warnings) · ✅ `typecheck` · ✅ `build` (all 15 routes) · ✅ `test` (147/147)
- ✅ Runtime smoke test: `/login` renders 200 with the new CSS tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)