### PR TITLE
feat: log rotation caps + delete-all-logs; keep scan indicator until data lands

### DIFF
--- a/controller/src/app/(app)/settings/actions.ts
+++ b/controller/src/app/(app)/settings/actions.ts
@@ -5,6 +5,8 @@ import { revalidatePath } from "next/cache";
 import { sendTestEmail } from "@/lib/mailer";
 import { broadcastGpuPolicy, setSetting, TIB } from "@/lib/settings";
 import { requireAdmin } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { pruneLogs } from "@/lib/maintenance";
 
 export async function saveStorageSettingsAction(formData: FormData) {
   await requireAdmin();
@@ -90,8 +92,22 @@ export async function saveAlertSettingsAction(formData: FormData) {
   const grace = Number(formData.get("nodeOfflineGraceSeconds"));
   setSetting("nodeOfflineGraceSeconds", Number.isFinite(grace) && grace >= 0 ? Math.trunc(grace) : 60);
   setSetting("logRetentionDays", Number(formData.get("logRetentionDays")) || 30);
+  // Log rotation caps: 0 (or invalid) means "no cap". Apply them right away so the admin sees the
+  // effect immediately rather than waiting for the next hourly maintenance tick.
+  const maxEntries = Number(formData.get("logMaxEntries"));
+  setSetting("logMaxEntries", Number.isFinite(maxEntries) && maxEntries > 0 ? Math.trunc(maxEntries) : 0);
+  const maxSizeMb = Number(formData.get("logMaxSizeMb"));
+  setSetting("logMaxSizeMb", Number.isFinite(maxSizeMb) && maxSizeMb > 0 ? maxSizeMb : 0);
   setSetting("quotaAlertPct", Number(formData.get("quotaAlertPct")) || 90);
+  pruneLogs();
   revalidatePath("/settings");
+}
+
+/** Purge every row from the `logs` table (the "Delete all logs" button). */
+export async function clearLogsAction() {
+  await requireAdmin();
+  const n = db().prepare("DELETE FROM logs").run().changes;
+  redirect(`/settings?logs=${encodeURIComponent(`Deleted ${n.toLocaleString()} log ${n === 1 ? "entry" : "entries"}`)}`);
 }
 
 export async function saveGpuPolicyAction(formData: FormData) {

--- a/controller/src/app/(app)/settings/page.tsx
+++ b/controller/src/app/(app)/settings/page.tsx
@@ -1,11 +1,16 @@
 import { getSettings, GPU_EMAIL_VARS, TIB, WELCOME_EMAIL_VARS } from "@/lib/settings";
+import { db } from "@/lib/db";
+import { fmtBytes } from "@/lib/format";
+import { logsContentBytes } from "@/lib/maintenance";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import { ConfirmButton } from "../_components/ConfirmButton";
 import {
+  clearLogsAction,
   saveAlertSettingsAction,
   saveGpuEmailsAction,
   saveGpuPolicyAction,
@@ -37,10 +42,12 @@ export const dynamic = "force-dynamic";
 export default async function SettingsPage({
   searchParams,
 }: {
-  searchParams: Promise<{ smtp?: string; scrub?: string }>;
+  searchParams: Promise<{ smtp?: string; scrub?: string; logs?: string }>;
 }) {
-  const { smtp, scrub } = await searchParams;
+  const { smtp, scrub, logs: logsMsg } = await searchParams;
   const s = getSettings();
+  const logCount = (db().prepare("SELECT COUNT(*) AS n FROM logs").get() as { n: number }).n;
+  const logBytes = logsContentBytes();
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
@@ -288,12 +295,37 @@ export default async function SettingsPage({
             </div>
             <div>
               <Label>Log retention (days)</Label>
-              <Input name="logRetentionDays" type="number" defaultValue={s.logRetentionDays} />
+              <Input name="logRetentionDays" type="number" min={0} defaultValue={s.logRetentionDays} />
+            </div>
+            <div>
+              <Label>Max log entries (0 = unlimited)</Label>
+              <Input name="logMaxEntries" type="number" min={0} defaultValue={s.logMaxEntries} />
+            </div>
+            <div>
+              <Label>Max log size (MB, 0 = unlimited)</Label>
+              <Input name="logMaxSizeMb" type="number" min={0} step="any" defaultValue={s.logMaxSizeMb} />
             </div>
             <div className="sm:col-span-2">
               <Button type="submit">Save alerts</Button>
             </div>
           </form>
+          <div className="flex flex-wrap items-center gap-3 border-t border-border pt-3">
+            <span className="text-sm text-muted-foreground">
+              {logCount.toLocaleString()} log {logCount === 1 ? "entry" : "entries"} · ~{fmtBytes(logBytes)} stored.
+              Rotation keeps the newest within every cap above.
+            </span>
+            <form action={clearLogsAction}>
+              <ConfirmButton
+                variant="destructive"
+                size="sm"
+                title="Delete all logs"
+                confirm={`Permanently delete all ${logCount.toLocaleString()} log entries? This cannot be undone.`}
+              >
+                Delete all logs
+              </ConfirmButton>
+            </form>
+          </div>
+          {logsMsg && <p className="text-sm text-primary">{logsMsg}</p>}
         </CardContent>
       </Card>
 

--- a/controller/src/app/(app)/stats/page.tsx
+++ b/controller/src/app/(app)/stats/page.tsx
@@ -11,13 +11,25 @@ import { usageScanAction } from "./actions";
 export const dynamic = "force-dynamic";
 
 /**
- * Per-lab scan control. The admin always has a "Scan now" button to force a fresh per-student usage
- * (du) scan, and whenever one is in flight a "scanning…" indicator is shown alongside it (the
- * page-level <ScanAutoRefresh> polls so that indicator clears on its own when the agent reports the
- * scan done). The freshness ("updated Xm ago") is always shown, tinted when the data is stale.
- * The button enqueues a usage.scan task on the lab's node.
+ * Per-lab scan control. While a per-student usage (du) scan is in flight the "Scan now" button is
+ * replaced by a live progress indicator; it reappears only once the scan is genuinely done — i.e.
+ * the agent has finished *and* the fresh numbers have landed (see `scanPending` in lib/stats). The
+ * page-level <ScanAutoRefresh> polls while any scan is pending, so the swap back to the button (and
+ * the updated table) happens on its own. When idle, the freshness ("updated Xm ago") is shown,
+ * tinted when stale. The button enqueues a usage.scan task on the lab's node.
  */
 function ScanControl({ lab }: { lab: LabStats }) {
+  if (lab.scanPending) {
+    return (
+      <div className="flex items-center gap-2 text-xs text-muted-foreground" aria-live="polite">
+        <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin" />
+        <span>Scanning…</span>
+        <span className="relative h-1 w-24 overflow-hidden rounded-full bg-muted" role="progressbar">
+          <span className="absolute inset-y-0 left-0 w-1/3 rounded-full bg-primary animate-indeterminate" />
+        </span>
+      </div>
+    );
+  }
   return (
     <div className="flex flex-wrap items-center gap-2 text-xs">
       <form action={usageScanAction}>
@@ -26,12 +38,7 @@ function ScanControl({ lab }: { lab: LabStats }) {
           Scan now
         </SubmitButton>
       </form>
-      {lab.scanPending && (
-        <span className="inline-flex items-center gap-1.5 text-muted-foreground" aria-live="polite">
-          <Loader2 className="h-3.5 w-3.5 animate-spin" /> scanning…
-        </span>
-      )}
-      <span className={lab.scanStale && !lab.scanPending ? "text-amber-500" : "text-muted-foreground"}>
+      <span className={lab.scanStale ? "text-amber-500" : "text-muted-foreground"}>
         {lab.usageScannedAt ? `updated ${ago(lab.usageScannedAt)}` : "never scanned"}
       </span>
     </div>

--- a/controller/src/app/globals.css
+++ b/controller/src/app/globals.css
@@ -106,6 +106,18 @@
 
   --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+
+  /* Indeterminate progress sweep (e.g. an in-flight usage scan with no known % complete). */
+  --animate-indeterminate: indeterminate 1.15s ease-in-out infinite;
+}
+
+@keyframes indeterminate {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(320%);
+  }
 }
 
 @layer base {

--- a/controller/src/lib/maintenance.ts
+++ b/controller/src/lib/maintenance.ts
@@ -8,11 +8,82 @@ import { db } from "./db";
 import { enqueueTask } from "./queue";
 import { getSetting } from "./settings";
 
+// Approximate byte size of a single `logs` row's textual content. SQLite has no cheap per-table
+// size, so we sum the text-column lengths plus a fixed estimate for the int columns + row overhead.
+// Used for the size-based rotation cap and the "~X stored" readout in settings.
+const LOG_ROW_BYTES = `(
+  LENGTH(msg)
+  + LENGTH(COALESCE(detail, ''))
+  + LENGTH(COALESCE(source, ''))
+  + LENGTH(COALESCE(node, ''))
+  + LENGTH(COALESCE(lab, ''))
+  + LENGTH(COALESCE(user, ''))
+  + LENGTH(COALESCE(task_id, ''))
+  + 48
+)`;
+
+/** Approximate total textual size (bytes) of the `logs` table — for the size cap and the UI. */
+export function logsContentBytes(): number {
+  const row = db().prepare(`SELECT COALESCE(SUM(${LOG_ROW_BYTES}), 0) AS bytes FROM logs`).get() as {
+    bytes: number;
+  };
+  return row.bytes;
+}
+
+/**
+ * Enforce the three log-rotation caps on the `logs` table, newest-wins, and return the number of
+ * rows removed:
+ *   - age:   drop rows older than logRetentionDays
+ *   - count: keep only the newest logMaxEntries rows
+ *   - size:  keep only the newest rows whose cumulative content size fits logMaxSizeMb
+ * A cap of 0 disables that dimension. Row recency is taken from the autoincrement id (true arrival
+ * order, immune to per-node clock skew) for the count/size caps; the age cap uses the agent ts.
+ */
+export function pruneLogs(now = Date.now()): number {
+  let removed = 0;
+
+  const retentionDays = getSetting("logRetentionDays");
+  if (retentionDays > 0) {
+    const cutoff = now - retentionDays * 86400 * 1000;
+    removed += db().prepare("DELETE FROM logs WHERE ts < ?").run(cutoff).changes;
+  }
+
+  const maxEntries = getSetting("logMaxEntries");
+  if (maxEntries > 0) {
+    // OFFSET lands on the id of the (maxEntries+1)-th newest row; drop it and everything older.
+    // When there are fewer rows than the cap the subquery is NULL, so `id <= NULL` deletes nothing.
+    removed += db()
+      .prepare("DELETE FROM logs WHERE id <= (SELECT id FROM logs ORDER BY id DESC LIMIT 1 OFFSET ?)")
+      .run(maxEntries).changes;
+  }
+
+  const maxBytes = getSetting("logMaxSizeMb") * 1024 * 1024;
+  if (maxBytes > 0) {
+    // Walk newest -> oldest accumulating row size; once the running total passes the cap, every
+    // remaining (older) row is surplus.
+    removed += db()
+      .prepare(
+        `DELETE FROM logs WHERE id IN (
+           SELECT id FROM (
+             SELECT id, SUM(${LOG_ROW_BYTES}) OVER (ORDER BY id DESC) AS cum FROM logs
+           ) WHERE cum > ?
+         )`,
+      )
+      .run(maxBytes).changes;
+  }
+
+  return removed;
+}
+
 export function pruneOldData(): { logs: number; gpuEvents: number } {
-  const retentionMs = getSetting("logRetentionDays") * 86400 * 1000;
-  const cutoff = Date.now() - retentionMs;
-  const logs = db().prepare("DELETE FROM logs WHERE ts < ?").run(cutoff).changes;
-  const gpuEvents = db().prepare("DELETE FROM gpu_events WHERE ts < ?").run(cutoff).changes;
+  const now = Date.now();
+  const logs = pruneLogs(now);
+  const retentionDays = getSetting("logRetentionDays");
+  const gpuEvents =
+    retentionDays > 0
+      ? db().prepare("DELETE FROM gpu_events WHERE ts < ?").run(now - retentionDays * 86400 * 1000)
+          .changes
+      : 0;
   return { logs, gpuEvents };
 }
 

--- a/controller/src/lib/settings.ts
+++ b/controller/src/lib/settings.ts
@@ -58,7 +58,11 @@ export interface Settings {
   alertLevel: "WARN" | "ERROR"; // minimum log level that triggers an admin alert
   alertDedupMinutes: number; // suppress duplicate alerts (same key) within this window
   nodeOfflineGraceSeconds: number; // tolerate a node disconnect this long before alerting admins
-  logRetentionDays: number;
+  // Log rotation. The maintenance ticker (and a save of these settings) prunes the `logs` table to
+  // satisfy all three caps, newest-wins. 0 means "no cap" for the respective dimension.
+  logRetentionDays: number; // drop rows older than this many days
+  logMaxEntries: number; // keep at most this many rows
+  logMaxSizeMb: number; // keep the table's textual content under ~this many MB
   quotaAlertPct: number; // email the PI when a lab pool crosses this percent
   // WebDAV backup target. Backups are written under <webdavUrl>/<webdavBaseDir>/<env> where env is
   // "prod" or "dev" (derived from NODE_ENV) so a shared store keeps the two deployments separate.
@@ -186,6 +190,8 @@ export const DEFAULT_SETTINGS: Settings = {
   alertDedupMinutes: 15,
   nodeOfflineGraceSeconds: 60,
   logRetentionDays: 30,
+  logMaxEntries: 0,
+  logMaxSizeMb: 0,
   quotaAlertPct: 90,
   webdavUrl: "",
   webdavUser: "",

--- a/controller/src/lib/stats.ts
+++ b/controller/src/lib/stats.ts
@@ -71,21 +71,55 @@ function latestSamples(): Map<string, Cell> {
   return map;
 }
 
-/** Set of `${node}::${labName}` with an in-flight (queued/sent) usage.scan task. */
-function pendingUsageScans(): Set<string> {
+// After a usage.scan task is marked done we keep treating the lab as "scanning" until the fresh
+// per-student numbers actually land. The agent runs the scan synchronously and marks the task `ok`
+// the instant it returns, but the new du breakdown (and usage_scanned_at) only reach us on the
+// *next* heartbeat — so without this grace the "Scan now" button would pop back while the table is
+// still showing the pre-scan numbers. Bounded so a heartbeat that never arrives can't hide the
+// button forever.
+const SCAN_INGEST_GRACE_MS = 10 * 60 * 1000;
+
+/**
+ * Most-recent usage.scan task per `${node}::${labName}` — its state and when it was requested. We
+ * keep only the latest so a stale ok/failed task never masks a newer in-flight one; `scanPending`
+ * (computed per lab in buildStats, where the scan-freshness timestamp is known) reads off this.
+ */
+function latestUsageScans(): Map<string, { state: string; createdAt: number }> {
   const rows = db()
-    .prepare("SELECT node, params FROM task_log WHERE action = 'usage.scan' AND state IN ('queued', 'sent')")
-    .all() as { node: string; params: string | null }[];
-  const set = new Set<string>();
+    .prepare(
+      "SELECT node, params, state, created_at AS createdAt FROM task_log WHERE action = 'usage.scan' ORDER BY created_at ASC",
+    )
+    .all() as { node: string; params: string | null; state: string; createdAt: number }[];
+  const map = new Map<string, { state: string; createdAt: number }>();
   for (const r of rows) {
     try {
       const lab = (JSON.parse(r.params ?? "{}") as { lab?: string }).lab;
-      if (lab) set.add(`${r.node}::${lab}`);
+      if (lab) map.set(`${r.node}::${lab}`, { state: r.state, createdAt: r.createdAt });
     } catch {
       /* ignore malformed params */
     }
   }
-  return set;
+  return map;
+}
+
+/** Whether a lab should still read as "scanning" given its latest scan task and data freshness. */
+function isScanPending(
+  scan: { state: string; createdAt: number } | undefined,
+  usageScannedAt: number | null,
+  now: number,
+): boolean {
+  if (!scan) return false;
+  // Dispatched and not yet acknowledged done.
+  if (scan.state === "queued" || scan.state === "sent") return true;
+  // Done on the agent, but keep "scanning" until the post-scan heartbeat advances usage_scanned_at
+  // past when we requested it (i.e. the new numbers have been ingested).
+  if (scan.state === "ok") {
+    return (
+      (usageScannedAt === null || usageScannedAt < scan.createdAt) &&
+      now - scan.createdAt < SCAN_INGEST_GRACE_MS
+    );
+  }
+  return false; // failed / unknown
 }
 
 export function buildStats(): NodeStats[] {
@@ -98,7 +132,7 @@ export function buildStats(): NodeStats[] {
   };
 
   const labs = listLabs();
-  const pending = pendingUsageScans();
+  const scans = latestUsageScans();
   const now = Date.now();
   const byNode = new Map<string, NodeStats>();
 
@@ -127,7 +161,7 @@ export function buildStats(): NodeStats[] {
       },
       usageScannedAt,
       scanStale: usageScannedAt === null || now - usageScannedAt > USAGE_STALE_MS,
-      scanPending: pending.has(`${lab.node_name}::${lab.name}`),
+      scanPending: isScanPending(scans.get(`${lab.node_name}::${lab.name}`), usageScannedAt, now),
     };
 
     let node = byNode.get(lab.node_name);

--- a/controller/tests/maintenance.test.ts
+++ b/controller/tests/maintenance.test.ts
@@ -72,6 +72,64 @@ describe("pruneOldData", () => {
   });
 });
 
+describe("pruneLogs caps", () => {
+  const insLog = (msg: string, ts: number) =>
+    dbmod
+      .db()
+      .prepare("INSERT INTO logs (node, level, source, msg, ts) VALUES ('n','INFO','s',?,?)")
+      .run(msg, ts);
+
+  beforeEach(() => {
+    dbmod.db().prepare("DELETE FROM logs").run();
+    settings.setSetting("logRetentionDays", 0); // isolate count/size caps from the age cap
+    settings.setSetting("logMaxEntries", 0);
+    settings.setSetting("logMaxSizeMb", 0);
+  });
+
+  it("keeps only the newest logMaxEntries rows", () => {
+    settings.setSetting("logMaxEntries", 3);
+    for (let i = 0; i < 10; i++) insLog(`m${i}`, 1000 + i);
+    const removed = maintenance.pruneLogs();
+    expect(removed).toBe(7);
+    const rows = dbmod.db().prepare("SELECT msg FROM logs ORDER BY id").all() as { msg: string }[];
+    expect(rows.map((r) => r.msg)).toEqual(["m7", "m8", "m9"]);
+  });
+
+  it("does nothing when row count is within the entry cap", () => {
+    settings.setSetting("logMaxEntries", 5);
+    for (let i = 0; i < 3; i++) insLog(`m${i}`, 1000 + i);
+    expect(maintenance.pruneLogs()).toBe(0);
+    const n = (dbmod.db().prepare("SELECT COUNT(*) AS n FROM logs").get() as { n: number }).n;
+    expect(n).toBe(3);
+  });
+
+  it("keeps the newest rows within the size cap and drops the rest", () => {
+    const big = "x".repeat(1000); // ~1 KB per row
+    for (let i = 0; i < 20; i++) insLog(`${i}-${big}`, 1000 + i);
+    settings.setSetting("logMaxSizeMb", 5 / 1024); // ~5 KB cap
+    const removed = maintenance.pruneLogs();
+    expect(removed).toBeGreaterThan(0);
+    expect(maintenance.logsContentBytes()).toBeLessThanOrEqual(5 * 1024);
+    // The most recent row always survives.
+    const newest = dbmod.db().prepare("SELECT msg FROM logs ORDER BY id DESC LIMIT 1").get() as {
+      msg: string;
+    };
+    expect(newest.msg.startsWith("19-")).toBe(true);
+  });
+
+  it("applies all three caps together, removing the union of surplus rows", () => {
+    settings.setSetting("logRetentionDays", 30);
+    settings.setSetting("logMaxEntries", 5);
+    const now = Date.now();
+    insLog("ancient", now - 40 * 86400 * 1000); // dropped by age
+    for (let i = 0; i < 8; i++) insLog(`r${i}`, now - i * 1000); // newest 5 kept by count
+    maintenance.pruneLogs(now);
+    const rows = dbmod.db().prepare("SELECT msg FROM logs").all() as { msg: string }[];
+    expect(rows).toHaveLength(5);
+    expect(rows.some((r) => r.msg === "ancient")).toBe(false);
+  });
+});
+
 describe("scheduleOldFileScans", () => {
   let bioId: number;
 

--- a/controller/tests/stats.test.ts
+++ b/controller/tests/stats.test.ts
@@ -36,6 +36,24 @@ beforeAll(async () => {
   d.prepare("INSERT INTO lab_members (lab_id, student_id, created_at) VALUES (1, 2, 0)").run();
 });
 
+let uuidSeq = 0;
+function scanTask(node: string, lab: string, state: string, createdAt: number) {
+  dbmod
+    .db()
+    .prepare(
+      `INSERT INTO task_log (task_uuid, node, action, params, state, created_at, updated_at)
+       VALUES (?, ?, 'usage.scan', ?, ?, ?, ?)`,
+    )
+    .run(`scan-${uuidSeq++}`, node, JSON.stringify({ lab }), state, createdAt, createdAt);
+}
+
+function findLab(name: string) {
+  return stats
+    .buildStats()
+    .find((n) => n.node === "node-a")!
+    .labs.find((l) => l.labName === name)!;
+}
+
 describe("buildStats", () => {
   it("groups latest per-student and lab-level usage by node and lab", () => {
     // Two docker samples for alice; the newer (ts=200) wins.
@@ -65,5 +83,60 @@ describe("buildStats", () => {
     expect(lab.aggregate.docker).toBe(300);
     expect(lab.aggregate.fast).toEqual({ used: 500, quota: 2000 });
     expect(lab.aggregate.slow).toEqual({ used: 200, quota: 3000 });
+  });
+});
+
+describe("scanPending", () => {
+  // Each scenario gets its own lab on node-a so their scan tasks don't collide.
+  beforeAll(() => {
+    const d = dbmod.db();
+    for (const [id, name] of [[10, "queued"], [11, "sent"], [12, "fresh-ingest"], [13, "landed"], [14, "expired"], [15, "failed"], [16, "noscan"]] as const) {
+      d.prepare(
+        `INSERT INTO labs (id, name, node_id, fast_quota_bytes, slow_quota_bytes, image, status, created_at)
+         VALUES (?, ?, 1, 2000, 3000, 'img-x', 'active', 0)`,
+      ).run(id, name);
+    }
+  });
+
+  it("is true while a scan task is queued or sent", () => {
+    scanTask("node-a", "queued", "queued", Date.now());
+    scanTask("node-a", "sent", "sent", Date.now());
+    expect(findLab("queued").scanPending).toBe(true);
+    expect(findLab("sent").scanPending).toBe(true);
+  });
+
+  it("stays true after the task is ok until the fresh numbers land (ingest gap)", () => {
+    const created = Date.now();
+    scanTask("node-a", "fresh-ingest", "ok", created);
+    // usage_scanned_at still predates the request -> data not ingested yet.
+    dbmod.db().prepare("UPDATE labs SET usage_scanned_at = ? WHERE name = 'fresh-ingest'").run(created - 1000);
+    expect(findLab("fresh-ingest").scanPending).toBe(true);
+  });
+
+  it("flips false once usage_scanned_at advances past the request (data landed)", () => {
+    const created = Date.now();
+    scanTask("node-a", "landed", "ok", created);
+    dbmod.db().prepare("UPDATE labs SET usage_scanned_at = ? WHERE name = 'landed'").run(created + 1000);
+    expect(findLab("landed").scanPending).toBe(false);
+  });
+
+  it("does not keep an ok task pending forever if the heartbeat never lands", () => {
+    // Requested 20 min ago, still no fresh scan -> grace window expired, show the button again.
+    scanTask("node-a", "expired", "ok", Date.now() - 20 * 60 * 1000);
+    expect(findLab("expired").scanPending).toBe(false);
+  });
+
+  it("is false for a failed scan and when there is no scan task", () => {
+    scanTask("node-a", "failed", "failed", Date.now());
+    expect(findLab("failed").scanPending).toBe(false);
+    expect(findLab("noscan").scanPending).toBe(false);
+  });
+
+  it("tracks only the latest task per lab", () => {
+    // An old ok (data landed) followed by a brand-new queued -> pending again.
+    scanTask("node-a", "noscan", "ok", Date.now() - 5000);
+    dbmod.db().prepare("UPDATE labs SET usage_scanned_at = ? WHERE name = 'noscan'").run(Date.now() - 4000);
+    scanTask("node-a", "noscan", "queued", Date.now());
+    expect(findLab("noscan").scanPending).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Two related admin-UI refinements on the controller:

### Log rotation caps + delete-all-logs (`feat(settings)`)
- Adds two new rotation dimensions alongside the existing age cap:
  - **`logMaxEntries`** — keep only the newest N rows
  - **`logMaxSizeMb`** — keep the newest rows within an approximate textual-content budget
- All three caps are **newest-wins** and use the autoincrement `id` for recency (immune to per-node clock skew); the age cap still uses the agent timestamp. A cap of `0` disables that dimension.
- `pruneLogs()` enforces all three and runs both on the hourly maintenance tick **and** immediately on saving alert settings, so the admin sees the effect at once.
- Settings page gains a "~X stored / N entries" readout and a confirm-gated **Delete all logs** button (`clearLogsAction`).

### Scan indicator stays up until fresh numbers land (`fix(stats)`)
- The agent marks a `usage.scan` task `ok` the instant it returns, but the new per-student `du` breakdown + `usage_scanned_at` only arrive on the next heartbeat — so the "Scan now" button used to pop back while the table still showed pre-scan numbers.
- Now tracks the latest scan task per lab and keeps the lab "scanning" through the `ok` state until `usage_scanned_at` advances past the request time, bounded by a 10-minute grace so a missing heartbeat can't hide the button forever.
- While pending, the button is replaced by an indeterminate progress sweep.

## Testing
Locally, all controller CI steps pass: `lint`, `typecheck`, `test` (162 passed), and `build`. New tests cover the three rotation caps (individually and combined) and every `scanPending` state transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)