### PR TITLE
Nested Docker on lab fast tier (GPU + storage passthrough) + left-align UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,9 +320,13 @@ open **Settings** and configure:
 
 ### Build a lab base image
 
-A default Ubuntu image is in [image/](image/): it runs **systemd** as PID 1 with SSH **and a full
-Docker engine**, so under the Sysbox runtime users get host-isolated nested Docker. Each user is
-granted `sudo` and added to the `docker` group when the agent provisions them.
+A default Ubuntu image is in [image/](image/): it runs **systemd** as PID 1 with SSH and **one shared
+Docker daemon** for nested containers, whose data-root is pinned to the lab's fast tier
+(`/labdata/fast/docker`) and which can re-pass the GPU into nested containers via the NVIDIA toolkit.
+Under the Sysbox runtime this daemon (and per-user sudo) is host-isolated. Each user is granted `sudo`
+and added to the `docker` group when the agent provisions them. Nested Docker is a last resort — the
+lab container already has sudo, Python, and GPU access; see [STUDENT_GUIDE.md](STUDENT_GUIDE.md) for
+when/how to use it (GPU + storage passthrough).
 
 ```bash
 docker build -t custom-ssh ./image     # run on each node, or push to a registry the nodes can pull

--- a/STUDENT_GUIDE.md
+++ b/STUDENT_GUIDE.md
@@ -56,6 +56,50 @@ labquota --refresh    # recompute installed-software sizes (and watch the progre
 home) is measured periodically; `labquota --refresh` asks the server for a fresh measurement if the
 last one is over an hour old.
 
+## Running Docker (only if you really need it)
+
+> **Try not to use Docker here.** Your lab container already gives you `sudo`, Python, and direct
+> access to the GPUs — for almost everything (installing packages, running training, notebooks) you do
+> **not** need a nested container. Reach for Docker **only** when a project genuinely requires it, e.g.
+> it ships a `Dockerfile`/`docker-compose.yml` you must run as-is. Nested containers are slower to
+> start and share one daemon with your whole lab.
+
+When you do need it, Docker is already installed and running — no setup. You're in the `docker` group,
+so just run `docker`:
+
+```bash
+docker run --rm hello-world
+```
+
+All images and containers are stored on the lab's **shared fast tier** (`/labdata/fast`), so they
+count against your lab's storage quota and the image cache is shared with your labmates. Clean up
+images you no longer need with `docker image prune`.
+
+### Passing your GPU into a container
+
+Add `--gpus all` (verify with `nvidia-smi` inside the container):
+
+```bash
+docker run --rm --gpus all nvidia/cuda:12.4.0-base-ubuntu22.04 nvidia-smi
+```
+
+### Passing your scratch and cold storage into a container
+
+Bind-mount your own folders so work survives the container and lands on the right storage tier. Use
+the real paths (your `~/scratch` and `~/cold-storage` are symlinks):
+
+```bash
+docker run --rm -it --gpus all \
+  -v "$(readlink -f ~/scratch):/scratch" \
+  -v "$(readlink -f ~/cold-storage):/cold-storage" \
+  -w /scratch \
+  nvidia/cuda:12.4.0-base-ubuntu22.04 bash
+```
+
+Anything written to `/scratch` or `/cold-storage` inside the container appears in your `~/scratch` /
+`~/cold-storage` and persists. **Don't** store data only inside the container's own filesystem — it's
+on the shared fast tier and is lost when the container is removed.
+
 ## GPUs
 
 All of the server's GPUs are available to your lab. To keep them fair for everyone, there is an

--- a/agent/src/lab_agent/executors/users.py
+++ b/agent/src/lab_agent/executors/users.py
@@ -42,13 +42,14 @@ def add_user(container: str, username: str, password: str) -> CommandResult:
     validate_username(username)
     # Password is embedded in the stdin-piped script body, never in argv.
     #
-    # Users ARE granted sudo and added to the `docker` group so they can administer the box and run
-    # nested Docker. This reverses the original H-05 stance and is only safe because every lab
-    # container runs under the Sysbox runtime: its user-namespace remap means container-root (which
-    # sudo grants) maps to an UNPRIVILEGED host UID, so neither sudo nor the in-container Docker
-    # daemon is a path to host root. Note the tradeoff: a lab container is shared by all of its
-    # students, so sudo means they are no longer isolated from one another *within the lab* (host
-    # isolation is unaffected). umask 027 still keeps each student's files private by default.
+    # Users ARE granted sudo and added to the `docker` group so they can administer the box and use
+    # the shared in-container Docker daemon (image/Dockerfile) when a project genuinely needs a
+    # nested container. This is only safe because every lab container runs under the Sysbox runtime:
+    # its user-namespace remap means container-root (which sudo and Docker grant) maps to an
+    # UNPRIVILEGED host UID, so neither sudo nor the in-container daemon is a path to host root.
+    # Note the tradeoff: a lab container is shared by all its students, so sudo means they are no
+    # longer isolated from one another *within the lab* (host isolation is unaffected). umask 027
+    # still keeps each student's files private by default.
     script = f"""set -e
 u={username}
 if ! id "$u" >/dev/null 2>&1; then useradd -m -s /bin/bash "$u"; fi

--- a/agent/tests/test_users.py
+++ b/agent/tests/test_users.py
@@ -31,7 +31,8 @@ def test_add_user_script_creates_user_and_links(cap):
     assert "ln -sfn /labusers/slow/" in script
     assert "umask 027" in script
     # Users are granted sudo + docker-group membership (safe only because lab containers run under
-    # the Sysbox runtime, which remaps container-root to an unprivileged host UID).
+    # the Sysbox runtime, which remaps container-root to an unprivileged host UID) so they can use the
+    # shared in-container Docker daemon when a project needs a nested container.
     assert "usermod -aG sudo,docker" in script
     assert "groupadd docker" in script
     assert "chpasswd" in script

--- a/controller/src/app/(app)/layout.tsx
+++ b/controller/src/app/(app)/layout.tsx
@@ -29,7 +29,7 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
           <SidebarContent email={admin.email} logout={logout} />
         </MobileNav>
 
-        <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-6 sm:px-6 lg:px-8">{children}</main>
+        <main className="w-full max-w-6xl flex-1 px-4 py-6 sm:px-6 lg:px-8">{children}</main>
       </div>
     </div>
   );

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,16 +1,29 @@
-# Default lab base image: an SSH-accessible Ubuntu running systemd, with sudo, Python, and a full
-# Docker engine for nested containers.
+# Default lab base image: an SSH-accessible Ubuntu running systemd, with sudo, Python, and ONE shared
+# in-container Docker daemon for nested containers.
 #
-# Lab containers run under the Sysbox runtime (--runtime=sysbox-runc), which provides
-# Docker-in-Docker WITHOUT --privileged and remaps container-root to an UNPRIVILEGED host UID — so
-# the in-container Docker daemon and per-user sudo cannot reach host root. GPUs are injected at run
-# time via the NVIDIA Container Device Interface (--device nvidia.com/gpu=all), independent of the
-# OCI runtime, so they compose with sysbox-runc.
+# The daemon's data-root is pinned to /labdata/fast/docker — the lab's shared fast tier, which the
+# agent bind-mounts at run time. So all nested images/layers/containers live on big, persistent,
+# quota-counted storage (and the layer cache is shared across the lab) instead of bloating the
+# ephemeral container overlay. Storage driver is fuse-overlayfs because the data-root sits on a
+# bind-mounted ZFS dataset, where overlay2 is not supported (see the validation note below).
 #
-# systemd is PID 1 (Sysbox's supported pattern) so ssh and docker run as real services. Students are
+# Nested Docker is meant to be a LAST RESORT: the lab container already has sudo, Python, and direct
+# GPU access, so most work needs no inner container. When a project genuinely needs one, students run
+# `docker` directly (they are in the `docker` group); STUDENT_GUIDE.md shows how to pass the GPU and
+# bind-mount their own ~/scratch and ~/cold-storage into the inner container.
+#
+# Lab containers run under the Sysbox runtime (--runtime=sysbox-runc), which provides nested Docker
+# WITHOUT --privileged and remaps container-root to an UNPRIVILEGED host UID — so the in-container
+# Docker daemon (and per-user sudo) cannot reach host root. The daemon therefore runs root-IN-CONTAINER
+# but is rootless/host-isolated from the host's point of view. GPUs reach the lab container via the
+# NVIDIA Container Device Interface (--device nvidia.com/gpu=all), independent of the OCI runtime, so
+# they compose with sysbox-runc; nvidia-container-toolkit is installed so the inner daemon can re-pass
+# those GPUs into nested containers (CDI spec regenerated at boot by nvidia-cdi.service).
+#
+# systemd is PID 1 (Sysbox's supported pattern) so ssh + docker run as real services. Students are
 # added later as Linux users by the agent (docker exec useradd ...), so this image does NOT create
-# users at boot. The agent bind-mounts lab data at /labdata/{fast,slow} and per-student datasets
-# under /labusers/{fast,slow}; the agent wires each student's ~/scratch and ~/cold-storage.
+# users at boot. The agent bind-mounts lab data at /labdata/{fast,slow} and per-student datasets under
+# /labusers/{fast,slow}; the agent wires each student's ~/scratch and ~/cold-storage.
 #
 # Build + tag for use as a lab image:
 #   docker build -t custom-ssh ./image
@@ -32,6 +45,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Docker engine (for nested containers), from Docker's official apt repo, pinned to the noble channel.
+# fuse-overlayfs is the storage driver (data-root lives on a bind-mounted ZFS dataset; see daemon.json).
 RUN install -m 0755 -d /etc/apt/keyrings \
     && curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc \
     && chmod a+r /etc/apt/keyrings/docker.asc \
@@ -39,8 +53,33 @@ RUN install -m 0755 -d /etc/apt/keyrings \
         > /etc/apt/sources.list.d/docker.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin \
+        docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin fuse-overlayfs \
     && rm -rf /var/lib/apt/lists/*
+
+# NVIDIA Container Toolkit, so the in-container daemon can re-pass the lab container's GPUs into nested
+# containers (via `--gpus all` or `--device nvidia.com/gpu=all`). The CDI spec is generated at boot.
+RUN curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \
+        | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
+    && curl -fsSL https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list \
+        | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
+        > /etc/apt/sources.list.d/nvidia-container-toolkit.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends nvidia-container-toolkit \
+    && rm -rf /var/lib/apt/lists/*
+
+# Pin the daemon's data-root to the lab's shared fast tier and select the fuse-overlayfs driver (the
+# data-root is a bind-mounted ZFS dataset, where overlay2 is unsupported). CDI is enabled and the
+# nvidia runtime registered so nested containers can request the GPU. The agent bind-mounts
+# /labdata/fast at run time; Docker creates /labdata/fast/docker on first start.
+RUN mkdir -p /etc/docker \
+    && printf '%s\n' \
+        '{' \
+        '  "data-root": "/labdata/fast/docker",' \
+        '  "storage-driver": "fuse-overlayfs",' \
+        '  "features": { "cdi": true },' \
+        '  "runtimes": { "nvidia": { "path": "nvidia-container-runtime", "runtimeArgs": [] } }' \
+        '}' \
+        > /etc/docker/daemon.json
 
 # Harden sshd: students authenticate with passwords, but root login is off, brute force is throttled,
 # and the login window is short. Instructors can still use key auth. (Per-user sudo is granted by the
@@ -62,12 +101,14 @@ RUN sed -i 's/^#\?PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh
 COPY labquota /usr/local/bin/labquota
 # Oneshot unit: regenerate unique SSH host keys on first boot, before sshd starts.
 COPY ssh-hostkeys.service /etc/systemd/system/ssh-hostkeys.service
+# Oneshot unit: generate the inner NVIDIA CDI spec (if GPUs present) before docker starts.
+COPY nvidia-cdi.service /etc/systemd/system/nvidia-cdi.service
 RUN chmod +x /usr/local/bin/labquota \
-    && systemctl enable ssh docker ssh-hostkeys \
+    && systemctl enable ssh docker ssh-hostkeys nvidia-cdi \
     # Strip systemd units that are useless or noisy inside a container.
     && systemctl mask systemd-udevd.service systemd-udevd-kernel.socket systemd-udevd-control.socket \
         systemd-modules-load.service sys-kernel-debug.mount sys-kernel-tracing.mount
 
 EXPOSE 22
-# systemd as PID 1 (runs unprivileged under Sysbox); it brings up ssh + docker.
+# systemd as PID 1 (runs unprivileged under Sysbox); it brings up ssh + the shared docker daemon.
 CMD ["/sbin/init"]

--- a/image/nvidia-cdi.service
+++ b/image/nvidia-cdi.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Generate NVIDIA CDI spec for nested Docker (when GPUs are present)
+# The lab container receives GPUs via the host's CDI injection, so /dev/nvidiactl exists only when a
+# GPU is attached. Generate an INNER CDI spec before docker starts so nested containers can request
+# the GPU with `--device nvidia.com/gpu=all` (or `--gpus all`). No-op on CPU-only labs.
+Before=docker.service
+After=local-fs.target
+ConditionPathExists=/dev/nvidiactl
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/mkdir -p /etc/cdi
+# `|| true` so a transient generation failure never blocks docker/boot on a CPU-only or oddly-wired node.
+ExecStart=/bin/sh -c '/usr/bin/nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml || true'
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Two changes:

1. **Image / agent** — the in-container Docker daemon now keeps its `data-root` on the lab's shared **fast tier** (`/labdata/fast/docker`) instead of the ephemeral container overlay, so nested images/layers are persistent, quota-counted, and share a layer cache across the lab. Nested Docker is reframed as a **last resort** (the lab container already has sudo, Python, and GPU access), with documented GPU + storage passthrough.
2. **Controller UI** — left-align app content beside the sidebar (removed `mx-auto` from the shared `(app)` layout).

## Image details
- `daemon.json`: `data-root=/labdata/fast/docker`, `storage-driver=fuse-overlayfs` (overlay2 is unsupported on a bind-mounted ZFS dataset), `features.cdi=true`, `nvidia` runtime registered.
- Installs `nvidia-container-toolkit`; new `nvidia-cdi.service` runs `nvidia-ctk cdi generate` at boot (before docker, only when `/dev/nvidiactl` exists) so nested containers can use `--gpus all` / `--device nvidia.com/gpu=all`.
- Students stay in `sudo` + `docker` groups (host-isolated under Sysbox).
- `STUDENT_GUIDE.md`: discourages nested Docker; shows GPU and `~/scratch` / `~/cold-storage` passthrough.

## ⚠️ Validate on a real node before fleet rollout
- `fuse-overlayfs` as a **rootful** storage driver with data-root on the bind-mounted ZFS `/labdata/fast` (fallback: `vfs` — reliable but slow/space-heavy).
- Inner `--gpus all` works after the boot-time CDI generate.

## Test plan
- `agent`: ruff clean, `pytest` 200 passed locally.
- `controller`: lint/tsc/vitest/build run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)