### PR TITLE
feat(stats): per-student fast/cold usage + on-demand storage scan

### DIFF
--- a/agent/src/lab_agent/client.py
+++ b/agent/src/lab_agent/client.py
@@ -17,6 +17,7 @@ import asyncio
 import json
 import ssl
 import threading
+from typing import Any
 
 import websockets
 
@@ -41,6 +42,10 @@ class Agent:
         self.dispatcher = Dispatcher(cfg, self.log)
         self.usage = UsageState()
         self._docker_lock = threading.Lock()  # single-flight guard for the docker-layer scan
+        # On-demand usage scan (Stats page "Scan now"). Registered here rather than in the
+        # dispatcher's builtins because it reuses the agent's shared scan cache + single-flight
+        # lock, which live on the Agent, not the Dispatcher.
+        self.dispatcher.register(P.A_USAGE_SCAN, self._handle_usage_scan)
         self._connected = asyncio.Event()
 
     # ------------------------------------------------------------------ helpers
@@ -331,6 +336,20 @@ class Agent:
             usagereport.publish_snapshot(self.cfg, lab, snapshot)
         except Exception as exc:
             self.log.warn("usage", f"docker scan failed for lab '{lab}': {exc}", lab=lab)
+
+    def _handle_usage_scan(self, cfg: AgentConfig, params: dict[str, Any]) -> tuple[Any, str]:
+        """Controller-triggered usage scan for one lab (Stats page "Scan now").
+
+        Blocks on the same single-flight lock the background loop uses, so it never double-scans a
+        container, then refreshes the shared cache. The fresh per-student numbers reach the
+        controller on the next heartbeat; the returned ``scanned_at`` is the freshness timestamp.
+        """
+        lab = params["lab"]
+        users_list = params.get("users") or usagereport.list_lab_students(cfg, lab)
+        with self._docker_lock:
+            self._scan_docker_lab(lab, users_list)
+        usage = self.usage.docker_for(lab)
+        return {"lab": lab, "scanned_at": usage.scanned_at}, f"usage scan complete for '{lab}'"
 
     # ----------------------------------------------------------------- weekly in-container patching
 

--- a/agent/src/lab_agent/executors/docker.py
+++ b/agent/src/lab_agent/executors/docker.py
@@ -175,15 +175,16 @@ def writable_layer_size(name: str) -> int | None:
         return None
 
 
-def du_home(name: str, username: str, *, timeout: float = 60.0) -> int | None:
-    """Bytes used by a student's home directory inside the container, or None on failure/timeout.
+def du_path(name: str, path: str, *, timeout: float = 60.0) -> int | None:
+    """Bytes used by an absolute path inside the container, or None on failure/timeout/missing path.
 
