### PR TITLE
fix(agent): per-student du as physical blocks, not apparent size

### DIFF
--- a/agent/src/lab_agent/executors/docker.py
+++ b/agent/src/lab_agent/executors/docker.py
@@ -179,12 +179,17 @@ def du_path(name: str, path: str, *, timeout: float = 60.0) -> int | None:
     """Bytes used by an absolute path inside the container, or None on failure/timeout/missing path.
 
     ``path`` is interpolated into the argv, so callers must pass a trusted value — the only dynamic
-    component used here is a username already validated against ``users.USERNAME_RE``. ``du -sb``
-    reports apparent size in bytes; we take the leading integer. A bounded timeout means a student
-    who packs a directory with millions of tiny files can, at worst, make their *own* number
-    unavailable — the scan moves on rather than hanging.
+    component used here is a username already validated against ``users.USERNAME_RE``. We use
+    ``du -sB1`` (allocated blocks, in bytes) rather than ``du -sb`` (apparent size): on ZFS the
+    block count is the *physical* on-disk size — after compression and ignoring sparse-file holes —
+    which is exactly what the lab-level ``zfs list`` ``used`` and the per-lab quota account for. The
+    apparent size double-counts holes (a 400 GiB sparse file backed by 200 GiB of blocks reads as
+    400 GiB), so per-student totals could exceed the lab total; allocated blocks reconcile with it.
+    We take the leading integer. A bounded timeout means a student who packs a directory with
+    millions of tiny files can, at worst, make their *own* number unavailable — the scan moves on
+    rather than hanging.
     """
-    res = exec_in(name, ["du", "-sb", path], timeout=timeout)
+    res = exec_in(name, ["du", "-sB1", path], timeout=timeout)
     if not res.ok:
         return None
     first = res.stdout.strip().split(None, 1)

--- a/agent/tests/test_docker.py
+++ b/agent/tests/test_docker.py
@@ -130,7 +130,7 @@ def test_du_home_parses_leading_int(monkeypatch):
     monkeypatch.setattr(docker, "run", fake_run)
     assert du_home("lab-bio", "alice") == 98304
     # du runs inside the container against the student's home directory.
-    assert captured["args"] == ["docker", "exec", "-i", "lab-bio", "du", "-sb", "/home/alice"]
+    assert captured["args"] == ["docker", "exec", "-i", "lab-bio", "du", "-sB1", "/home/alice"]
 
 
 def test_du_home_none_on_failure(monkeypatch):


### PR DESCRIPTION
## Problem

The Storage Stats page and `labquota` showed a single student using **400 GB** of Fast scratch inside a lab whose **total** Fast usage was only **200 GB** — an impossible-looking result.

Root cause: per-student Fast/Cold usage is measured with `du -sb` (**apparent** size, which counts sparse-file holes), while the lab total and the per-lab quota come from ZFS `used` (**physical** allocated blocks). A student with a sparse file (VM/qcow2 image, `truncate`/`fallocate` preallocation, a DB with holes) is over-reported and can exceed the lab total.

Confirmed on a live node — same directory:

| Measurement | Value | Basis |
|---|---|---|
| `du -sb` (old) | 429496729600 = **400.0 GiB** | apparent (counts holes) |
| `du -sB1` (new) | 214892725760 = **200.1 GiB** | physical (allocated blocks) |
| ZFS `used` / `logicalused` | **200G** / 200G | physical |
| `compressratio` | 1.00x | (not compression — sparseness) |

## Fix

Switch `du_path` from `du -sb` → `du -sB1` (allocated blocks, in bytes). On ZFS the block count is the physical on-disk size (post-compression, holes excluded), which reconciles with `zfs list` `used` and the quota. This corrects every consumer of `du_path`: `du_home`, the fast/cold scan, `tier_datasets` telemetry, and the `labquota` snapshot.

## Notes

- Existing cached numbers stay stale until the next usage scan (Stats → **Scan now**, or `labquota --refresh`).
- This was systematic — any student with sparse files was over-reported, not just this one.

## Test plan

- [x] Updated argv assertion in `test_docker.py`
- [x] `pytest tests/test_docker.py tests/test_usagereport.py tests/test_telemetry.py` → 43 passed
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)