### PR TITLE
fix(controller): live WebDAV status + pending button feedback on Backups

### DIFF
--- a/controller/package-lock.json
+++ b/controller/package-lock.json
@@ -33,6 +33,7 @@
         "@types/node": "^26.0.0",
         "@types/nodemailer": "^8.0.1",
         "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
         "@types/ws": "^8.5.12",
         "eslint": "^9",
         "eslint-config-next": "^16.2.9",
@@ -2899,6 +2900,16 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/ws": {

--- a/controller/package.json
+++ b/controller/package.json
@@ -40,6 +40,7 @@
     "@types/node": "^26.0.0",
     "@types/nodemailer": "^8.0.1",
     "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
     "@types/ws": "^8.5.12",
     "eslint": "^9",
     "eslint-config-next": "^16.2.9",

--- a/controller/src/app/(app)/backups/_components/SubmitButton.tsx
+++ b/controller/src/app/(app)/backups/_components/SubmitButton.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+/**
+ * A form submit button that reflects the pending state of its enclosing <form>. While the server
+ * action runs it disables itself and swaps its leading icon for a spinner (optionally showing
+ * `pendingText`), so the user gets immediate feedback instead of a dead-looking button.
+ *
+ * useFormStatus tracks the *nearest* parent form, so give each action its own <form> when you want
+ * independent per-button feedback rather than every button in a shared form spinning at once.
+ */
+
+import { useFormStatus } from "react-dom";
+import { Loader2 } from "lucide-react";
+import { Button, type ButtonProps } from "@/components/ui/button";
+
+interface SubmitButtonProps extends Omit<ButtonProps, "type"> {
+  /** Leading icon shown when idle (replaced by a spinner while pending). */
+  icon?: React.ReactNode;
+  /** Optional label to show while the action runs (defaults to children). */
+  pendingText?: React.ReactNode;
+}
+
+export function SubmitButton({ icon, pendingText, children, ...props }: SubmitButtonProps) {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" disabled={pending} aria-busy={pending} {...props}>
+      {pending ? <Loader2 className="animate-spin" /> : icon}
+      {pending && pendingText ? pendingText : children}
+    </Button>
+  );
+}

--- a/controller/src/app/(app)/backups/page.tsx
+++ b/controller/src/app/(app)/backups/page.tsx
@@ -1,13 +1,26 @@
-import { Clock, Database, HardDriveDownload, Play, RefreshCw, Save, Server } from "lucide-react";
+import { Suspense, cache } from "react";
+import {
+  AlertCircle,
+  CheckCircle2,
+  Clock,
+  Database,
+  HardDriveDownload,
+  Loader2,
+  Play,
+  RefreshCw,
+  Save,
+  Server,
+  XCircle,
+} from "lucide-react";
 import { backupEnv, getSettings, isWebdavConfigured } from "@/lib/settings";
-import { listBackups, type BackupEntry } from "@/lib/backup";
+import { webdavStatus } from "@/lib/backup";
 import { nextBackupRun } from "@/lib/maintenance";
