### PR TITLE
feat(controller): dedicated Backups page with full WebDAV backup UI

### DIFF
--- a/controller/src/app/(app)/_components/NavLinks.tsx
+++ b/controller/src/app/(app)/_components/NavLinks.tsx
@@ -4,6 +4,7 @@ import { usePathname } from "next/navigation";
 import {
   Bell,
   Cpu,
+  DatabaseBackup,
   FlaskConical,
   HardDrive,
   LayoutDashboard,
@@ -24,6 +25,7 @@ const NAV: [string, string, LucideIcon][] = [
   ["/gpu", "GPU", Cpu],
   ["/logs", "Logs", ScrollText],
   ["/announcements", "Announce", Bell],
+  ["/backups", "Backups", DatabaseBackup],
   ["/settings", "Settings", Settings],
 ];
 

--- a/controller/src/app/(app)/backups/_components/ClientTime.tsx
+++ b/controller/src/app/(app)/backups/_components/ClientTime.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+/**
+ * Render an epoch-ms timestamp in the viewer's local timezone/locale. Formatting differs between the
+ * server (its tz) and the browser, so suppressHydrationWarning avoids a spurious mismatch warning.
+ */
+export function ClientTime({ ts }: { ts: number }) {
+  if (!ts) return <span>never</span>;
+  return <span suppressHydrationWarning>{new Date(ts).toLocaleString()}</span>;
+}

--- a/controller/src/app/(app)/backups/actions.ts
+++ b/controller/src/app/(app)/backups/actions.ts
@@ -1,0 +1,87 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { revalidatePath } from "next/cache";
+import { requireAdmin } from "@/lib/auth";
+import { setSetting } from "@/lib/settings";
+
+function done(msg: string): never {
+  redirect(`/backups?msg=${encodeURIComponent(msg)}`);
+}
+
+export async function saveWebdavSettingsAction(formData: FormData) {
+  await requireAdmin();
+  setSetting("webdavUrl", String(formData.get("webdavUrl") ?? "").trim());
+  setSetting("webdavUser", String(formData.get("webdavUser") ?? "").trim());
+  const pass = String(formData.get("webdavPass") ?? "");
+  // The password field renders blank; only overwrite the stored secret when a new one is entered.
+  if (pass) setSetting("webdavPass", pass);
+  const base = String(formData.get("webdavBaseDir") ?? "").trim() || "/backups";
+  setSetting("webdavBaseDir", base);
+  done("Configuration saved");
+}
+
+export async function saveScheduleAction(formData: FormData) {
+  await requireAdmin();
+  setSetting("backupEnabled", formData.get("backupEnabled") === "on");
+  setSetting("backupIntervalHours", Number(formData.get("backupIntervalHours")) || 24);
+
+  // Anchor time arrives as "HH:MM" from an <input type="time">.
+  const [h, m] = String(formData.get("backupAnchor") ?? "02:00").split(":").map(Number);
+  setSetting("backupAnchorHour", Number.isInteger(h) && h >= 0 && h <= 23 ? h : 2);
+  setSetting("backupAnchorMinute", Number.isInteger(m) && m >= 0 && m <= 59 ? m : 0);
+
+  const tz = String(formData.get("backupTimezone") ?? "").trim();
+  let validTz = "UTC";
+  try {
+    if (tz) {
+      new Intl.DateTimeFormat("en-US", { timeZone: tz });
+      validTz = tz;
+    }
+  } catch {
+    validTz = "UTC";
+  }
+  setSetting("backupTimezone", validTz);
+
+  const nonNeg = (name: string, fallback: number) => {
+    const n = Number(formData.get(name));
+    return Number.isFinite(n) && n >= 0 ? Math.trunc(n) : fallback;
+  };
+  setSetting("backupKeepRecent", nonNeg("backupKeepRecent", 7));
+  setSetting("backupKeepWeekly", nonNeg("backupKeepWeekly", 4));
+  setSetting("backupKeepMonthly", nonNeg("backupKeepMonthly", 12));
+  setSetting("backupKeepYearly", nonNeg("backupKeepYearly", 3));
+  done("Schedule saved");
+}
+
+export async function testConnectionAction() {
+  await requireAdmin();
+  const { testConnection } = await import("@/lib/backup");
+  const res = await testConnection();
+  done(res.ok ? "Connection OK" : `Connection failed: ${res.error}`);
+}
+
+export async function backupNowAction() {
+  await requireAdmin();
+  const { backupAll } = await import("@/lib/backup");
+  const res = await backupAll();
+  done(res.ok ? `Backed up ${res.name}` : `Backup failed: ${res.error}`);
+}
+
+export async function restoreAction(formData: FormData) {
+  await requireAdmin();
+  const name = String(formData.get("name") ?? "");
+  const { stageRestore } = await import("@/lib/backup");
+  const res = await stageRestore(name);
+  done(
+    res.ok
+      ? "Restore staged — restart the controller to apply it"
+      : `Restore failed: ${res.error}`,
+  );
+}
+
+export async function refreshAction() {
+  await requireAdmin();
+  revalidatePath("/backups");
+  redirect("/backups");
+}

--- a/controller/src/app/(app)/backups/page.tsx
+++ b/controller/src/app/(app)/backups/page.tsx
@@ -1,0 +1,260 @@
+import { Clock, Database, HardDriveDownload, Play, RefreshCw, Save, Server } from "lucide-react";
+import { backupEnv, getSettings, isWebdavConfigured } from "@/lib/settings";
+import { listBackups, type BackupEntry } from "@/lib/backup";
+import { nextBackupRun } from "@/lib/maintenance";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { ClientTime } from "./_components/ClientTime";
+import {
+  backupNowAction,
+  refreshAction,
+  restoreAction,
+  saveScheduleAction,
+  saveWebdavSettingsAction,
+  testConnectionAction,
+} from "./actions";
+
+// Common IANA timezones for the schedule picker (free text still allowed via the datalist).
+const COMMON_TIMEZONES = [
+  "UTC",
+  "America/New_York",
+  "America/Chicago",
+  "America/Denver",
+  "America/Los_Angeles",
+  "Europe/London",
+  "Europe/Berlin",
+  "Asia/Kolkata",
+  "Asia/Shanghai",
+  "Asia/Tokyo",
+  "Australia/Sydney",
+];
+
+export const dynamic = "force-dynamic";
+
+export default async function BackupsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ msg?: string }>;
+}) {
+  const { msg } = await searchParams;
+  const s = getSettings();
+  const env = backupEnv();
+  const nextRun = nextBackupRun();
+
+  let backups: BackupEntry[] = [];
+  if (isWebdavConfigured()) {
+    try {
+      backups = await listBackups();
+    } catch {
+      backups = [];
+    }
+  }
+
+  const anchor = `${String(s.backupAnchorHour).padStart(2, "0")}:${String(
+    s.backupAnchorMinute,
+  ).padStart(2, "0")}`;
+  const failed = s.backupLastStatus === "failed";
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-semibold tracking-tight">Backups</h1>
+      {msg && <p className="text-sm text-primary">{msg}</p>}
+
+      {/* Status */}
+      <Card>
+        <CardContent className="space-y-2">
+          <h3 className="flex items-center gap-2 text-base font-semibold">
+            <Clock className="h-4 w-4" /> Status
+          </h3>
+          <p className="text-sm">
+            <span className="font-medium">Last run: </span>
+            <ClientTime ts={s.backupLastRun} />
+            {s.backupLastStatus && (
+              <span className={failed ? "text-destructive" : "text-emerald-500"}>
+                {" "}
+                ({failed ? "FAILED" : "OK"})
+              </span>
+            )}
+          </p>
+          <p className="text-sm">
+            <span className="font-medium">Next run: </span>
+            {nextRun ? <ClientTime ts={nextRun} /> : <span className="text-muted-foreground">disabled</span>}
+          </p>
+          {failed && s.backupLastError && (
+            <p className="text-sm text-destructive">Last error: {s.backupLastError}</p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* WebDAV connection */}
+      <Card>
+        <CardContent className="space-y-3">
+          <h3 className="flex items-center gap-2 text-base font-semibold">
+            <Server className="h-4 w-4" /> WebDAV connection
+          </h3>
+          <form action={saveWebdavSettingsAction} className="grid max-w-2xl grid-cols-1 gap-3 sm:grid-cols-2">
+            <div className="sm:col-span-2">
+              <Label>WebDAV URL</Label>
+              <Input name="webdavUrl" defaultValue={s.webdavUrl} placeholder="https://dav.example.com/db-backup" />
+            </div>
+            <div>
+              <Label>Username</Label>
+              <Input name="webdavUser" defaultValue={s.webdavUser} />
+            </div>
+            <div>
+              <Label>Password</Label>
+              <Input name="webdavPass" type="password" placeholder={s.webdavPass ? "•••••••• (unchanged)" : ""} />
+            </div>
+            <div className="sm:col-span-2">
+              <Label>Base directory</Label>
+              <Input name="webdavBaseDir" defaultValue={s.webdavBaseDir} placeholder="/backups" />
+              <p className="pt-1 text-xs text-muted-foreground">
+                Backups are written under <code>{s.webdavBaseDir.replace(/\/+$/, "")}/prod</code> and{" "}
+                <code>{s.webdavBaseDir.replace(/\/+$/, "")}/dev</code>.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2 sm:col-span-2">
+              <Button type="submit">
+                <Save /> Save configuration
+              </Button>
+              <Button type="submit" formAction={testConnectionAction} variant="outline">
+                <Server /> Test connection
+              </Button>
+              <Button type="submit" formAction={backupNowAction} variant="outline">
+                <Play /> Backup now
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      {/* Schedule & retention */}
+      <Card>
+        <CardContent className="space-y-3">
+          <h3 className="flex items-center gap-2 text-base font-semibold">
+            <Clock className="h-4 w-4" /> Schedule &amp; retention
+          </h3>
+          <form action={saveScheduleAction} className="space-y-4">
+            <label className="flex items-center gap-2 text-sm font-medium">
+              <input
+                type="checkbox"
+                name="backupEnabled"
+                defaultChecked={s.backupEnabled}
+                className="accent-primary"
+              />
+              Enable scheduled backups
+            </label>
+
+            <div className="grid max-w-2xl grid-cols-1 gap-3 sm:grid-cols-3">
+              <div>
+                <Label>Every (hours)</Label>
+                <Input name="backupIntervalHours" type="number" min={1} defaultValue={s.backupIntervalHours} />
+              </div>
+              <div>
+                <Label>Anchor time</Label>
+                <Input name="backupAnchor" type="time" defaultValue={anchor} />
+              </div>
+              <div>
+                <Label>Timezone</Label>
+                <Input name="backupTimezone" defaultValue={s.backupTimezone} list="backup-tz-list" placeholder="UTC" />
+                <datalist id="backup-tz-list">
+                  {COMMON_TIMEZONES.map((tz) => (
+                    <option key={tz} value={tz} />
+                  ))}
+                </datalist>
+              </div>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Default is daily at 02:00 America/New_York (handles EST/EDT).
+            </p>
+
+            <div className="grid max-w-2xl grid-cols-2 gap-3 sm:grid-cols-4">
+              <div>
+                <Label>Keep recent</Label>
+                <Input name="backupKeepRecent" type="number" min={0} defaultValue={s.backupKeepRecent} />
+              </div>
+              <div>
+                <Label>Keep weekly</Label>
+                <Input name="backupKeepWeekly" type="number" min={0} defaultValue={s.backupKeepWeekly} />
+              </div>
+              <div>
+                <Label>Keep monthly</Label>
+                <Input name="backupKeepMonthly" type="number" min={0} defaultValue={s.backupKeepMonthly} />
+              </div>
+              <div>
+                <Label>Keep yearly</Label>
+                <Input name="backupKeepYearly" type="number" min={0} defaultValue={s.backupKeepYearly} />
+              </div>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Grandfather-father-son retention: keep the newest N, plus the newest in each of the last
+              N weeks, months, and years.
+            </p>
+
+            <Button type="submit">
+              <Save /> Save configuration
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      {/* Available backups */}
+      <Card>
+        <CardContent className="space-y-3">
+          <h3 className="flex items-center gap-2 text-base font-semibold">
+            <Database className="h-4 w-4" /> Available backups ({env})
+          </h3>
+          <form action={refreshAction}>
+            <Button type="submit" variant="outline" size="sm">
+              <RefreshCw /> Refresh
+            </Button>
+          </form>
+          {backups.length > 0 ? (
+            <>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Backup</TableHead>
+                    <TableHead>Taken</TableHead>
+                    <TableHead></TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {backups.map((b) => (
+                    <TableRow key={b.name}>
+                      <TableCell className="font-mono text-xs">{b.name}</TableCell>
+                      <TableCell className="text-sm">
+                        <ClientTime ts={b.stamp} />
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <form action={restoreAction}>
+                          <input type="hidden" name="name" value={b.name} />
+                          <Button type="submit" variant="secondary" size="sm">
+                            <HardDriveDownload /> Stage restore
+                          </Button>
+                        </form>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+              <p className="text-xs text-muted-foreground">
+                Restoring stages the backup; it replaces the live database on the next service restart.
+              </p>
+            </>
+          ) : (
+            <>
+              <p className="text-sm text-muted-foreground">No backups found.</p>
+              <p className="text-xs text-muted-foreground">
+                Restoring stages the backup; it replaces the live database on the next service restart.
+              </p>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/controller/src/app/(app)/settings/actions.ts
+++ b/controller/src/app/(app)/settings/actions.ts
@@ -162,35 +162,6 @@ export async function scrubNowAction() {
   redirect(`/settings?scrub=${encodeURIComponent(`Scrub started on ${count} node(s)`)}`);
 }
 
-export async function saveWebdavSettingsAction(formData: FormData) {
-  await requireAdmin();
-  setSetting("webdavUrl", String(formData.get("webdavUrl") ?? "").trim());
-  setSetting("webdavUser", String(formData.get("webdavUser") ?? "").trim());
-  const pass = String(formData.get("webdavPass") ?? "");
-  if (pass) setSetting("webdavPass", pass);
-  setSetting("webdavRetention", Number(formData.get("webdavRetention")) || 7);
-  setSetting("backupIntervalHours", Number(formData.get("backupIntervalHours")) || 0);
-  revalidatePath("/settings");
-}
-
-export async function backupNowAction() {
-  await requireAdmin();
-  const { backupAll } = await import("@/lib/backup");
-  const res = await backupAll();
-  redirect(`/settings?backup=${encodeURIComponent(res.ok ? `Backed up ${res.name}` : `Failed: ${res.error}`)}`);
-}
-
-export async function restoreAction(formData: FormData) {
-  await requireAdmin();
-  const name = String(formData.get("name") ?? "");
-  const { stageRestore } = await import("@/lib/backup");
-  const res = await stageRestore(name);
-  const msg = res.ok
-    ? "Restore staged — restart the controller to apply it"
-    : `Failed: ${res.error}`;
-  redirect(`/settings?backup=${encodeURIComponent(msg)}`);
-}
-
 export async function testEmailAction(formData: FormData) {
   await requireAdmin();
   const to = String(formData.get("to") ?? "").trim();

--- a/controller/src/app/(app)/settings/page.tsx
+++ b/controller/src/app/(app)/settings/page.tsx
@@ -1,22 +1,17 @@
-import { listBackups } from "@/lib/backup";
-import { getSettings, GPU_EMAIL_VARS, isWebdavConfigured, TIB, WELCOME_EMAIL_VARS } from "@/lib/settings";
+import { getSettings, GPU_EMAIL_VARS, TIB, WELCOME_EMAIL_VARS } from "@/lib/settings";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import {
-  backupNowAction,
-  restoreAction,
   saveAlertSettingsAction,
   saveGpuEmailsAction,
   saveGpuPolicyAction,
   saveScrubSettingsAction,
   saveSmtpSettingsAction,
   saveStorageSettingsAction,
-  saveWebdavSettingsAction,
   saveWelcomeEmailAction,
   scrubNowAction,
   testEmailAction,
@@ -42,18 +37,10 @@ export const dynamic = "force-dynamic";
 export default async function SettingsPage({
   searchParams,
 }: {
-  searchParams: Promise<{ smtp?: string; backup?: string; scrub?: string }>;
+  searchParams: Promise<{ smtp?: string; scrub?: string }>;
 }) {
-  const { smtp, backup, scrub } = await searchParams;
+  const { smtp, scrub } = await searchParams;
   const s = getSettings();
-  let backups: string[] = [];
-  if (isWebdavConfigured()) {
-    try {
-      backups = await listBackups();
-    } catch {
-      backups = [];
-    }
-  }
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
@@ -349,74 +336,6 @@ export default async function SettingsPage({
               Scrub now
             </Button>
           </form>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardContent className="space-y-3">
-          <h3 className="text-base font-semibold">WebDAV backup</h3>
-          {backup && <p className="text-sm text-primary">{backup}</p>}
-          <form action={saveWebdavSettingsAction} className="grid max-w-xl grid-cols-1 gap-3 sm:grid-cols-2">
-            <div className="sm:col-span-2">
-              <Label>WebDAV base URL</Label>
-              <Input name="webdavUrl" defaultValue={s.webdavUrl} placeholder="https://dav.example.com/labmgr" />
-            </div>
-            <div>
-              <Label>Username</Label>
-              <Input name="webdavUser" defaultValue={s.webdavUser} />
-            </div>
-            <div>
-              <Label>Password</Label>
-              <Input name="webdavPass" type="password" placeholder={s.webdavPass ? "•••••• (unchanged)" : ""} />
-            </div>
-            <div>
-              <Label>Keep last N backups</Label>
-              <Input name="webdavRetention" type="number" defaultValue={s.webdavRetention} />
-            </div>
-            <div>
-              <Label>Backup every (hours, 0=off)</Label>
-              <Input name="backupIntervalHours" type="number" defaultValue={s.backupIntervalHours} />
-            </div>
-            <div className="sm:col-span-2">
-              <Button type="submit">Save WebDAV</Button>
-            </div>
-          </form>
-          <form action={backupNowAction}>
-            <Button type="submit" variant="secondary">
-              Back up now
-            </Button>
-          </form>
-          {backups.length > 0 && (
-            <div className="space-y-2 pt-2">
-              <h4 className="text-sm font-semibold">Restore</h4>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Backup</TableHead>
-                    <TableHead></TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {backups.map((b) => (
-                    <TableRow key={b}>
-                      <TableCell>{b}</TableCell>
-                      <TableCell className="text-right">
-                        <form action={restoreAction}>
-                          <input type="hidden" name="name" value={b} />
-                          <Button type="submit" variant="secondary" size="sm">
-                            Stage restore
-                          </Button>
-                        </form>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-              <p className="text-xs text-muted-foreground">
-                Staging a restore takes effect after the controller restarts.
-              </p>
-            </div>
-          )}
         </CardContent>
       </Card>
     </div>

--- a/controller/src/lib/backup.ts
+++ b/controller/src/lib/backup.ts
@@ -3,17 +3,25 @@
  *
  * Backup: take a consistent snapshot of controller.db via `VACUUM INTO` (safe while the DB is live),
  * upload it to WebDAV as both a timestamped file and `controller-latest.db`, then prune old
- * timestamped backups beyond the retention count.
+ * timestamped backups down to the grandfather-father-son retention policy.
  *
  * Restore: download a backup and stage it as `<dbPath>.restore`. On next boot, db() swaps a staged
  * restore in before opening (see applyStagedRestore). This avoids mutating an open SQLite file.
+ *
+ * Backups live in an env-scoped collection (see webdavConfig) so a prod and a dev controller can
+ * share one WebDAV target without clobbering each other.
  */
 
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { basename } from "node:path";
 import { db } from "./db";
 import { env } from "./env";
-import { getSetting, isWebdavConfigured, webdavConfig } from "./settings";
+import {
+  getSetting,
+  isWebdavConfigured,
+  setSetting,
+  webdavConfig,
+} from "./settings";
 import * as webdav from "./webdav";
 
 const LATEST = "controller-latest.db";
@@ -29,6 +37,13 @@ function snapshot(): Buffer {
   return data;
 }
 
+/** Parse the epoch-ms timestamp out of a `controller-<stamp>.db` name; null if it doesn't match. */
+function parseStamp(name: string): number | null {
+  if (!name.startsWith(PREFIX) || !name.endsWith(".db") || name === LATEST) return null;
+  const n = Number(name.slice(PREFIX.length, -3));
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
 export interface BackupResult {
   ok: boolean;
   name?: string;
@@ -36,9 +51,23 @@ export interface BackupResult {
   error?: string;
 }
 
+export interface BackupEntry {
+  name: string;
+  stamp: number; // epoch ms
+}
+
+/** Persist the outcome of a backup run so the UI can show last-run status / errors. */
+function recordRun(stamp: number, r: BackupResult): void {
+  setSetting("backupLastRun", stamp);
+  setSetting("backupLastStatus", r.ok ? "ok" : "failed");
+  setSetting("backupLastError", r.ok ? "" : r.error ?? "Unknown error");
+  if (r.ok && r.name) setSetting("backupLastName", r.name);
+}
+
 /** Back up the controller DB and ask every node to back up its local state DB to the same WebDAV. */
 export async function backupAll(stamp = Date.now()): Promise<BackupResult> {
   const result = await backupNow(stamp);
+  recordRun(stamp, result);
   if (isWebdavConfigured()) {
     const cfg = webdavConfig();
     const nodes = db().prepare("SELECT name FROM nodes").all() as { name: string }[];
@@ -68,24 +97,81 @@ export async function backupNow(stamp = Date.now()): Promise<BackupResult> {
   }
 }
 
+/**
+ * Grandfather-father-son selection: keep the newest `recent`, plus the newest backup in each of the
+ * most recent `weekly` weeks, `monthly` months, and `yearly` years. Returns the stamps to retain.
+ */
+function selectKeep(
+  stamps: number[],
+  keep: { recent: number; weekly: number; monthly: number; yearly: number },
+): Set<number> {
+  const sorted = [...stamps].sort((a, b) => b - a); // newest first
+  const keepSet = new Set<number>();
+  for (let i = 0; i < Math.min(keep.recent, sorted.length); i++) keepSet.add(sorted[i]);
+
+  // For the most recent `count` distinct buckets, keep the newest backup falling in each.
+  const keepPerBucket = (bucketOf: (s: number) => string, count: number) => {
+    if (count <= 0) return;
+    const seen = new Set<string>();
+    for (const s of sorted) {
+      const b = bucketOf(s);
+      if (seen.has(b)) continue; // an even newer backup already represents this bucket
+      if (seen.size >= count) break; // past the N most-recent buckets
+      seen.add(b);
+      keepSet.add(s);
+    }
+  };
+  const week = (s: number) => String(Math.floor(s / 604_800_000)); // 7 days, epoch-anchored
+  const month = (s: number) => {
+    const d = new Date(s);
+    return `${d.getUTCFullYear()}-${d.getUTCMonth()}`;
+  };
+  const year = (s: number) => String(new Date(s).getUTCFullYear());
+  keepPerBucket(week, keep.weekly);
+  keepPerBucket(month, keep.monthly);
+  keepPerBucket(year, keep.yearly);
+  return keepSet;
+}
+
 async function pruneBackups(): Promise<void> {
-  const retention = getSetting("webdavRetention");
   const cfg = webdavConfig();
-  const stamped = (await webdav.list(cfg))
-    .filter((n) => n.startsWith(PREFIX) && n !== LATEST)
-    .sort(); // timestamp-named -> lexical sort == chronological
-  const excess = stamped.length - retention;
-  for (let i = 0; i < excess; i++) {
-    await webdav.del(cfg, stamped[i]);
+  const entries = (await webdav.list(cfg))
+    .map((name) => ({ name, stamp: parseStamp(name) }))
+    .filter((e): e is BackupEntry => e.stamp !== null);
+  const keep = selectKeep(entries.map((e) => e.stamp), {
+    recent: getSetting("backupKeepRecent"),
+    weekly: getSetting("backupKeepWeekly"),
+    monthly: getSetting("backupKeepMonthly"),
+    yearly: getSetting("backupKeepYearly"),
+  });
+  for (const e of entries) {
+    if (!keep.has(e.stamp)) await webdav.del(cfg, e.name);
   }
 }
 
-export async function listBackups(): Promise<string[]> {
+/** Timestamped backups, newest first, for the current environment. */
+export async function listBackups(): Promise<BackupEntry[]> {
   if (!isWebdavConfigured()) return [];
   return (await webdav.list(webdavConfig()))
-    .filter((n) => n.startsWith(PREFIX))
-    .sort()
-    .reverse();
+    .map((name) => ({ name, stamp: parseStamp(name) }))
+    .filter((e): e is BackupEntry => e.stamp !== null)
+    .sort((a, b) => b.stamp - a.stamp);
+}
+
+/** Verify the WebDAV target is reachable and writable with the configured credentials. */
+export async function testConnection(): Promise<{ ok: boolean; error?: string }> {
+  if (!isWebdavConfigured()) return { ok: false, error: "WebDAV not configured" };
+  try {
+    const cfg = webdavConfig();
+    await webdav.ensureCollection(cfg);
+    // A round-trip PUT/DELETE surfaces auth (401), gateway (502), and read-only errors that a
+    // bare PROPFIND would swallow.
+    await webdav.put(cfg, ".labmgr-probe", Buffer.from("ok"));
+    await webdav.del(cfg, ".labmgr-probe");
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
 }
 
 /** Download a backup and stage it; takes effect on the next controller restart. */
@@ -95,7 +181,7 @@ export async function stageRestore(name: string): Promise<{ ok: boolean; error?:
   // next-boot DB. basename() already blocks traversal; this also blocks substituting a foreign file.
   const safe = basename(name);
   const known = await listBackups();
-  if (!known.includes(safe)) return { ok: false, error: "Unknown backup name" };
+  if (!known.some((e) => e.name === safe)) return { ok: false, error: "Unknown backup name" };
   try {
     const data = await webdav.get(webdavConfig(), safe);
     writeFileSync(`${env.dbPath}.restore`, data);

--- a/controller/src/lib/maintenance.ts
+++ b/controller/src/lib/maintenance.ts
@@ -27,6 +27,98 @@ export function hourInTimezone(now: number, tz: string): number | null {
   }
 }
 
+/** Offset in ms such that local-wall-clock = utc + offset, for an instant in a timezone. */
+function tzOffsetMs(utcMs: number, tz: string): number {
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+  const p: Record<string, number> = {};
+  for (const part of fmt.formatToParts(new Date(utcMs))) {
+    if (part.type !== "literal") p[part.type] = Number(part.value);
+  }
+  const asUTC = Date.UTC(p.year, p.month - 1, p.day, p.hour, p.minute, p.second);
+  return asUTC - utcMs;
+}
+
+/** The UTC instant for a wall-clock time on a given calendar day in a timezone. */
+function wallClockToUtc(
+  y: number,
+  mo: number,
+  d: number,
+  h: number,
+  mi: number,
+  tz: string,
+): number {
+  let ts = Date.UTC(y, mo, d, h, mi, 0);
+  // Two passes converge across DST boundaries (the offset depends on the instant we're solving for).
+  for (let i = 0; i < 2; i++) ts = Date.UTC(y, mo, d, h, mi, 0) - tzOffsetMs(ts, tz);
+  return ts;
+}
+
+/** The anchor-aligned schedule grid, or null when scheduled backups are off / misconfigured. */
+function backupGrid(now: number): { anchor: number; intervalMs: number } | null {
+  if (!getSetting("backupEnabled")) return null;
+  const intervalHours = getSetting("backupIntervalHours");
+  if (!(intervalHours > 0)) return null;
+  const tz = getSetting("backupTimezone");
+  let parts: Record<string, number>;
+  try {
+    const fmt = new Intl.DateTimeFormat("en-US", {
+      timeZone: tz,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    });
+    parts = {};
+    for (const part of fmt.formatToParts(new Date(now))) {
+      if (part.type !== "literal") parts[part.type] = Number(part.value);
+    }
+  } catch {
+    return null; // invalid timezone -> don't fire on a guess
+  }
+  const anchor = wallClockToUtc(
+    parts.year,
+    parts.month - 1,
+    parts.day,
+    getSetting("backupAnchorHour"),
+    getSetting("backupAnchorMinute"),
+    tz,
+  );
+  return { anchor, intervalMs: intervalHours * 3600 * 1000 };
+}
+
+/** First scheduled instant strictly after `ref` on the anchor grid, or null if disabled. */
+function slotAfter(ref: number, now: number): number | null {
+  const g = backupGrid(now);
+  if (!g) return null;
+  const k = Math.floor((ref - g.anchor) / g.intervalMs) + 1;
+  let next = g.anchor + k * g.intervalMs;
+  while (next <= ref) next += g.intervalMs;
+  return next;
+}
+
+/** The next scheduled backup instant (epoch ms), or null if scheduled backups are off. */
+export function nextBackupRun(now = Date.now()): number | null {
+  // Reference off the last run, but never further back than one interval, so a never-run or
+  // long-idle controller still shows a sensible near-future time rather than an ancient slot.
+  const intervalMs = getSetting("backupIntervalHours") * 3600 * 1000;
+  const ref = Math.max(getSetting("backupLastRun"), now - intervalMs);
+  return slotAfter(ref, now);
+}
+
+/** Whether a scheduled backup is due (the slot after the last run has arrived). */
+export function backupDue(now = Date.now()): boolean {
+  const next = slotAfter(getSetting("backupLastRun"), now);
+  return next !== null && now >= next;
+}
+
 /**
  * Enqueue a ZFS scrub to every online ZFS-capable node whose last scheduled scrub is older than the
  * configured interval, but only during the configured hour-of-day (in the configured timezone) so
@@ -100,16 +192,13 @@ export function scheduleOldFileScans(now = Date.now()): string[] {
 /** Start an hourly ticker: prune old data, run scheduled backups, and kick off due ZFS scrubs. */
 export function startMaintenance(): NodeJS.Timeout {
   pruneOldData();
-  let lastBackup = 0;
   const tick = () => {
     pruneOldData();
     scheduleScrubs();
     scheduleOldFileScans();
-    const intervalHours = getSetting("backupIntervalHours");
-    if (intervalHours > 0 && Date.now() - lastBackup >= intervalHours * 3600 * 1000) {
-      lastBackup = Date.now();
-      void backupAll();
-    }
+    // backupAll persists the last-run timestamp, so the schedule survives restarts and the next slot
+    // is computed off durable state rather than an in-memory counter.
+    if (backupDue()) void backupAll();
   };
   return setInterval(tick, 60 * 60 * 1000);
 }

--- a/controller/src/lib/settings.ts
+++ b/controller/src/lib/settings.ts
@@ -6,6 +6,7 @@
 
 import { db } from "./db";
 import { enqueueTask } from "./queue";
+import { env } from "./env";
 import { decryptSecret, encryptSecret } from "./secrets";
 
 export const TIB = 1024 ** 4;
@@ -59,12 +60,30 @@ export interface Settings {
   nodeOfflineGraceSeconds: number; // tolerate a node disconnect this long before alerting admins
   logRetentionDays: number;
   quotaAlertPct: number; // email the PI when a lab pool crosses this percent
-  // WebDAV backup target.
-  webdavUrl: string; // e.g. https://dav.example.com/labmgr
+  // WebDAV backup target. Backups are written under <webdavUrl>/<webdavBaseDir>/<env> where env is
+  // "prod" or "dev" (derived from NODE_ENV) so a shared store keeps the two deployments separate.
+  webdavUrl: string; // connection root, e.g. https://dav.example.com/dav
   webdavUser: string;
   webdavPass: string;
-  webdavRetention: number; // keep this many timestamped backups
-  backupIntervalHours: number; // 0 disables scheduled backups
+  webdavBaseDir: string; // collection under the root, e.g. /backups
+  // Scheduled backups run every backupIntervalHours, aligned to an anchor time-of-day evaluated in
+  // backupTimezone (so "daily at 02:00" survives DST). backupEnabled gates the scheduler.
+  backupEnabled: boolean;
+  backupIntervalHours: number; // hours between runs (must be > 0)
+  backupAnchorHour: number; // 0-23, the time-of-day the schedule is aligned to
+  backupAnchorMinute: number; // 0-59
+  backupTimezone: string; // IANA tz the anchor time is evaluated in
+  // Grandfather-father-son retention: keep the newest N, plus the newest backup in each of the most
+  // recent N weeks, months, and years.
+  backupKeepRecent: number;
+  backupKeepWeekly: number;
+  backupKeepMonthly: number;
+  backupKeepYearly: number;
+  // Last-run state, written by the backup runner and surfaced as status in the UI.
+  backupLastRun: number; // epoch ms, 0 = never
+  backupLastStatus: "" | "ok" | "failed";
+  backupLastError: string;
+  backupLastName: string;
   // Scheduled ZFS scrub. The controller enqueues node.scrub to each ZFS-capable node when due;
   // the agent reports scrub status/errors back via heartbeat telemetry.
   scrubEnabled: boolean;
@@ -171,8 +190,20 @@ export const DEFAULT_SETTINGS: Settings = {
   webdavUrl: "",
   webdavUser: "",
   webdavPass: "",
-  webdavRetention: 7,
+  webdavBaseDir: "/backups",
+  backupEnabled: false,
   backupIntervalHours: 24,
+  backupAnchorHour: 2,
+  backupAnchorMinute: 0,
+  backupTimezone: "America/New_York",
+  backupKeepRecent: 7,
+  backupKeepWeekly: 4,
+  backupKeepMonthly: 12,
+  backupKeepYearly: 3,
+  backupLastRun: 0,
+  backupLastStatus: "",
+  backupLastError: "",
+  backupLastName: "",
   scrubEnabled: false,
   scrubIntervalDays: 30,
   scrubHour: 2,
@@ -183,9 +214,21 @@ export function isWebdavConfigured(): boolean {
   return getSetting("webdavUrl").trim() !== "";
 }
 
+/** Which environment's backup collection this deployment reads/writes. */
+export function backupEnv(): "prod" | "dev" {
+  return env.isProd ? "prod" : "dev";
+}
+
+/**
+ * The env-scoped WebDAV collection backups are written to: <webdavUrl>/<webdavBaseDir>/<env>.
+ * All slashes are normalised so the parts join cleanly regardless of leading/trailing slashes.
+ */
 export function webdavConfig() {
+  const root = getSetting("webdavUrl").trim().replace(/\/+$/, "");
+  const base = getSetting("webdavBaseDir").trim().replace(/^\/+|\/+$/g, "");
+  const url = [root, base, backupEnv()].filter(Boolean).join("/");
   return {
-    url: getSetting("webdavUrl").trim().replace(/\/$/, ""),
+    url,
     user: getSetting("webdavUser"),
     pass: getSetting("webdavPass"),
   };

--- a/controller/src/lib/webdav.ts
+++ b/controller/src/lib/webdav.ts
@@ -22,10 +22,19 @@ function dav(url: string, init: RequestInit): Promise<Response> {
 }
 
 export async function ensureCollection(cfg: WebdavConfig): Promise<void> {
-  // MKCOL is idempotent enough: 405/301 means it already exists.
-  const res = await dav(cfg.url, { method: "MKCOL", headers: authHeader(cfg) });
-  if (![200, 201, 204, 301, 405].includes(res.status)) {
-    // Not fatal — some servers disallow MKCOL on an existing collection.
+  // MKCOL is not recursive, so walk the URL's path and create each segment from the root outward
+  // (e.g. /db-backup, /db-backup/backups, /db-backup/backups/dev). Non-success statuses are ignored:
+  // 405/301 means the collection already exists, and some servers disallow MKCOL on existing ones.
+  let u: URL;
+  try {
+    u = new URL(cfg.url);
+  } catch {
+    return;
+  }
+  let path = "";
+  for (const seg of u.pathname.split("/").filter(Boolean)) {
+    path += `/${seg}`;
+    await dav(`${u.origin}${path}`, { method: "MKCOL", headers: authHeader(cfg) }).catch(() => {});
   }
 }
 

--- a/controller/tests/actions-auth.test.ts
+++ b/controller/tests/actions-auth.test.ts
@@ -25,11 +25,13 @@ describe("Server Actions reject unauthenticated callers", () => {
   let labs: typeof import("../src/app/(app)/labs/actions.js");
   let students: typeof import("../src/app/(app)/students/actions.js");
   let settings: typeof import("../src/app/(app)/settings/actions.js");
+  let backups: typeof import("../src/app/(app)/backups/actions.js");
 
   beforeAll(async () => {
     labs = await import("../src/app/(app)/labs/actions.js");
     students = await import("../src/app/(app)/students/actions.js");
     settings = await import("../src/app/(app)/settings/actions.js");
+    backups = await import("../src/app/(app)/backups/actions.js");
   });
 
   const fd = () => new FormData();
@@ -51,10 +53,13 @@ describe("Server Actions reject unauthenticated callers", () => {
       settings.saveGpuPolicyAction(fd()),
       settings.saveScrubSettingsAction(fd()),
       settings.scrubNowAction(),
-      settings.saveWebdavSettingsAction(fd()),
-      settings.backupNowAction(),
-      settings.restoreAction(fd()),
       settings.testEmailAction(fd()),
+      backups.saveWebdavSettingsAction(fd()),
+      backups.saveScheduleAction(fd()),
+      backups.testConnectionAction(),
+      backups.backupNowAction(),
+      backups.restoreAction(fd()),
+      backups.refreshAction(),
     ];
     for (const c of calls) {
       await expect(c).rejects.toThrow(/NEXT_REDIRECT:\/login/);

--- a/controller/tests/backup.test.ts
+++ b/controller/tests/backup.test.ts
@@ -38,7 +38,11 @@ beforeAll(async () => {
   backup = await import("../src/lib/backup");
   dbmod.db().prepare("INSERT INTO settings (key, value) VALUES ('x','1')").run();
   settings.setSetting("webdavUrl", "https://dav.example/labmgr");
-  settings.setSetting("webdavRetention", 2);
+  // Keep the newest 2; disable the weekly/monthly/yearly tiers so the test exercises plain pruning.
+  settings.setSetting("backupKeepRecent", 2);
+  settings.setSetting("backupKeepWeekly", 0);
+  settings.setSetting("backupKeepMonthly", 0);
+  settings.setSetting("backupKeepYearly", 0);
 });
 
 describe("controller backup", () => {
@@ -53,11 +57,11 @@ describe("controller backup", () => {
 
   it("prunes timestamped backups beyond retention", async () => {
     await backup.backupNow(2000);
-    await backup.backupNow(3000); // retention=2 -> oldest (1000) pruned
-    const list = await backup.listBackups();
-    expect(list).not.toContain("controller-1000.db");
-    expect(list).toContain("controller-3000.db");
-    expect(list).toContain("controller-2000.db");
+    await backup.backupNow(3000); // keepRecent=2 -> oldest (1000) pruned
+    const names = (await backup.listBackups()).map((e) => e.name);
+    expect(names).not.toContain("controller-1000.db");
+    expect(names).toContain("controller-3000.db");
+    expect(names).toContain("controller-2000.db");
   });
 
   it("stages a restore to <dbPath>.restore", async () => {

--- a/controller/tests/settings.test.ts
+++ b/controller/tests/settings.test.ts
@@ -86,15 +86,18 @@ describe("configuration helpers", () => {
     expect(settings.isSmtpConfigured()).toBe(true);
   });
 
-  it("isWebdavConfigured + webdavConfig strip the trailing slash", () => {
+  it("webdavConfig composes <url>/<baseDir>/<env>, normalising slashes", () => {
     settings.setSetting("webdavUrl", "");
     expect(settings.isWebdavConfigured()).toBe(false);
     settings.setSetting("webdavUrl", "https://dav.example/labmgr/");
+    settings.setSetting("webdavBaseDir", "/backups/");
     settings.setSetting("webdavUser", "bob");
     settings.setSetting("webdavPass", "pw");
     expect(settings.isWebdavConfigured()).toBe(true);
+    // env is "dev" outside NODE_ENV=production (see backupEnv()).
+    expect(settings.backupEnv()).toBe("dev");
     expect(settings.webdavConfig()).toEqual({
-      url: "https://dav.example/labmgr",
+      url: "https://dav.example/labmgr/backups/dev",
       user: "bob",
       pass: "pw",
     });


### PR DESCRIPTION
Promotes DB backup from a card in Settings to its own sidebar entry (`/backups`) with the full feature set.

## Page
- **Status** — last run + OK/FAILED, next scheduled run, last error
- **WebDAV connection** — URL, user, password, base directory; Save / Test connection / Backup now
- **Schedule & retention** — enable toggle, interval, anchor time + timezone (DST-aware), grandfather-father-son keep recent/weekly/monthly/yearly
- **Available backups** (env-scoped) with Refresh + Stage restore

## Backend
- Env-scoped storage under `<url>/<baseDir>/{prod,dev}`; `ensureCollection` now creates nested path segments (MKCOL isn't recursive)
- `backup.ts`: GFS pruning, `testConnection` probe, persisted last-run status, richer `listBackups` (name + timestamp)
- `maintenance.ts`: anchor + interval + timezone scheduler with persistent last-run, `nextBackupRun()` / `backupDue()`
- Backup Server Actions moved to `backups/actions.ts`; dropped the old single-count `webdavRetention` setting

## Behavior notes
- Scheduled backups are now gated by an explicit **Enable** toggle (default off), replacing the old "interval > 0" convention — existing deployments must flip it on
- Anchor minute is stored/displayed but the ticker runs hourly, so firing has hour granularity

## Verification
typecheck, lint, affected tests (4 passing), and full `next build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)