-    The username is the only interpolated value; callers must have validated it (users.USERNAME_RE)
-    before this point. ``du -sb`` reports apparent size in bytes; we take the leading integer. A
-    bounded timeout means a student who packs their home with millions of tiny files can, at worst,
-    make their *own* number unavailable — the scan moves on rather than hanging.
+    ``path`` is interpolated into the argv, so callers must pass a trusted value — the only dynamic
+    component used here is a username already validated against ``users.USERNAME_RE``. ``du -sb``
+    reports apparent size in bytes; we take the leading integer. A bounded timeout means a student
+    who packs a directory with millions of tiny files can, at worst, make their *own* number
+    unavailable — the scan moves on rather than hanging.
     """
-    res = exec_in(name, ["du", "-sb", f"/home/{username}"], timeout=timeout)
+    res = exec_in(name, ["du", "-sb", path], timeout=timeout)
     if not res.ok:
         return None
     first = res.stdout.strip().split(None, 1)
@@ -193,3 +194,12 @@ def du_home(name: str, username: str, *, timeout: float = 60.0) -> int | None:
         return int(first[0])
     except (ValueError, TypeError):
         return None
+
+
+def du_home(name: str, username: str, *, timeout: float = 60.0) -> int | None:
+    """Bytes used by a student's home directory (installed software) inside the container.
+
+    Counts ``/home/<u>`` only; the student's scratch/cold-storage live there as symlinks, which
+    ``du`` does not follow, so the fast/cold tiers are measured separately (see ``du_path``).
+    """
+    return du_path(name, f"/home/{username}", timeout=timeout)

--- a/agent/src/lab_agent/protocol.py
+++ b/agent/src/lab_agent/protocol.py
@@ -32,6 +32,7 @@ A_NODE_REPORT_STATE = "node.report_state"
 A_NODE_BACKUP = "node.backup"
 A_NODE_SCRUB = "node.scrub"
 A_OLDFILES_SCAN = "oldfiles.scan"
+A_USAGE_SCAN = "usage.scan"  # on-demand per-student storage (du) scan for one lab
 
 
 def now_ms() -> int:

--- a/agent/src/lab_agent/telemetry.py
+++ b/agent/src/lab_agent/telemetry.py
@@ -51,14 +51,28 @@ def _dataset_usage(cfg: AgentConfig, docker_state: Any = None) -> list[dict[str,
             }
         )
     out.extend(coldstore.list_usage(cfg))
-    # Cached docker writable-layer usage (pool="docker"), so the controller stores per-student
-    # "installed software" alongside the ZFS tiers. Computed by the scan loop, not measured here.
+    # Cached scan results: the docker writable layer (pool="docker") plus the per-student scratch/
+    # cold ``du`` breakdown (pool="fast"/"slow"), so the controller stores per-student usage that
+    # ZFS metadata can't break down. Computed by the scan loop / on demand, not measured here.
     if docker_state is not None:
         from . import usagereport
 
         for lab, usage in docker_state.all_docker().items():
             out.extend(usagereport.docker_datasets(lab, usage))
+            out.extend(usagereport.tier_datasets(lab, usage))
     return out
+
+
+def _usage_scans(docker_state: Any = None) -> list[dict[str, Any]]:
+    """Per-lab timestamp of the last per-student usage (``du``) scan, so the controller can show
+    data freshness and decide whether an on-demand rescan is warranted."""
+    if docker_state is None:
+        return []
+    return [
+        {"lab": lab, "scanned_at": usage.scanned_at}
+        for lab, usage in docker_state.all_docker().items()
+        if usage.scanned_at is not None
+    ]
 
 
 def collect_heartbeat(cfg: AgentConfig, docker_state: Any = None) -> dict[str, Any]:
@@ -67,4 +81,5 @@ def collect_heartbeat(cfg: AgentConfig, docker_state: Any = None) -> dict[str, A
         "datasets": _dataset_usage(cfg, docker_state),
         "scrub": [zfs.scrub_status(p).to_dict() for p in cfg.scrub_pools],
         "gpu_processes": list_gpu_processes(),
+        "usage_scans": _usage_scans(docker_state),
     }

--- a/agent/src/lab_agent/usagereport.py
+++ b/agent/src/lab_agent/usagereport.py
@@ -57,12 +57,20 @@ REFRESH_MARKER = ".labquota-refresh"
 
 @dataclass
 class DockerUsage:
-    """Cached docker writable-layer measurement for one lab (updated only by a scan)."""
+    """Cached per-student usage from the expensive ``du`` scan (updated only by a scan).
+
+    Holds the container writable layer total plus, for each student, the three numbers the cheap
+    publish loop cannot get from ZFS metadata: their docker home (installed software), and — since
+    there are no per-student ZFS datasets — their scratch (fast) and cold (slow) directory sizes
+    measured with ``du``.
+    """
 
     scanned_at: int | None = None  # epoch ms of the last successful scan
     status: str = "idle"  # "idle" | "running"
     total_used: int | None = None  # container writable layer (SizeRw)
-    per_user: dict[str, int] = field(default_factory=dict)  # username -> du bytes
+    per_user: dict[str, int] = field(default_factory=dict)  # username -> docker-home du bytes
+    per_user_fast: dict[str, int] = field(default_factory=dict)  # username -> scratch du bytes
+    per_user_slow: dict[str, int] = field(default_factory=dict)  # username -> cold-storage du bytes
     unattributed: int | None = None  # total - sum(per_user), files outside any home (/tmp, etc.)
 
     def to_dict(self) -> dict[str, Any]:
@@ -71,6 +79,8 @@ class DockerUsage:
             "status": self.status,
             "total_used": self.total_used,
             "per_user": dict(self.per_user),
+            "per_user_fast": dict(self.per_user_fast),
+            "per_user_slow": dict(self.per_user_slow),
             "unattributed": self.unattributed,
         }
 
@@ -193,11 +203,19 @@ def build_snapshot(
     students = []
     for name in usernames:
         tiers = lab_usage.users.get(name, {})
+        # Prefer ZFS metadata when per-student datasets exist; otherwise fall back to the docker
+        # scan's ``du`` measurement (used-only, no per-student quota — the lab quota covers all).
+        scratch = _usage_pair(tiers.get("fast"))
+        if scratch is None and name in docker_usage.per_user_fast:
+            scratch = {"used": docker_usage.per_user_fast[name], "quota": None}
+        cold = _usage_pair(tiers.get("slow"))
+        if cold is None and name in docker_usage.per_user_slow:
+            cold = {"used": docker_usage.per_user_slow[name], "quota": None}
         students.append(
             {
                 "username": name,
-                "scratch": _usage_pair(tiers.get("fast")),  # None: no per-student dataset
-                "cold": _usage_pair(tiers.get("slow")),  # None: no per-student dataset/SMB
+                "scratch": scratch,
+                "cold": cold,
                 "docker_home_used": docker_usage.per_user.get(name),
             }
         )
@@ -243,6 +261,31 @@ def docker_datasets(lab: str, docker_usage: DockerUsage) -> list[dict[str, Any]]
                 "quota_bytes": None,
             }
         )
+    return rows
+
+
+def tier_datasets(lab: str, docker_usage: DockerUsage) -> list[dict[str, Any]]:
+    """Telemetry rows for the per-student scratch (fast) / cold (slow) ``du`` breakdown.
+
+    With no per-student ZFS datasets, scratch/cold have no cheap per-student metadata, so the scan
+    measures each student's directory with ``du`` instead (the lab-level fast/slow rows still come
+    from ZFS metadata in the heartbeat). Dataset names mirror the ZFS layout
+    (``<pool>/labs/<lab>/users/<u>``) so the controller's ``parseDataset`` maps them to the right
+    lab/student. quota is omitted — the per-student number is a breakdown, not a quota (the lab
+    quota covers everyone), so it must never raise a PI quota alert.
+    """
+    rows: list[dict[str, Any]] = []
+    tiers = (("fast", docker_usage.per_user_fast), ("slow", docker_usage.per_user_slow))
+    for pool, per_user in tiers:
+        for user, used in per_user.items():
+            rows.append(
+                {
+                    "pool": pool,
+                    "dataset": f"{pool}/labs/{lab}/users/{user}",
+                    "used_bytes": used,
+                    "quota_bytes": None,
+                }
+            )
     return rows
 
 
@@ -347,10 +390,14 @@ def run_docker_scan(
     progress: ProgressCb | None = None,
     now: int | None = None,
 ) -> DockerUsage:
-    """Measure the container writable layer + per-home usage. The expensive path (`du` per home).
+    """Measure the container writable layer + per-student usage. The expensive path (`du` per dir).
 
-    Returns an idle DockerUsage with whatever was measured. Missing container / failed `du` degrade
-    to None/omitted entries rather than raising, so one bad lab never breaks the loop.
+    For each student we ``du`` three directories inside the container: their docker home (installed
+    software), their scratch (``/labusers/fast/<u>``) and — only when this node owns cold storage
+    (local ZFS; on the SMB client the owner node reports it) — their cold-storage
+    (``/labusers/slow/<u>``). Returns an idle DockerUsage with whatever was measured. Missing
+    container / failed ``du`` degrade to None/omitted entries rather than raising, so one bad lab
+    never breaks the loop.
     """
     now = now if now is not None else now_ms()
     container = docker.container_name(lab)