-import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { ClientTime } from "./_components/ClientTime";
+import { SubmitButton } from "./_components/SubmitButton";
 import {
   backupNowAction,
   refreshAction,
@@ -34,6 +47,93 @@ const COMMON_TIMEZONES = [
 
 export const dynamic = "force-dynamic";
 
+// Shared, request-scoped: the live status badge and the backup list both read this, but it issues a
+// single PROPFIND per render thanks to cache().
+const loadStatus = cache(webdavStatus);
+
+function Checking({ label }: { label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 text-sm text-muted-foreground">
+      <Loader2 className="h-4 w-4 animate-spin" /> {label}
+    </span>
+  );
+}
+
+/** Live WebDAV connection state, streamed in after the shell paints. */
+async function WebdavStatusBadge() {
+  const st = await loadStatus();
+  if (!st.configured) {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-sm text-muted-foreground">
+        <AlertCircle className="h-4 w-4" /> Not configured
+      </span>
+    );
+  }
+  if (st.ok) {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-sm text-emerald-500">
+        <CheckCircle2 className="h-4 w-4" /> Connected — {st.backups.length} backup
+        {st.backups.length === 1 ? "" : "s"} available
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-start gap-1.5 text-sm text-destructive">
+      <XCircle className="mt-0.5 h-4 w-4 shrink-0" /> Unreachable — {st.error}
+    </span>
+  );
+}
+
+/** The available-backups table, gated on actual reachability so failures aren't shown as "empty". */
+async function BackupsList() {
+  const st = await loadStatus();
+  if (!st.configured) {
+    return (
+      <p className="text-sm text-muted-foreground">Configure a WebDAV target above to see backups.</p>
+    );
+  }
+  if (!st.ok) {
+    return <p className="text-sm text-destructive">Could not list backups: {st.error}</p>;
+  }
+  if (st.backups.length === 0) {
+    return <p className="text-sm text-muted-foreground">No backups found.</p>;
+  }
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Backup</TableHead>
+          <TableHead>Taken</TableHead>
+          <TableHead></TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {st.backups.map((b) => (
+          <TableRow key={b.name}>
+            <TableCell className="font-mono text-xs">{b.name}</TableCell>
+            <TableCell className="text-sm">
+              <ClientTime ts={b.stamp} />
+            </TableCell>
+            <TableCell className="text-right">
+              <form action={restoreAction}>
+                <input type="hidden" name="name" value={b.name} />
+                <SubmitButton
+                  variant="secondary"
+                  size="sm"
+                  icon={<HardDriveDownload />}
+                  pendingText="Staging…"
+                >
+                  Stage restore
+                </SubmitButton>
+              </form>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
 export default async function BackupsPage({
   searchParams,
 }: {
@@ -43,15 +143,7 @@ export default async function BackupsPage({
   const s = getSettings();
   const env = backupEnv();
   const nextRun = nextBackupRun();
-
-  let backups: BackupEntry[] = [];
-  if (isWebdavConfigured()) {
-    try {
-      backups = await listBackups();
-    } catch {
-      backups = [];
-    }
-  }
+  const configured = isWebdavConfigured();
 
   const anchor = `${String(s.backupAnchorHour).padStart(2, "0")}:${String(
     s.backupAnchorMinute,
@@ -69,6 +161,16 @@ export default async function BackupsPage({
           <h3 className="flex items-center gap-2 text-base font-semibold">
             <Clock className="h-4 w-4" /> Status
           </h3>
+          <p className="text-sm">
+            <span className="font-medium">Connection: </span>
+            {configured ? (
+              <Suspense fallback={<Checking label="Checking connection…" />}>
+                <WebdavStatusBadge />
+              </Suspense>
+            ) : (
+              <span className="text-muted-foreground">not configured</span>
+            )}
+          </p>
           <p className="text-sm">
             <span className="font-medium">Last run: </span>
             <ClientTime ts={s.backupLastRun} />
@@ -116,18 +218,26 @@ export default async function BackupsPage({
                 <code>{s.webdavBaseDir.replace(/\/+$/, "")}/dev</code>.
               </p>
             </div>
-            <div className="flex flex-wrap gap-2 sm:col-span-2">
-              <Button type="submit">
-                <Save /> Save configuration
-              </Button>
-              <Button type="submit" formAction={testConnectionAction} variant="outline">
-                <Server /> Test connection
-              </Button>
-              <Button type="submit" formAction={backupNowAction} variant="outline">
-                <Play /> Backup now
-              </Button>
+            <div className="sm:col-span-2">
+              <SubmitButton icon={<Save />} pendingText="Saving…">
+                Save configuration
+              </SubmitButton>
             </div>
           </form>
+          {/* Test / Backup act on the saved settings (not the fields above), so they get their own
+              forms — that keeps each button's pending spinner independent. */}
+          <div className="flex flex-wrap items-center gap-2">
+            <form action={testConnectionAction}>
+              <SubmitButton variant="outline" icon={<Server />} pendingText="Testing…">
+                Test connection
+              </SubmitButton>
+            </form>
+            <form action={backupNowAction}>
+              <SubmitButton variant="outline" icon={<Play />} pendingText="Backing up…">
+                Backup now
+              </SubmitButton>
+            </form>
+          </div>
         </CardContent>
       </Card>
 
@@ -194,9 +304,9 @@ export default async function BackupsPage({
               N weeks, months, and years.
             </p>
 
-            <Button type="submit">
-              <Save /> Save configuration
-            </Button>
+            <SubmitButton icon={<Save />} pendingText="Saving…">
+              Save configuration
+            </SubmitButton>
           </form>
         </CardContent>
       </Card>
@@ -208,51 +318,16 @@ export default async function BackupsPage({
             <Database className="h-4 w-4" /> Available backups ({env})
           </h3>
           <form action={refreshAction}>
-            <Button type="submit" variant="outline" size="sm">
-              <RefreshCw /> Refresh
-            </Button>
+            <SubmitButton variant="outline" size="sm" icon={<RefreshCw />} pendingText="Refreshing…">
+              Refresh
+            </SubmitButton>
           </form>
-          {backups.length > 0 ? (
-            <>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Backup</TableHead>
-                    <TableHead>Taken</TableHead>
-                    <TableHead></TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {backups.map((b) => (
-                    <TableRow key={b.name}>
-                      <TableCell className="font-mono text-xs">{b.name}</TableCell>
-                      <TableCell className="text-sm">
-                        <ClientTime ts={b.stamp} />
-                      </TableCell>
-                      <TableCell className="text-right">
-                        <form action={restoreAction}>
-                          <input type="hidden" name="name" value={b.name} />
-                          <Button type="submit" variant="secondary" size="sm">
-                            <HardDriveDownload /> Stage restore
-                          </Button>
-                        </form>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-              <p className="text-xs text-muted-foreground">
-                Restoring stages the backup; it replaces the live database on the next service restart.
-              </p>
-            </>
-          ) : (
-            <>
-              <p className="text-sm text-muted-foreground">No backups found.</p>
-              <p className="text-xs text-muted-foreground">
-                Restoring stages the backup; it replaces the live database on the next service restart.
-              </p>
-            </>
-          )}
+          <Suspense fallback={<Checking label="Loading backups…" />}>
+            <BackupsList />
+          </Suspense>
+          <p className="text-xs text-muted-foreground">
+            Restoring stages the backup; it replaces the live database on the next service restart.
+          </p>
         </CardContent>
       </Card>
     </div>

--- a/controller/src/lib/backup.ts
+++ b/controller/src/lib/backup.ts
@@ -158,6 +158,36 @@ export async function listBackups(): Promise<BackupEntry[]> {
     .sort((a, b) => b.stamp - a.stamp);
 }
 
+export interface WebdavStatus {
+  configured: boolean;
+  ok: boolean;
+  error?: string;
+  backups: BackupEntry[];
+}
+
+/**
+ * Live, read-only reachability check for the configured WebDAV target. A single PROPFIND tells us
+ * whether the collection is reachable with the saved credentials and, as a side effect, returns the
+ * available backups — so the UI can show the actual connection state instead of a silent empty list.
+ */
+export async function webdavStatus(): Promise<WebdavStatus> {
+  if (!isWebdavConfigured()) return { configured: false, ok: false, backups: [] };
+  try {
+    const backups = (await webdav.listStrict(webdavConfig()))
+      .map((name) => ({ name, stamp: parseStamp(name) }))
+      .filter((e): e is BackupEntry => e.stamp !== null)
+      .sort((a, b) => b.stamp - a.stamp);
+    return { configured: true, ok: true, backups };
+  } catch (err) {
+    return {
+      configured: true,
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+      backups: [],
+    };
+  }
+}
+
 /** Verify the WebDAV target is reachable and writable with the configured credentials. */
 export async function testConnection(): Promise<{ ok: boolean; error?: string }> {
   if (!isWebdavConfigured()) return { ok: false, error: "WebDAV not configured" };

--- a/controller/src/lib/webdav.ts
+++ b/controller/src/lib/webdav.ts
@@ -57,14 +57,18 @@ export async function del(cfg: WebdavConfig, name: string): Promise<void> {
   await dav(`${cfg.url}/${name}`, { method: "DELETE", headers: authHeader(cfg) });
 }
 
-/** List entry hrefs in the collection (Depth: 1). Returns basenames, excluding the collection itself. */
-export async function list(cfg: WebdavConfig): Promise<string[]> {
+/**
+ * List entry basenames in the collection (Depth: 1), excluding the collection itself.
+ * Throws on a non-OK status or transport error so callers can surface a real "unreachable" state
+ * rather than confusing a failed listing with an empty collection.
+ */
+export async function listStrict(cfg: WebdavConfig): Promise<string[]> {
   const res = await dav(cfg.url, {
     method: "PROPFIND",
     headers: { ...authHeader(cfg), Depth: "1", "Content-Type": "application/xml" },
     body: '<?xml version="1.0"?><d:propfind xmlns:d="DAV:"><d:prop><d:displayname/></d:prop></d:propfind>',
   });
-  if (!res.ok) return [];
+  if (!res.ok) throw new Error(`WebDAV PROPFIND failed: ${res.status} ${res.statusText}`);
   const xml = await res.text();
   const hrefs = [...xml.matchAll(/<[a-z]*:?href>([^<]+)<\/[a-z]*:?href>/gi)].map((m) =>
     decodeURIComponent(m[1]),
@@ -72,4 +76,9 @@ export async function list(cfg: WebdavConfig): Promise<string[]> {
   return hrefs
     .map((h) => h.replace(/\/$/, "").split("/").pop() ?? "")
     .filter((b) => b && !cfg.url.endsWith(b));
+}
+
+/** Forgiving variant of {@link listStrict}: any failure (unreachable, auth, etc.) yields []. */
+export async function list(cfg: WebdavConfig): Promise<string[]> {
+  return listStrict(cfg).catch(() => []);
 }

--- a/controller/tests/backup.test.ts
+++ b/controller/tests/backup.test.ts
@@ -26,6 +26,7 @@ vi.mock("../src/lib/webdav", () => ({
     store.delete(name);
   }),
   list: vi.fn(async () => [...store.keys()]),
+  listStrict: vi.fn(async () => [...store.keys()]),
 }));
 
 let dbmod: typeof import("../src/lib/db");
@@ -71,5 +72,25 @@ describe("controller backup", () => {
     expect(existsSync(staged)).toBe(true);
     expect(readFileSync(staged).subarray(0, 15).toString()).toBe("SQLite format 3");
     rmSync(staged);
+  });
+});
+
+describe("webdavStatus", () => {
+  it("reports ok with the available backups when the collection is reachable", async () => {
+    const webdav = await import("../src/lib/webdav");
+    vi.mocked(webdav.listStrict).mockResolvedValueOnce(["controller-2000.db", "controller-3000.db"]);
+    const st = await backup.webdavStatus();
+    expect(st).toMatchObject({ configured: true, ok: true });
+    expect(st.backups.map((b) => b.name)).toEqual(["controller-3000.db", "controller-2000.db"]);
+  });
+
+  it("reports not-ok with the error when the listing fails", async () => {
+    const webdav = await import("../src/lib/webdav");
+    vi.mocked(webdav.listStrict).mockRejectedValueOnce(new Error("WebDAV PROPFIND failed: 401 Unauthorized"));
+    const st = await backup.webdavStatus();
+    expect(st.configured).toBe(true);
+    expect(st.ok).toBe(false);
+    expect(st.error).toMatch(/401/);
+    expect(st.backups).toEqual([]);
   });
 });

--- a/controller/tests/webdav.test.ts
+++ b/controller/tests/webdav.test.ts
@@ -111,3 +111,16 @@ describe("list", () => {
     expect(await webdav.list(cfg)).toEqual([]);
   });
 });
+
+describe("listStrict", () => {
+  it("throws on a non-ok status so failures aren't mistaken for an empty collection", async () => {
+    vi.stubGlobal("fetch", mockFetch(() => ({ ok: false, status: 401, statusText: "Unauthorized" })));
+    await expect(webdav.listStrict(cfg)).rejects.toThrow(/401/);
+  });
+
+  it("returns basenames on success", async () => {
+    const xml = `<d:multistatus xmlns:d="DAV:"><d:response><d:href>/labmgr/controller-1000.db</d:href></d:response></d:multistatus>`;
+    vi.stubGlobal("fetch", mockFetch(() => ({ ok: true, _text: xml })));
+    expect(await webdav.listStrict(cfg)).toEqual(["controller-1000.db"]);
+  });
+});


### PR DESCRIPTION
## Problem
The Backups page felt broken: it loaded slowly and clicking any button gave no feedback, so a closed/unreachable WebDAV target looked fine and clicks looked dead.

Root causes:
- The page did a **blocking** WebDAV `PROPFIND` at render time (up to the 15s timeout) before painting anything.
- A failed listing was **silently swallowed** as "No backups found" — indistinguishable from a genuinely empty collection.
- Action buttons had **no loading/pending state** (plain server-action form submits), so they looked frozen while the action ran, and the result only appeared after a redirect.

## Changes
- **`backup.ts`**: add `webdavStatus()` — a read-only PROPFIND returning `{configured, ok, error, backups}` so the UI shows the **actual** connection state.
- **`webdav.ts`**: add `listStrict()` that throws on non-OK/transport errors; keep `list()` as the forgiving (`→ []`) variant. Failures no longer masquerade as empty.
- **`SubmitButton`**: new client component using `useFormStatus()` — each action button disables + shows a spinner ("Testing…", "Backing up…", etc.) while its server action runs. WebDAV card buttons split into separate forms for independent pending state (Test/Backup act on saved settings, not the typed-in fields).
- **`page.tsx`**: drop the render-time blocking `listBackups()`; stream live status + the backups table via `<Suspense>` so the page paints instantly.
- Add `@types/react-dom@^19` (first `react-dom` import in the repo).

## What the admin now sees
- **Status** card shows a live line: ⚠️ Not configured / ✅ Connected — N backups / ❌ Unreachable — &lt;exact error&gt;.
- Backups card shows "Could not list backups: &lt;error&gt;" on failure instead of "No backups found".
- Buttons spin + disable while running.

## Verification
- `npm run typecheck` — clean
- `npm run lint` — clean (0 warnings)
- `npm test` — **151/151 pass**, incl. new tests for `listStrict` (throws on non-OK) and both `webdavStatus` paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)