### PR TITLE
fix(backups): show run times in browser-local + configured schedule tz

### DIFF
--- a/controller/src/app/(app)/backups/_components/ClientTime.tsx
+++ b/controller/src/app/(app)/backups/_components/ClientTime.tsx
@@ -1,10 +1,53 @@
 "use client";
 
+import { useSyncExternalStore } from "react";
+
+// `false` on the server and during the first hydration render, `true` thereafter — the
+// useSyncExternalStore pattern keeps hydration consistent without a setState-in-effect.
+const subscribe = () => () => {};
+function useHydrated() {
+  return useSyncExternalStore(
+    subscribe,
+    () => true,
+    () => false,
+  );
+}
+
 /**
- * Render an epoch-ms timestamp in the viewer's local timezone/locale. Formatting differs between the
- * server (its tz) and the browser, so suppressHydrationWarning avoids a spurious mismatch warning.
+ * Render an epoch-ms timestamp in the viewer's browser timezone, plus — when it differs — the same
+ * instant in the configured schedule timezone. toLocaleString() formats in the *runtime's* tz, so
+ * this must run in the browser: rendering on the server (as the old version did) pinned the display
+ * to the server's tz, and suppressHydrationWarning then froze that wrong value in the DOM. We format
+ * only after hydration and show a placeholder until then, which also sidesteps a hydration mismatch.
  */
-export function ClientTime({ ts }: { ts: number }) {
+export function ClientTime({ ts, tz }: { ts: number; tz?: string }) {
+  const hydrated = useHydrated();
+
   if (!ts) return <span>never</span>;
-  return <span suppressHydrationWarning>{new Date(ts).toLocaleString()}</span>;
+  if (!hydrated) return <span className="text-muted-foreground">…</span>;
+
+  const local = new Date(ts).toLocaleString();
+  const browserTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  let inTz: string | null = null;
+  // Only add the schedule-tz reading when it actually differs from the viewer's tz (no point showing
+  // the same time twice for an admin who lives in the configured zone).
+  if (tz && tz !== browserTz) {
+    try {
+      inTz = new Date(ts).toLocaleString(undefined, { timeZone: tz });
+    } catch {
+      inTz = null; // unknown tz name -> just show the browser-local time
+    }
+  }
+
+  return (
+    <span>
+      {local}
+      {inTz && (
+        <span className="text-muted-foreground">
+          {" · "}
+          {inTz} ({tz})
+        </span>
+      )}
+    </span>
+  );
 }

--- a/controller/src/app/(app)/backups/page.tsx
+++ b/controller/src/app/(app)/backups/page.tsx
@@ -85,7 +85,7 @@ async function WebdavStatusBadge() {
 }
 
 /** The available-backups table, gated on actual reachability so failures aren't shown as "empty". */
-async function BackupsList() {
+async function BackupsList({ tz }: { tz: string }) {
   const st = await loadStatus();
   if (!st.configured) {
     return (
@@ -112,7 +112,7 @@ async function BackupsList() {
           <TableRow key={b.name}>
             <TableCell className="font-mono text-xs">{b.name}</TableCell>
             <TableCell className="text-sm">
-              <ClientTime ts={b.stamp} />
+              <ClientTime ts={b.stamp} tz={tz} />
             </TableCell>
             <TableCell className="text-right">
               <form action={restoreAction}>
@@ -173,7 +173,7 @@ export default async function BackupsPage({
           </p>
           <p className="text-sm">
             <span className="font-medium">Last run: </span>
-            <ClientTime ts={s.backupLastRun} />
+            <ClientTime ts={s.backupLastRun} tz={s.backupTimezone} />
             {s.backupLastStatus && (
               <span className={failed ? "text-destructive" : "text-emerald-500"}>
                 {" "}
@@ -183,7 +183,11 @@ export default async function BackupsPage({
           </p>
           <p className="text-sm">
             <span className="font-medium">Next run: </span>
-            {nextRun ? <ClientTime ts={nextRun} /> : <span className="text-muted-foreground">disabled</span>}
+            {nextRun ? (
+              <ClientTime ts={nextRun} tz={s.backupTimezone} />
+            ) : (
+              <span className="text-muted-foreground">disabled</span>
+            )}
           </p>
           {failed && s.backupLastError && (
             <p className="text-sm text-destructive">Last error: {s.backupLastError}</p>
@@ -323,7 +327,7 @@ export default async function BackupsPage({
             </SubmitButton>
           </form>
           <Suspense fallback={<Checking label="Loading backups…" />}>
-            <BackupsList />
+            <BackupsList tz={s.backupTimezone} />
           </Suspense>
           <p className="text-xs text-muted-foreground">
             Restoring stages the backup; it replaces the live database on the next service restart.


### PR DESCRIPTION
## Problem

On the **Backups** page, the **Last run** / **Next run** / **Taken** timestamps were displayed in the *server's* timezone (UTC), not the viewer's local time — e.g. a 02:00 America/New_York anchor rendered as `6:00:00 AM`.

**Root cause:** `ClientTime` is a `"use client"` component but was rendered during SSR. `new Date(ts).toLocaleString()` formats in the *runtime's* timezone (UTC on the server), and `suppressHydrationWarning` then *froze* that server-tz text in the DOM — React never patched it to the browser's tz on hydration.

## Fix

`ClientTime` now formats **only after hydration** (gated on a `useSyncExternalStore`-based flag — the lint-clean alternative to a `setState`-in-effect mount flag), showing a brief `…` placeholder until then. Each timestamp renders twice:

- **Browser-local time** (primary) — in the viewer's actual timezone
- **Configured schedule timezone** (muted, e.g. `· 6/30/2026, 2:00:00 AM (America/New_York)`) — shown only when it differs from the viewer's zone

`backupTimezone` is threaded into all three displays (Last run, Next run, and the Available-backups "Taken" column).

The editable **Anchor time** input is intentionally unchanged — it's the configured wall-clock value *in* the set timezone, not an instant.

## Verification

- `tsc --noEmit` ✓
- `eslint` (`--max-warnings=0`) ✓
- `vitest run` — 163 tests pass ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)