@@ -358,13 +405,23 @@ def run_docker_scan(
         return DockerUsage(scanned_at=now, status="idle")
     total = docker.writable_layer_size(container)
     per_user: dict[str, int] = {}
+    per_user_fast: dict[str, int] = {}
+    per_user_slow: dict[str, int] = {}
     valid = [u for u in usernames if users.USERNAME_RE.match(u)]
+    measure_cold = cfg.slow_is_zfs
     for i, user in enumerate(valid):
         if progress is not None:
             progress(i, len(valid), user)
-        used = docker.du_home(container, user)
-        if used is not None:
-            per_user[user] = used
+        home = docker.du_home(container, user)
+        if home is not None:
+            per_user[user] = home
+        fast = docker.du_path(container, f"/labusers/fast/{user}")
+        if fast is not None:
+            per_user_fast[user] = fast
+        if measure_cold:
+            cold = docker.du_path(container, f"/labusers/slow/{user}")
+            if cold is not None:
+                per_user_slow[user] = cold
     unattributed = None
     if total is not None:
         unattributed = max(0, total - sum(per_user.values()))
@@ -373,5 +430,7 @@ def run_docker_scan(
         status="idle",
         total_used=total,
         per_user=per_user,
+        per_user_fast=per_user_fast,
+        per_user_slow=per_user_slow,
         unattributed=unattributed,
     )

--- a/agent/tests/test_telemetry.py
+++ b/agent/tests/test_telemetry.py
@@ -94,3 +94,33 @@ def test_collect_heartbeat_assembles_all_sections(monkeypatch):
     assert datasets == {"fast/labs/bio", "slow/labs/bio"}
     assert {s["pool"] for s in hb["scrub"]} == {"fast", "slow"}
     assert hb["gpu_processes"] == [{"pid": 1, "vram_bytes": 1024}]
+    # No scan cache passed -> no per-student du rows, no scan timestamps.
+    assert hb["usage_scans"] == []
+
+
+def test_collect_heartbeat_includes_scan_breakdown(monkeypatch):
+    """A populated scan cache contributes per-student docker/fast/slow rows + a scan timestamp."""
+    from lab_agent import usagereport
+
+    cfg = _cfg()
+    monkeypatch.setattr(telemetry, "run",
+                        lambda args, **kw: CommandResult(True, [], 0, f"{args[-1]}\t10\t1\t9\n", ""))
+    monkeypatch.setattr(telemetry.zfs, "list_usage", lambda root: [])
+    monkeypatch.setattr(telemetry.coldstore, "list_usage", lambda cfg: [])
+    monkeypatch.setattr(telemetry.zfs, "scrub_status",
+                        lambda p: SimpleNamespace(to_dict=lambda: {"pool": p}))
+    monkeypatch.setattr(telemetry, "list_gpu_processes", lambda: [])
+
+    state = usagereport.UsageState()
+    state.set_docker("bio", usagereport.DockerUsage(
+        scanned_at=777, total_used=300, per_user={"alice": 120},
+        per_user_fast={"alice": 40}, per_user_slow={"alice": 10},
+    ))
+
+    hb = telemetry.collect_heartbeat(cfg, state)
+    rows = {(d["pool"], d["dataset"]): d["used_bytes"] for d in hb["datasets"]}
+    assert rows[("docker", "docker/labs/bio")] == 300
+    assert rows[("docker", "docker/labs/bio/users/alice")] == 120
+    assert rows[("fast", "fast/labs/bio/users/alice")] == 40
+    assert rows[("slow", "slow/labs/bio/users/alice")] == 10
+    assert hb["usage_scans"] == [{"lab": "bio", "scanned_at": 777}]

--- a/agent/tests/test_usagereport.py
+++ b/agent/tests/test_usagereport.py
@@ -94,6 +94,22 @@ def test_build_snapshot_shape():
     assert bob["docker_home_used"] == 80
 
 
+def test_build_snapshot_falls_back_to_du_for_scratch_and_cold():
+    """With no per-student ZFS dataset, scratch/cold come from the docker scan's du measurement
+    (used-only, no per-student quota)."""
+    docker_usage = usagereport.DockerUsage(
+        scanned_at=5, per_user={"alice": 120},
+        per_user_fast={"alice": 40}, per_user_slow={"alice": 10},
+    )
+    snap = usagereport.build_snapshot(
+        cfg(), "bio", usagereport.LabUsage(), docker_usage, roster=["alice"], now=1
+    )
+    alice = snap["students"][0]
+    assert alice["scratch"] == {"used": 40, "quota": None}
+    assert alice["cold"] == {"used": 10, "quota": None}
+    assert alice["docker_home_used"] == 120
+
+
 def test_build_snapshot_lists_roster_with_no_usage():
     """A provisioned student must appear even before any ZFS/docker usage exists for them."""
     snap = usagereport.build_snapshot(
@@ -130,6 +146,25 @@ def test_docker_datasets_telemetry_rows():
 def test_docker_datasets_omits_total_when_unknown():
     rows = usagereport.docker_datasets("bio", usagereport.DockerUsage(per_user={"alice": 120}))
     assert all(r["dataset"] != "docker/labs/bio" for r in rows)
+
+
+def test_tier_datasets_per_student_fast_and_cold():
+    usage = usagereport.DockerUsage(
+        per_user_fast={"alice": 40, "bob": 60}, per_user_slow={"alice": 10}
+    )
+    rows = usagereport.tier_datasets("bio", usage)
+    assert {"pool": "fast", "dataset": "fast/labs/bio/users/alice", "used_bytes": 40,
+            "quota_bytes": None} in rows
+    assert {"pool": "fast", "dataset": "fast/labs/bio/users/bob", "used_bytes": 60,
+            "quota_bytes": None} in rows
+    assert {"pool": "slow", "dataset": "slow/labs/bio/users/alice", "used_bytes": 10,
+            "quota_bytes": None} in rows
+    # bob has no cold measurement -> no slow row for him.
+    assert all(r["dataset"] != "slow/labs/bio/users/bob" for r in rows)
+
+
+def test_tier_datasets_empty_without_scan():
+    assert usagereport.tier_datasets("bio", usagereport.DockerUsage()) == []
 
 
 # --------------------------------------------------------------------------- request dir + scan
@@ -196,22 +231,50 @@ def test_publish_and_status_write(tmp_path, monkeypatch):
     assert (base / usagereport.STATUS_FILE).exists()
 
 
-def test_run_docker_scan_collects_per_home(monkeypatch):
+def test_run_docker_scan_collects_per_student_tiers(monkeypatch):
     monkeypatch.setattr(usagereport.docker, "container_exists", lambda name: True)
     monkeypatch.setattr(usagereport.docker, "writable_layer_size", lambda name: 1000)
     monkeypatch.setattr(usagereport.docker, "du_home", lambda name, u: {"alice": 600, "bob": 300}[u])
+    # Scratch + cold-storage are measured per student via du on /labusers/{fast,slow}/<u>.
+    du_paths = {
+        "/labusers/fast/alice": 40, "/labusers/slow/alice": 10,
+        "/labusers/fast/bob": 60, "/labusers/slow/bob": 20,
+    }
+    monkeypatch.setattr(usagereport.docker, "du_path", lambda name, p: du_paths.get(p))
     seen = []
     usage = usagereport.run_docker_scan(
         cfg(), "bio", ["alice", "bob"], progress=lambda d, t, c: seen.append((d, t, c)), now=42
     )
     assert usage.total_used == 1000
     assert usage.per_user == {"alice": 600, "bob": 300}
-    assert usage.unattributed == 100  # 1000 - 900
+    assert usage.per_user_fast == {"alice": 40, "bob": 60}
+    assert usage.per_user_slow == {"alice": 10, "bob": 20}
+    assert usage.unattributed == 100  # 1000 - 900 (docker homes only)
     assert usage.scanned_at == 42 and usage.status == "idle"
     assert seen == [(0, 2, "alice"), (1, 2, "bob")]
+
+
+def test_run_docker_scan_skips_cold_on_smb(monkeypatch):
+    """On the SMB cold-storage backend the owner node reports cold usage, so this node measures
+    scratch per student but never cold."""
+    monkeypatch.setattr(usagereport.docker, "container_exists", lambda name: True)
+    monkeypatch.setattr(usagereport.docker, "writable_layer_size", lambda name: 0)
+    monkeypatch.setattr(usagereport.docker, "du_home", lambda name, u: 0)
+    calls = []
+
+    def fake_du_path(name, p):
+        calls.append(p)
+        return 5
+
+    monkeypatch.setattr(usagereport.docker, "du_path", fake_du_path)
+    usage = usagereport.run_docker_scan(cfg(slow_backend="smb"), "bio", ["alice"], now=1)
+    assert usage.per_user_fast == {"alice": 5}
+    assert usage.per_user_slow == {}  # cold not measured on the SMB client
+    assert calls == ["/labusers/fast/alice"]  # never du'd the cold dir
 
 
 def test_run_docker_scan_no_container(monkeypatch):
     monkeypatch.setattr(usagereport.docker, "container_exists", lambda name: False)
     usage = usagereport.run_docker_scan(cfg(), "bio", ["alice"], now=42)
     assert usage.total_used is None and usage.per_user == {} and usage.scanned_at == 42
+    assert usage.per_user_fast == {} and usage.per_user_slow == {}

--- a/controller/src/app/(app)/stats/actions.ts
+++ b/controller/src/app/(app)/stats/actions.ts
@@ -1,0 +1,30 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { requireAdmin } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { enqueueTask } from "@/lib/queue";
+
+/**
+ * Trigger an on-demand per-student storage (du) scan for one lab. The agent runs it on the same
+ * single-flight path as its background scan and reports the fresh per-student fast/cold/image
+ * numbers on its next heartbeat. Mirrors the old-files rescanAction.
+ */
+export async function usageScanAction(formData: FormData) {
+  const who = (await requireAdmin()).email;
+  const labId = Number(formData.get("labId"));
+  const lab = db()
+    .prepare(
+      "SELECT labs.name AS name, nodes.name AS node FROM labs JOIN nodes ON nodes.id = labs.node_id WHERE labs.id = ?",
+    )
+    .get(labId) as { name: string; node: string } | undefined;
+  if (!lab) return;
+  const users = (db()
+    .prepare(
+      `SELECT students.username AS username FROM lab_members
+       JOIN students ON students.id = lab_members.student_id WHERE lab_members.lab_id = ?`,
+    )
+    .all(labId) as { username: string }[]).map((r) => r.username);
+  enqueueTask(lab.node, "usage.scan", { lab: lab.name, users }, who);
+  revalidatePath("/stats");
+}

--- a/controller/src/app/(app)/stats/page.tsx
+++ b/controller/src/app/(app)/stats/page.tsx
@@ -1,10 +1,39 @@
-import { fmtBytes, pct } from "@/lib/format";
-import { buildStats } from "@/lib/stats";
+import { ago, fmtBytes, pct } from "@/lib/format";
+import { buildStats, type LabStats } from "@/lib/stats";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { usageScanAction } from "./actions";
 
 export const dynamic = "force-dynamic";
+
+/**
+ * Per-lab scan control: offer a "Scan now" button only when a per-student usage scan is actually
+ * warranted (never run, or stale) and none is already in flight; otherwise just show how fresh the
+ * data is. The button enqueues a usage.scan task on the lab's node.
+ */
+function ScanControl({ lab }: { lab: LabStats }) {
+  return (
+    <form action={usageScanAction} className="flex items-center gap-2 text-xs">
+      <input type="hidden" name="labId" value={lab.labId} />
+      {lab.scanPending ? (
+        <span className="text-muted-foreground">scanning…</span>
+      ) : lab.scanStale ? (
+        <>
+          <Button type="submit" variant="outline" size="sm">
+            Scan now
+          </Button>
+          <span className="text-muted-foreground">
+            {lab.usageScannedAt ? `updated ${ago(lab.usageScannedAt)}` : "never scanned"}
+          </span>
+        </>
+      ) : (
+        <span className="text-muted-foreground">updated {ago(lab.usageScannedAt)}</span>
+      )}
+    </form>
+  );
+}
 
 function quotaCell(used: number | null, quota: number | null) {
   if (used === null) return <span className="text-muted-foreground">—</span>;
@@ -33,9 +62,10 @@ export default async function StatsPage() {
         <p className="text-sm text-muted-foreground">
           Per-student storage by node and lab. <strong className="text-foreground">Image</strong> is a
           student&apos;s writable-layer (overlayfs) usage; <strong className="text-foreground">Fast</strong>{" "}
-          is scratch; <strong className="text-foreground">Cold</strong> is cold storage. Fast/Cold are
-          usually reported only at the lab level (the lab quota covers all students). Numbers come from
-          the latest agent usage report.
+          is scratch; <strong className="text-foreground">Cold</strong> is cold storage. Per-student
+          Fast/Cold come from a periodic per-lab <em>du</em> scan (use <strong className="text-foreground">Scan
+          now</strong> to refresh); the <strong className="text-foreground">Lab total</strong> row shows
+          live usage against the lab quota.
         </p>
       </div>
 
@@ -61,15 +91,18 @@ export default async function StatsPage() {
 
               {node.labs.map((lab) => (
                 <div key={lab.labId} className="space-y-2">
-                  <h4 className="text-sm font-semibold">
-                    <a href={`/labs/${lab.labId}`} className="text-primary hover:underline">
-                      {lab.labName}
-                    </a>{" "}
-                    <span className="font-normal text-muted-foreground">
-                      · image {lab.image} · {lab.students.length} student
-                      {lab.students.length === 1 ? "" : "s"}
-                    </span>
-                  </h4>
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <h4 className="text-sm font-semibold">
+                      <a href={`/labs/${lab.labId}`} className="text-primary hover:underline">
+                        {lab.labName}
+                      </a>{" "}
+                      <span className="font-normal text-muted-foreground">
+                        · image {lab.image} · {lab.students.length} student
+                        {lab.students.length === 1 ? "" : "s"}
+                      </span>
+                    </h4>
+                    <ScanControl lab={lab} />
+                  </div>
                   <Table>
                     <TableHeader>
                       <TableRow>

--- a/controller/src/lib/db.ts
+++ b/controller/src/lib/db.ts
@@ -255,6 +255,14 @@ const MIGRATIONS: { id: string; sql: string }[] = [
     CREATE INDEX idx_announcements_ts ON announcements(ts);
     `,
   },
+  {
+    id: "0007_usage_scan_time",
+    sql: `
+    -- Last time the agent ran a per-student usage (du) scan for this lab, reported by its heartbeat.
+    -- Drives the Stats page freshness ("updated X ago") and the conditional "Scan now" button.
+    ALTER TABLE labs ADD COLUMN usage_scanned_at INTEGER;
+    `,
+  },
 ];
 
 function migrate(conn: Database.Database): void {

--- a/controller/src/lib/ingest.ts
+++ b/controller/src/lib/ingest.ts
@@ -99,6 +99,19 @@ export function ingestTelemetry(node: string, payload: any): void {
     }
   }
 
+  // Per-lab usage-scan freshness: when the agent last ran the per-student du breakdown. Only ever
+  // moves forward, so a stale heartbeat (or one from before a scan) can't roll it back.
+  for (const u of (payload.usage_scans ?? []) as { lab?: string; scanned_at?: number | null }[]) {
+    if (!u.lab || typeof u.scanned_at !== "number") continue;
+    const labId = labIdByName(u.lab);
+    if (labId === null) continue;
+    db()
+      .prepare(
+        "UPDATE labs SET usage_scanned_at = ? WHERE id = ? AND (usage_scanned_at IS NULL OR usage_scanned_at < ?)",
+      )
+      .run(u.scanned_at, labId, u.scanned_at);
+  }
+
   // GPU snapshot: replace this node's rows with the current process list.
   const gpu = (payload.gpu_processes ?? []) as any[];
   const tx = db().transaction(() => {

--- a/controller/src/lib/labs.ts
+++ b/controller/src/lib/labs.ts
@@ -29,6 +29,7 @@ export interface Lab {
   container_options: string | null;
   status: string;
   created_at: number;
+  usage_scanned_at: number | null; // last per-student usage (du) scan time, from agent telemetry
 }
 
 export interface ContainerOptions {

--- a/controller/src/lib/stats.ts
+++ b/controller/src/lib/stats.ts
@@ -30,7 +30,14 @@ export interface LabStats {
     fast: { used: number | null; quota: number | null };
     slow: { used: number | null; quota: number | null };
   };
+  usageScannedAt: number | null; // when the per-student du breakdown was last computed
+  scanStale: boolean; // no scan yet, or older than USAGE_STALE_MS -> offer a "Scan now" button
+  scanPending: boolean; // a usage.scan task is queued/sent for this lab and not yet done
 }
+
+// A per-student usage scan older than this warrants offering a manual rescan. Matches the agent's
+// default unprompted docker-scan cadence (docker_scan_interval_s = 1h).
+const USAGE_STALE_MS = 60 * 60 * 1000;
 
 export interface NodeStats {
   node: string;
@@ -64,6 +71,23 @@ function latestSamples(): Map<string, Cell> {
   return map;
 }
 
+/** Set of `${node}::${labName}` with an in-flight (queued/sent) usage.scan task. */
+function pendingUsageScans(): Set<string> {
+  const rows = db()
+    .prepare("SELECT node, params FROM task_log WHERE action = 'usage.scan' AND state IN ('queued', 'sent')")
+    .all() as { node: string; params: string | null }[];
+  const set = new Set<string>();
+  for (const r of rows) {
+    try {
+      const lab = (JSON.parse(r.params ?? "{}") as { lab?: string }).lab;
+      if (lab) set.add(`${r.node}::${lab}`);
+    } catch {
+      /* ignore malformed params */
+    }
+  }
+  return set;
+}
+
 export function buildStats(): NodeStats[] {
   const samples = latestSamples();
   const used = (labId: number, sid: number | "L", pool: string): number | null =>
@@ -74,6 +98,8 @@ export function buildStats(): NodeStats[] {
   };
 
   const labs = listLabs();
+  const pending = pendingUsageScans();
+  const now = Date.now();
   const byNode = new Map<string, NodeStats>();
 
   for (const lab of labs) {
@@ -88,6 +114,7 @@ export function buildStats(): NodeStats[] {
     }));
     students.sort((a, b) => (b.docker ?? 0) - (a.docker ?? 0) || a.username.localeCompare(b.username));
 
+    const usageScannedAt = lab.usage_scanned_at ?? null;
     const labStats: LabStats = {
       labId: lab.id,
       labName: lab.name,
@@ -98,6 +125,9 @@ export function buildStats(): NodeStats[] {
         fast: cell(lab.id, "fast"),
         slow: cell(lab.id, "slow"),
       },
+      usageScannedAt,
+      scanStale: usageScannedAt === null || now - usageScannedAt > USAGE_STALE_MS,
+      scanPending: pending.has(`${lab.node_name}::${lab.name}`),
     };
 
     let node = byNode.get(lab.node_name);

--- a/controller/tests/phase2.test.ts
+++ b/controller/tests/phase2.test.ts
@@ -104,6 +104,25 @@ describe("telemetry ingestion", () => {
     expect(aliceRow.atime_count).toBe(5);
   });
 
+  it("records per-lab usage-scan time and only moves it forward", () => {
+    ingest.ingestTelemetry("gpu-1", {
+      datasets: [],
+      usage_scans: [{ lab: "bio", scanned_at: 5000 }],
+      gpu_processes: [],
+    });
+    const after = db.db().prepare("SELECT usage_scanned_at FROM labs WHERE name='bio'").get() as any;
+    expect(after.usage_scanned_at).toBe(5000);
+
+    // An older (stale) report must not roll the timestamp back.
+    ingest.ingestTelemetry("gpu-1", {
+      datasets: [],
+      usage_scans: [{ lab: "bio", scanned_at: 1000 }],
+      gpu_processes: [],
+    });
+    const stale = db.db().prepare("SELECT usage_scanned_at FROM labs WHERE name='bio'").get() as any;
+    expect(stale.usage_scanned_at).toBe(5000);
+  });
+
   it("stores docker-pool samples (installed software) without raising a PI quota alert", () => {
     ingest.ingestTelemetry("gpu-1", {
       pools: [{ name: "fast", free: 100 }],


### PR DESCRIPTION
## What & why

Two Storage-stats fixes:

### 1. Per-student Fast/Cold now populate (were `—`)
There are no per-student ZFS datasets — each student's scratch/cold is a plain subdir under the lab's shared `users` mount — so ZFS metadata only yields *lab-level* fast/cold. The agent never measured them per student.

- The expensive scan (`run_docker_scan`) now also `du`s `/labusers/fast/<u>` and `/labusers/slow/<u>` per student (new `docker.du_path`; `du_home` delegates to it).
- Cold is measured only when this node owns cold storage (local ZFS); on the SMB-client backend the owner node reports it, so per-student cold stays blank there — consistent with existing architecture.
- New `tier_datasets` emits per-student `fast`/`slow` telemetry rows. The controller's existing `parseDataset`/ingest already map `<pool>/labs/<lab>/users/<u>` → student, so no controller parsing changes were needed. The in-container `labquota` snapshot also falls back to these `du` numbers.

### 2. Conditional "Scan now" button + last-update time
- New `usage.scan` task, handled in `client.py`, reuses the agent's single-flight lock + shared cache so an on-demand scan never double-scans alongside the background loop.
- Server action `usageScanAction` enqueues it (admin-gated; mirrors the old-files `rescanAction`).
- Per-lab control: **scanning…** while in flight → **Scan now** + freshness when never-scanned/stale (>1h) → just **updated Xago** when fresh. The button appears only when a trigger is actually needed; otherwise it shows the last update time.
- Scan freshness is propagated via a new `usage_scans` heartbeat field into `labs.usage_scanned_at` (migration `0007`, monotonic so a stale heartbeat can't roll it back).

## Notes
- Per-student Fast/Cold are `du` apparent-size (a breakdown), so they won't exactly sum to the ZFS lab total — same as how the docker layer already works. The **Lab total** row remains the authoritative quota figure; the page explainer text was updated to say so.

## Testing
- Agent: 205 pytest pass + ruff clean (new tests for tier rows, per-student tier scan, SMB cold-skip, du fallback, heartbeat usage_scans).
- Controller: 152 vitest pass + `tsc --noEmit` + eslint clean (new test for usage_scans → `usage_scanned_at` monotonic ingest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)