### PR TITLE
feat(stats): recompute lab-level usage every 5 min; drop "live" framing

### DIFF
--- a/agent/src/lab_agent/client.py
+++ b/agent/src/lab_agent/client.py
@@ -72,6 +72,7 @@ class Agent:
         worker = asyncio.create_task(self._task_worker(), name="task-worker")
         gpu = asyncio.create_task(self._gpu_loop(), name="gpu-killer")
         publish = asyncio.create_task(self._usage_publish_loop(), name="usage-publish")
+        lab_usage = asyncio.create_task(self._lab_usage_loop(), name="lab-usage")
         docker_scan = asyncio.create_task(self._docker_scan_loop(), name="docker-scan")
         pkg_update = asyncio.create_task(self._pkg_update_loop(), name="pkg-update")
         try:
@@ -80,6 +81,7 @@ class Agent:
             worker.cancel()
             gpu.cancel()
             publish.cancel()
+            lab_usage.cancel()
             docker_scan.cancel()
             pkg_update.cancel()
             self.localq.close()
@@ -249,6 +251,22 @@ class Agent:
                 self.log.error("usage", f"usage publish error: {exc}")
             await asyncio.sleep(max(15, self.cfg.usage_publish_interval_s))
 
+    async def _lab_usage_loop(self) -> None:
+        """Recompute each lab's lab-level usage (fast/slow ZFS + container writable layer) on a
+        fixed cadence and cache it; the heartbeat re-reports the cached snapshot. Moved off the
+        per-15s heartbeat path so the agent does one ``zfs list`` / ``docker inspect`` per interval,
+        not per heartbeat. The (expensive) per-student du breakdown is a separate, slower cache (see
+        ``_docker_scan_loop``)."""
+        while True:
+            try:
+                await asyncio.to_thread(self._refresh_lab_usage)
+            except Exception as exc:  # never let the refresher die
+                self.log.error("usage", f"lab usage refresh error: {exc}")
+            await asyncio.sleep(max(30, self.cfg.lab_usage_interval_s))
+
+    def _refresh_lab_usage(self) -> None:
+        self.usage.replace_lab_level(usagereport.collect_lab_level(self.cfg, self.usage))
+
     def _publish_all_usage(self) -> None:
         # collect_zfs_usage returns a row per lab (lab-level fast), so it enumerates the labs; the
         # roster (provisioned scratch subdirs) is added per lab so a freshly-provisioned student is
@@ -269,10 +287,10 @@ class Agent:
         """Refresh the (expensive) per-student du breakdown on a daily fallback cadence / on demand.
 
         A lab is (re)scanned when its cached data is older than ``docker_scan_interval_s`` (a daily
-        safety net; the controller drives the precise off-peak nightly scan), or when a student
-        dropped a refresh marker and the cache is older than the forced floor (5 min). The
-        container-level writable-layer total is NOT scanned here — it is measured live every
-        heartbeat (see ``telemetry`` / ``usagereport.live_docker_dataset``).
+        safety net; the controller drives the precise nightly scan, by default at midnight), or when
+        a student dropped a refresh marker and the cache is older than the forced floor (5 min). The
+        container-level writable-layer total is NOT scanned here — it lives in the lab-level cache,
+        refreshed on its own faster cadence (see ``_lab_usage_loop``).
         """
         floor_ms = 5 * 60 * 1000
         while True:
@@ -343,14 +361,22 @@ class Agent:
     def _handle_usage_scan(self, cfg: AgentConfig, params: dict[str, Any]) -> tuple[Any, str]:
         """Controller-triggered usage scan for one lab (Stats page "Scan now").
 
-        Blocks on the same single-flight lock the background loop uses, so it never double-scans a
-        container, then refreshes the shared cache. The fresh per-student numbers reach the
-        controller on the next heartbeat; the returned ``scanned_at`` is the freshness timestamp.
+        Refreshes **both** caches the Stats page reads so a single trigger updates the whole page:
+        the lab-level totals (fast/slow ZFS + container writable layer) and the per-student ``du``
+        breakdown. The per-student scan blocks on the same single-flight lock the background loop
+        uses, so it never double-scans a container. The fresh numbers reach the controller on the
+        next heartbeat; the returned ``scanned_at`` is the per-student freshness timestamp.
         """
         lab = params["lab"]
         users_list = params.get("users") or usagereport.list_lab_students(cfg, lab)
         with self._docker_lock:
             self._scan_docker_lab(lab, users_list)
+        # Also recompute the lab-level snapshot now, so fast/cold/image refresh on the same trigger
+        # rather than waiting for the next lab-usage cycle.
+        try:
+            self.usage.set_lab_level(lab, usagereport.lab_level_for(cfg, lab))
+        except Exception as exc:  # lab-level refresh is best-effort; the per-student scan still ran
+            self.log.warn("usage", f"lab-level refresh failed for '{lab}': {exc}", lab=lab)
         usage = self.usage.docker_for(lab)
         return {"lab": lab, "scanned_at": usage.scanned_at}, f"usage scan complete for '{lab}'"
 

--- a/agent/src/lab_agent/config.py
+++ b/agent/src/lab_agent/config.py
@@ -49,6 +49,11 @@ class AgentConfig:
     heartbeat_interval_s: int = 15
     # How often the per-lab labquota usage snapshot is republished (live ZFS metadata only — cheap).
     usage_publish_interval_s: int = 120
+    # How often the lab-level storage totals (fast/slow ZFS + container writable-layer "image") are
+    # recomputed and cached for the controller's Stats page. The heartbeat re-reports the cached
+    # snapshot, so this is the real refresh cadence for those numbers — they are NOT measured per
+    # heartbeat. An on-demand "Scan now" refreshes them immediately regardless of this interval.
+    lab_usage_interval_s: int = 300
     # Fallback cadence for the (expensive) per-student du scan when the agent runs it unprompted,
     # and the freshness gate below which a student-requested refresh is skipped as "already fresh".
     # The controller schedules the precise off-peak nightly scan (Settings -> per-student usage
@@ -127,6 +132,7 @@ def load_config(path: Path | None = None) -> AgentConfig:
         "state_db",
         "heartbeat_interval_s",
         "usage_publish_interval_s",
+        "lab_usage_interval_s",
         "docker_scan_interval_s",
         "apt_update_enabled",
         "apt_update_interval_s",
@@ -167,6 +173,7 @@ def render_config(cfg: AgentConfig) -> str:
         "state_db",
         "heartbeat_interval_s",
         "usage_publish_interval_s",
+        "lab_usage_interval_s",
         "docker_scan_interval_s",
         "apt_update_enabled",
         "apt_update_interval_s",

--- a/agent/src/lab_agent/telemetry.py
+++ b/agent/src/lab_agent/telemetry.py
@@ -7,6 +7,12 @@ Reports, every heartbeat:
   - ZFS scrub status per pool (so the controller can alert when a scrub finds errors),
   - the live GPU process list (pid + VRAM, resolved to container/user where possible).
 
+Storage usage is **not** measured on the heartbeat: the lab-level totals (fast/slow ZFS + container
+writable-layer "image") come from the lab-usage cache (refreshed every ``lab_usage_interval_s``, see
+``usagereport.collect_lab_level``) and the per-student ``du`` breakdown from the scan cache. The
+heartbeat just re-reports whichever cached numbers are current, so a 15s heartbeat never triggers an
+expensive ``zfs list`` / ``docker inspect`` / ``du``.
+
 The controller stores the latest snapshot; GPU is snapshot-only (no time-series).
 """
 
@@ -14,7 +20,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from . import coldstore, usagereport
+from . import usagereport
 from .config import AgentConfig
 from .executors import zfs
 from .executors.base import run
@@ -39,38 +45,20 @@ def _pools(cfg: AgentConfig) -> list[dict[str, Any]]:
 
 
 def _dataset_usage(cfg: AgentConfig, docker_state: Any = None) -> list[dict[str, Any]]:
-    out = []
-    labs: set[str] = set()
-    for u in zfs.list_usage(cfg.labs_fast_root):
-        out.append(
-            {
-                "pool": "fast",
-                "dataset": u.dataset,
-                "used_bytes": u.used_bytes,
-                "quota_bytes": u.quota_bytes,
-                "available_bytes": u.available_bytes,
-            }
-        )
-        parsed = usagereport._parse_dataset(u.dataset, cfg.labs_fast_root)
-        if parsed is not None and parsed[1] is None:  # lab-level row -> a lab to measure
-            labs.add(parsed[0])
-    out.extend(coldstore.list_usage(cfg))
-    if docker_state is not None:
-        labs |= set(docker_state.all_docker().keys())
-    # Container-level usage: the whole-container writable layer (pool="docker", lab level), measured
-    # LIVE every heartbeat (one cheap ``docker inspect --size`` per lab) so the Stats page's
-    # whole-image number is always current rather than frozen until the next scan.
-    for lab in sorted(labs):
-        row = usagereport.live_docker_dataset(lab)
-        if row is not None:
-            out.append(row)
+    if docker_state is None:
+        return []
+    out: list[dict[str, Any]] = []
+    # Lab-level totals: the container writable-layer ("image") plus lab-level fast/slow ZFS
+    # usage-vs-quota. Sourced from the lab-usage cache (refreshed every ``lab_usage_interval_s`` /
+    # on-demand), so the heartbeat re-reports the last computed snapshot — it does not re-measure.
+    for level in docker_state.all_lab_level().values():
+        out.extend(level.datasets)
     # Per-student breakdown from the (expensive) scan cache: each student's docker home (installed
     # software) plus their scratch/cold ``du``. Updated only by the nightly / on-demand scan, so the
     # heartbeat just re-reports the cached numbers — they change on disk only when a scan reruns.
-    if docker_state is not None:
-        for lab, usage in docker_state.all_docker().items():
-            out.extend(usagereport.docker_datasets(lab, usage))
-            out.extend(usagereport.tier_datasets(lab, usage))
+    for lab, usage in docker_state.all_docker().items():
+        out.extend(usagereport.docker_datasets(lab, usage))
+        out.extend(usagereport.tier_datasets(lab, usage))
     return out
 
 

--- a/agent/src/lab_agent/usagereport.py
+++ b/agent/src/lab_agent/usagereport.py
@@ -85,11 +85,32 @@ class DockerUsage:
         }
 
 
+@dataclass
+class LabLevelUsage:
+    """Cached lab-level storage totals, refreshed on a fixed cadence (NOT per heartbeat).
+
+    Holds the ready-to-emit telemetry rows for one lab's lab-level usage: the fast/slow ZFS
+    used/quota rows plus the container writable-layer ("image") total. The agent recomputes these on
+    its lab-usage cadence (``lab_usage_interval_s``) — or immediately on an on-demand scan — and
+    caches them here; the heartbeat just re-reports the cached ``datasets`` every cycle, so the
+    expensive ``zfs list`` / ``docker inspect`` work no longer runs on every 15s heartbeat.
+    """
+
+    computed_at: int | None = None  # epoch ms of the last refresh
+    datasets: list[dict[str, Any]] = field(default_factory=list)  # lab-level telemetry rows
+
+
 class UsageState:
-    """Per-lab docker-usage cache shared between the publish loop, the scan loop, and telemetry."""
+    """Per-lab usage cache shared between the publish loop, the scan loop, and telemetry.
+
+    Two independently-cadenced caches: ``_docker`` is the expensive per-student ``du`` breakdown
+    (refreshed by the nightly / on-demand scan) and ``_lab`` is the lab-level totals (fast/slow ZFS
+    + container writable layer, refreshed every ``lab_usage_interval_s`` / on demand).
+    """
 
     def __init__(self) -> None:
         self._docker: dict[str, DockerUsage] = {}
+        self._lab: dict[str, LabLevelUsage] = {}
 
     def docker_for(self, lab: str) -> DockerUsage:
         return self._docker.get(lab, DockerUsage())
@@ -99,6 +120,19 @@ class UsageState:
 
     def all_docker(self) -> dict[str, DockerUsage]:
         return dict(self._docker)
+
+    def lab_level_for(self, lab: str) -> LabLevelUsage:
+        return self._lab.get(lab, LabLevelUsage())
+
+    def set_lab_level(self, lab: str, usage: LabLevelUsage) -> None:
+        self._lab[lab] = usage
+
+    def all_lab_level(self) -> dict[str, LabLevelUsage]:
+        return dict(self._lab)
+
+    def replace_lab_level(self, mapping: dict[str, LabLevelUsage]) -> None:
+        """Swap in a freshly-computed map for every lab, so labs that disappeared drop out."""
+        self._lab = dict(mapping)
 
 
 # --------------------------------------------------------------------------- ZFS usage collection
@@ -236,13 +270,13 @@ def build_snapshot(
 
 
 def live_docker_dataset(lab: str) -> dict[str, Any] | None:
-    """The lab-level docker writable-layer (``SizeRw``) telemetry row, measured **live**.
+    """The lab-level docker writable-layer (``SizeRw``) telemetry row.
 
-    This is the "whole image" / container-level number. Unlike the per-student ``du`` breakdown
-    (expensive, cached, refreshed only by a scan), the container total is cheap enough to re-measure
-    on every heartbeat via ``docker inspect --size``, so the controller's Stats page always shows
-    the current writable-layer size. Returns None when the container is absent or the measurement
-    fails, in which case the heartbeat omits the row and the controller keeps the last known value.
+    This is the "whole image" / container-level number, measured with one ``docker inspect --size``.
+    It is recomputed on the agent's lab-usage cadence (``lab_usage_interval_s``) and cached in
+    ``LabLevelUsage`` — not measured on every heartbeat — alongside the lab-level ZFS rows (see
+    ``lab_level_for``). Returns None when the container is absent or the measurement fails, in which
+    case the row is omitted and the controller keeps the last known value.
     """
     container = docker.container_name(lab)
     if not docker.container_exists(container):
@@ -258,12 +292,67 @@ def live_docker_dataset(lab: str) -> dict[str, Any] | None:
     }
 
 
+def _zfs_row(pool: str, u: zfs.Usage) -> dict[str, Any]:
+    return {
+        "pool": pool,
+        "dataset": u.dataset,
+        "used_bytes": u.used_bytes,
+        "quota_bytes": u.quota_bytes,
+        "available_bytes": u.available_bytes,
+    }
+
+
+def lab_level_for(
+    cfg: AgentConfig, lab: str, lab_usage: LabUsage | None = None, *, now: int | None = None
+) -> LabLevelUsage:
+    """Compute one lab's lab-level usage rows: fast/slow ZFS (+ any per-student ZFS datasets) plus
+    the container writable-layer "image" total. ``lab_usage`` may be passed in (e.g. from a single
+    ``collect_zfs_usage`` covering all labs) to avoid re-listing ZFS per lab."""
+    now = now if now is not None else now_ms()
+    if lab_usage is None:
+        lab_usage = collect_zfs_usage(cfg).get(lab, LabUsage())
+    rows: list[dict[str, Any]] = []
+    if lab_usage.fast is not None:
+        rows.append(_zfs_row("fast", lab_usage.fast))
+    if lab_usage.slow is not None:
+        rows.append(_zfs_row("slow", lab_usage.slow))
+    # Per-student ZFS rows only exist if per-student datasets are in use; normally empty (scratch
+    # and cold come from the du scan's tier_datasets instead). Included so both layouts work.
+    for tiers in lab_usage.users.values():
+        if "fast" in tiers:
+            rows.append(_zfs_row("fast", tiers["fast"]))
+        if "slow" in tiers:
+            rows.append(_zfs_row("slow", tiers["slow"]))
+    image = live_docker_dataset(lab)
+    if image is not None:
+        rows.append(image)
+    return LabLevelUsage(computed_at=now, datasets=rows)
+
+
+def collect_lab_level(
+    cfg: AgentConfig, docker_state: UsageState | None = None, *, now: int | None = None
+) -> dict[str, LabLevelUsage]:
+    """Recompute lab-level usage for every lab: one ``zfs list`` per pool + one ``docker inspect
+    --size`` per lab. This is the work that used to run on every 15s heartbeat; it now runs on the
+    agent's lab-usage cadence and is cached. Labs are enumerated from ZFS (every lab has a fast
+    dataset), unioned with any lab present only in the docker-scan cache."""
+    now = now if now is not None else now_ms()
+    grouped = collect_zfs_usage(cfg)
+    labs = set(grouped.keys())
+    if docker_state is not None:
+        labs |= set(docker_state.all_docker().keys())
+    return {
+        lab: lab_level_for(cfg, lab, grouped.get(lab, LabUsage()), now=now) for lab in sorted(labs)
+    }
+
+
 def docker_datasets(lab: str, docker_usage: DockerUsage) -> list[dict[str, Any]]:
     """Per-student docker-home telemetry rows from the cached scan (installed software per student).
 
-    The lab-level container total is **not** emitted here — it is measured live every heartbeat by
-    ``live_docker_dataset``. These per-student rows come from the (expensive) ``du`` scan cache and
-    only change when a scan runs. Dataset names mirror the ZFS layout
+    The lab-level container total is **not** emitted here — it lives in the lab-level cache
+    (``lab_level_for`` / ``live_docker_dataset``), refreshed on the lab-usage cadence. These
+    per-student rows come from the (expensive) ``du`` scan cache and only change when a scan runs.
+    Dataset names mirror the ZFS layout
     (``docker/labs/<lab>/users/<u>``) so the controller's ``parseDataset`` maps them to the right
     student. quota is omitted (the writable layer is not a per-student quota and must not alert).
     """

--- a/agent/tests/test_telemetry.py
+++ b/agent/tests/test_telemetry.py
@@ -72,25 +72,26 @@ def test_pools_drops_unavailable_pool(monkeypatch):
 
 
 def test_collect_heartbeat_assembles_all_sections(monkeypatch):
+    from lab_agent import usagereport
+
     cfg = _cfg()
     monkeypatch.setattr(
         telemetry, "run",
         lambda args, **kw: CommandResult(True, [], 0, f"{args[-1]}\t10\t1\t9\n", ""),
     )
-    monkeypatch.setattr(telemetry.zfs, "list_usage", lambda root: [
-        SimpleNamespace(dataset="fast/labs/bio", used_bytes=100, quota_bytes=200, available_bytes=100),
-    ])
-    monkeypatch.setattr(telemetry.coldstore, "list_usage", lambda cfg: [
-        {"pool": "slow", "dataset": "slow/labs/bio", "used_bytes": 5, "quota_bytes": None,
-         "available_bytes": None},
-    ])
     monkeypatch.setattr(telemetry.zfs, "scrub_status",
                         lambda p: SimpleNamespace(to_dict=lambda: {"pool": p, "healthy": True}))
     monkeypatch.setattr(telemetry, "list_gpu_processes", lambda: [{"pid": 1, "vram_bytes": 1024}])
-    # No container present -> no live container-level docker row.
-    monkeypatch.setattr(telemetry.usagereport, "live_docker_dataset", lambda lab: None)
 
-    hb = telemetry.collect_heartbeat(cfg)
+    # Lab-level usage comes from the cache (refreshed off the heartbeat path by the lab-usage loop),
+    # not from a live measurement on the heartbeat itself.
+    state = usagereport.UsageState()
+    state.set_lab_level("bio", usagereport.LabLevelUsage(computed_at=1, datasets=[
+        {"pool": "fast", "dataset": "fast/labs/bio", "used_bytes": 100, "quota_bytes": 200},
+        {"pool": "slow", "dataset": "slow/labs/bio", "used_bytes": 5, "quota_bytes": None},
+    ]))
+
+    hb = telemetry.collect_heartbeat(cfg, state)
     assert {p["name"] for p in hb["pools"]} == {"fast", "slow"}
     datasets = {d["dataset"] for d in hb["datasets"]}
     assert datasets == {"fast/labs/bio", "slow/labs/bio"}
@@ -100,30 +101,40 @@ def test_collect_heartbeat_assembles_all_sections(monkeypatch):
     assert hb["usage_scans"] == []
 
 
-def test_collect_heartbeat_includes_scan_breakdown(monkeypatch):
-    """Live container total + cached per-student docker/fast/slow rows + a scan timestamp.
+def test_collect_heartbeat_emits_nothing_without_state(monkeypatch):
+    """With no usage state there is no cache to report, so storage datasets are empty (the rest of
+    the heartbeat still assembles)."""
+    cfg = _cfg()
+    monkeypatch.setattr(telemetry, "run",
+                        lambda args, **kw: CommandResult(True, [], 0, f"{args[-1]}\t10\t1\t9\n", ""))
+    monkeypatch.setattr(telemetry.zfs, "scrub_status",
+                        lambda p: SimpleNamespace(to_dict=lambda: {"pool": p}))
+    monkeypatch.setattr(telemetry, "list_gpu_processes", lambda: [])
+    hb = telemetry.collect_heartbeat(cfg)
+    assert hb["datasets"] == []
+    assert {p["name"] for p in hb["pools"]} == {"fast", "slow"}
 
-    The lab-level docker row is measured live (``live_docker_dataset``); the per-student rows come
-    from the scan cache. A lab present only in the cache (no fast dataset rows this heartbeat) is
-    still measured live, so the whole-image number never disappears between scans.
+
+def test_collect_heartbeat_includes_scan_breakdown(monkeypatch):
+    """Lab-level cache (whole-image total) + cached per-student docker/fast/slow rows + a scan ts.
+
+    The lab-level docker row comes from the lab-usage cache; the per-student rows come from the scan
+    cache. A lab present only in the scan cache contributes only its per-student rows.
     """
     from lab_agent import usagereport
 
     cfg = _cfg()
     monkeypatch.setattr(telemetry, "run",
                         lambda args, **kw: CommandResult(True, [], 0, f"{args[-1]}\t10\t1\t9\n", ""))
-    monkeypatch.setattr(telemetry.zfs, "list_usage", lambda root: [])
-    monkeypatch.setattr(telemetry.coldstore, "list_usage", lambda cfg: [])
     monkeypatch.setattr(telemetry.zfs, "scrub_status",
                         lambda p: SimpleNamespace(to_dict=lambda: {"pool": p}))
     monkeypatch.setattr(telemetry, "list_gpu_processes", lambda: [])
-    monkeypatch.setattr(
-        telemetry.usagereport, "live_docker_dataset",
-        lambda lab: {"pool": "docker", "dataset": f"docker/labs/{lab}", "used_bytes": 300,
-                     "quota_bytes": None} if lab == "bio" else None,
-    )
 
     state = usagereport.UsageState()
+    # Lab-level cache holds the whole-image row (from the lab-usage loop / on-demand scan).
+    state.set_lab_level("bio", usagereport.LabLevelUsage(computed_at=1, datasets=[
+        {"pool": "docker", "dataset": "docker/labs/bio", "used_bytes": 300, "quota_bytes": None},
+    ]))
     state.set_docker("bio", usagereport.DockerUsage(
         scanned_at=777, total_used=300, per_user={"alice": 120},
         per_user_fast={"alice": 40}, per_user_slow={"alice": 10},
@@ -131,7 +142,7 @@ def test_collect_heartbeat_includes_scan_breakdown(monkeypatch):
 
     hb = telemetry.collect_heartbeat(cfg, state)
     rows = {(d["pool"], d["dataset"]): d["used_bytes"] for d in hb["datasets"]}
-    assert rows[("docker", "docker/labs/bio")] == 300  # live container total
+    assert rows[("docker", "docker/labs/bio")] == 300  # whole-image total from the lab-level cache
     assert rows[("docker", "docker/labs/bio/users/alice")] == 120
     assert rows[("fast", "fast/labs/bio/users/alice")] == 40
     assert rows[("slow", "slow/labs/bio/users/alice")] == 10

--- a/agent/tests/test_usagereport.py
+++ b/agent/tests/test_usagereport.py
@@ -136,7 +136,7 @@ def test_list_lab_students_missing_mount(monkeypatch):
 
 
 def test_docker_datasets_are_per_student_only():
-    # The lab-level container total is measured live (live_docker_dataset), not from this cache.
+    # The lab-level container total lives in the lab-level cache (lab_level_for), not in these rows.
     usage = usagereport.DockerUsage(total_used=300, per_user={"alice": 120})
     rows = usagereport.docker_datasets("bio", usage)
     assert {"pool": "docker", "dataset": "docker/labs/bio/users/alice", "used_bytes": 120,
@@ -161,6 +161,52 @@ def test_live_docker_dataset_none_when_measure_fails(monkeypatch):
     monkeypatch.setattr(usagereport.docker, "container_exists", lambda name: True)
     monkeypatch.setattr(usagereport.docker, "writable_layer_size", lambda name: None)
     assert usagereport.live_docker_dataset("bio") is None
+
+
+# --------------------------------------------------------------------------- lab-level cache
+
+
+def test_lab_level_for_builds_zfs_and_image_rows(monkeypatch):
+    monkeypatch.setattr(usagereport.docker, "container_exists", lambda name: True)
+    monkeypatch.setattr(usagereport.docker, "writable_layer_size", lambda name: 4242)
+    lab_usage = usagereport.LabUsage(
+        fast=U("fast/labs/bio", 500, 1000, 500),
+        slow=U("slow/labs/bio", 200, 2000, 1800),
+        users={"alice": {"fast": U("fast/labs/bio/users/alice", 40, 100, 60)}},
+    )
+    level = usagereport.lab_level_for(cfg(), "bio", lab_usage, now=999)
+    assert level.computed_at == 999
+    rows = {(d["pool"], d["dataset"]): d["used_bytes"] for d in level.datasets}
+    assert rows[("fast", "fast/labs/bio")] == 500
+    assert rows[("slow", "slow/labs/bio")] == 200
+    assert rows[("fast", "fast/labs/bio/users/alice")] == 40
+    assert rows[("docker", "docker/labs/bio")] == 4242  # whole-image writable-layer total
+
+
+def test_lab_level_for_omits_image_when_no_container(monkeypatch):
+    monkeypatch.setattr(usagereport.docker, "container_exists", lambda name: False)
+    level = usagereport.lab_level_for(
+        cfg(), "bio", usagereport.LabUsage(fast=U("fast/labs/bio", 5, 10, 5)), now=1
+    )
+    pools = {d["pool"] for d in level.datasets}
+    assert "docker" not in pools  # no container -> no image row, but the ZFS row still reports
+    assert ("fast", "fast/labs/bio") in {(d["pool"], d["dataset"]) for d in level.datasets}
+
+
+def test_collect_lab_level_covers_all_labs(monkeypatch):
+    fast_rows = [U("fast/labs/bio", 500, 1000, 500), U("fast/labs/chem", 10, 100, 90)]
+    monkeypatch.setattr(
+        usagereport.zfs, "list_usage",
+        lambda root: fast_rows if root == "fast/labs" else [],
+    )
+    monkeypatch.setattr(usagereport.docker, "container_exists", lambda name: True)
+    monkeypatch.setattr(usagereport.docker, "writable_layer_size", lambda name: 7)
+    levels = usagereport.collect_lab_level(cfg(), now=123)
+    assert set(levels) == {"bio", "chem"}
+    bio_rows = {(d["pool"], d["dataset"]) for d in levels["bio"].datasets}
+    assert ("fast", "fast/labs/bio") in bio_rows
+    assert ("docker", "docker/labs/bio") in bio_rows
+    assert levels["bio"].computed_at == 123
 
 
 def test_tier_datasets_per_student_fast_and_cold():

--- a/controller/src/app/(app)/settings/page.tsx
+++ b/controller/src/app/(app)/settings/page.tsx
@@ -84,9 +84,10 @@ export default async function SettingsPage({
         <CardContent className="space-y-3">
           <h3 className="text-base font-semibold">Per-student usage scan</h3>
           <p className="text-xs text-muted-foreground">
-            Once a night the controller measures each student&apos;s home / scratch / cold usage (a{" "}
-            <em>du</em> scan) on every online lab&apos;s node, shown on the Stats page. Container-level
-            usage is separate: it is measured live on every heartbeat and is always current.
+            Once a night (by default at midnight) the controller measures each student&apos;s home /
+            scratch / cold usage (a <em>du</em> scan) on every online lab&apos;s node, shown on the
+            Stats page. Lab-level usage (image + fast/cold) is separate: the agent recomputes it on
+            its own ~5-minute cadence.
           </p>
           <form action={saveUsageScanSettingsAction} className="grid max-w-xl grid-cols-1 gap-3 sm:grid-cols-2">
             <label className="flex items-center gap-2 text-sm sm:col-span-2">

--- a/controller/src/app/(app)/stats/actions.ts
+++ b/controller/src/app/(app)/stats/actions.ts
@@ -6,9 +6,10 @@ import { db } from "@/lib/db";
 import { enqueueTask } from "@/lib/queue";
 
 /**
- * Trigger an on-demand per-student storage (du) scan for one lab. The agent runs it on the same
- * single-flight path as its nightly scan and reports the fresh per-student home/fast/cold numbers
- * on its next heartbeat. (Container-level usage is measured live every heartbeat, independent of this.)
+ * Trigger an on-demand storage scan for one lab. The agent runs the per-student (du) breakdown on
+ * the same single-flight path as its nightly scan AND recomputes the lab-level totals (image +
+ * fast/cold), so a single "Scan now" refreshes the whole Stats page; the fresh numbers reach us on
+ * the agent's next heartbeat.
  */
 export async function usageScanAction(formData: FormData) {
   const who = (await requireAdmin()).email;

--- a/controller/src/app/(app)/stats/page.tsx
+++ b/controller/src/app/(app)/stats/page.tsx
@@ -83,10 +83,13 @@ function LabBlock({ lab }: { lab: LabStats }) {
         </span>
       </h4>
 
-      {/* Container-level + lab totals — re-measured on every agent heartbeat, so always current. */}
+      {/* Container-level + lab totals — recomputed by the agent on a ~5-min cadence, not per heartbeat. */}
       <div className="rounded-md border border-border/60 bg-muted/20 p-3">
-        <div className="mb-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-          Live · refreshed every heartbeat
+        <div className="mb-2 flex flex-wrap items-center gap-x-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+          <span>Lab storage · checked every 5 min</span>
+          <span className={lab.liveStale ? "text-amber-500" : "text-muted-foreground/70"}>
+            · {lab.liveUpdatedAt ? `updated ${ago(lab.liveUpdatedAt)}` : "no data yet"}
+          </span>
         </div>
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
           <Stat
@@ -160,12 +163,12 @@ export default async function StatsPage() {
         <h1 className="text-2xl font-semibold tracking-tight">Storage stats</h1>
         <p className="text-sm text-muted-foreground">
           Two kinds of data, shown separately per lab. The{" "}
-          <strong className="text-foreground">Live</strong> row (container image writable layer, plus
-          Fast/Cold usage against the lab quota) is re-measured on every node heartbeat, so it is
-          always current. The <strong className="text-foreground">Per-student</strong> table (each
-          student&apos;s installed software, scratch and cold-storage) comes from a nightly{" "}
-          <em>du</em> scan — use <strong className="text-foreground">Scan now</strong> to refresh it
-          on demand.
+          <strong className="text-foreground">Lab storage</strong> row (container image writable
+          layer, plus Fast/Cold usage against the lab quota) is recomputed on the node about every 5
+          minutes. The <strong className="text-foreground">Per-student</strong> table (each
+          student&apos;s installed software, scratch and cold-storage) comes from a once-a-day scan
+          (by default at midnight). Both carry an &ldquo;updated&rdquo; time, and{" "}
+          <strong className="text-foreground">Scan now</strong> refreshes both on demand.
         </p>
       </div>
 
@@ -183,7 +186,7 @@ export default async function StatsPage() {
                 {node.node}{" "}
                 <Badge variant={node.online ? "ok" : "err"}>{node.online ? "online" : "offline"}</Badge>
                 <span className="text-sm font-normal text-muted-foreground">
-                  {" "}· whole-image usage on this node (live): {fmtBytes(node.totalImageBytes)}
+                  {" "}· whole-image usage on this node: {fmtBytes(node.totalImageBytes)}
                 </span>
               </h3>
 

--- a/controller/src/lib/ingest.ts
+++ b/controller/src/lib/ingest.ts
@@ -52,16 +52,16 @@ function studentIdInLab(labId: number, username: string): number | null {
 /**
  * Whether to persist a new sample for (lab, student, pool).
  *
- * Live ZFS metrics — the lab-level fast/slow rows, re-measured from `zfs list` on every 15s
- * heartbeat — are throttled to one row per STORAGE_SAMPLE_MIN_INTERVAL_MS so the time-series stays
- * bounded. Scan-derived metrics (`scanDerived`) — the docker writable layer and the per-student
- * `du` breakdown — only change when a usage scan runs, so they bypass the throttle whenever the
- * value actually changes. Without that bypass, a fresh on-demand "Scan now" landing on a heartbeat
- * <5min after the previous sample would be silently dropped, leaving the table stuck on the pre-scan
- * number even though "updated Xm ago" (usage_scanned_at, which always moves forward) advanced — the
- * exact desync where the image total froze at a stale value after delete+scan until a manual reload.
- * Storing only on *change* keeps the series from bloating between scans (the agent re-reports the
- * same cached number every heartbeat), so this fires at most once per scan.
+ * Lab-level fast/slow ZFS rows — recomputed by the agent on its lab-usage cadence (~5 min) and
+ * re-reported on each heartbeat — are throttled to one row per STORAGE_SAMPLE_MIN_INTERVAL_MS so the
+ * time-series stays bounded. Scan-derived metrics (`scanDerived`) — the docker writable layer and
+ * the per-student `du` breakdown — only change when a usage scan runs, so they bypass the throttle
+ * whenever the value actually changes. Without that bypass, a fresh on-demand "Scan now" landing on
+ * a heartbeat <5min after the previous sample would be silently dropped, leaving the table stuck on
+ * the pre-scan number even though "updated Xm ago" (usage_scanned_at, which always moves forward)
+ * advanced — the exact desync where the image total froze at a stale value after delete+scan until a
+ * manual reload. Storing only on *change* keeps the series from bloating between scans (the agent
+ * re-reports the same cached number every heartbeat), so this fires at most once per scan.
  */
 function shouldSample(
   labId: number,
@@ -115,9 +115,10 @@ export function ingestTelemetry(node: string, payload: any): void {
     if (labId === null) continue;
     const studentId = parsed.user ? studentIdInLab(labId, parsed.user) : null;
     if (parsed.level === "user" && studentId === null) continue;
-    // The docker writable layer and every per-student row come from the on-demand/periodic `du`
-    // scan (there are no per-student ZFS datasets), so they're scan-derived: store on change to let
-    // a fresh scan's numbers land immediately. Lab-level fast/slow are live ZFS — keep throttled.
+    // The docker writable layer (lab-level image + per-student homes) and per-student fast/slow rows
+    // change only when their cache is recomputed — the lab-usage refresh or the `du` scan — so
+    // they're scan-derived: store on change to let a fresh value land immediately. Lab-level
+    // fast/slow are periodic ZFS reads, re-reported every heartbeat — keep them throttled.
     const scanDerived = ds.pool === "docker" || parsed.level === "user";
     if (!shouldSample(labId, studentId, ds.pool, ds.used_bytes, now, scanDerived)) continue;
     insertSample.run(labId, studentId, ds.pool, ds.used_bytes, ds.quota_bytes ?? null, now);

--- a/controller/src/lib/maintenance.ts
+++ b/controller/src/lib/maintenance.ts
@@ -230,11 +230,11 @@ const USAGE_SCAN_MIN_GAP_MS = 20 * 3600 * 1000;
 
 /**
  * Enqueue a per-student usage (du) scan to each online lab once a night, during the configured hour
- * (in usageScanTimezone) so it runs off-peak. The agent measures each student's home/scratch/cold
+ * (in usageScanTimezone, default midnight). The agent measures each student's home/scratch/cold
  * usage and reports it back on its heartbeat; we only kick the scans off here. Returns the lab names
- * a scan was scheduled for. Container-level usage is NOT scheduled here — it is measured live on
- * every heartbeat. Since the maintenance ticker runs hourly, the configured hour is a one-hour
- * window; last_usage_scan guards against enqueuing the same lab twice in a night.
+ * a scan was scheduled for. Lab-level usage (image + fast/cold) is NOT scheduled here — the agent
+ * recomputes it on its own ~5-min cadence. Since the maintenance ticker runs hourly, the configured
+ * hour is a one-hour window; last_usage_scan guards against enqueuing the same lab twice in a night.
  */
 export function scheduleUsageScans(now = Date.now()): string[] {
   if (!getSetting("usageScanEnabled")) return [];

--- a/controller/src/lib/settings.ts
+++ b/controller/src/lib/settings.ts
@@ -19,10 +19,10 @@ export interface Settings {
   slowQuotaDefaultBytes: number;
   sshPortStart: number;
   sshPortEnd: number;
-  // Nightly per-student usage (du) scan. Once a day, during usageScanHour (in usageScanTimezone),
-  // the controller enqueues a usage.scan to each online lab's node; the agent measures each
-  // student's home/scratch/cold usage and reports it back. Container-level usage is separate — it
-  // is measured live on every agent heartbeat and is not gated by this schedule.
+  // Nightly per-student usage (du) scan. Once a day, during usageScanHour (in usageScanTimezone,
+  // default midnight), the controller enqueues a usage.scan to each online lab's node; the agent
+  // measures each student's home/scratch/cold usage and reports it back. Lab-level usage is separate
+  // — the agent recomputes it on its own ~5-min cadence and it is not gated by this schedule.
   usageScanEnabled: boolean;
   usageScanHour: number; // hour of day (0-23, in usageScanTimezone) the nightly scan may start
   usageScanTimezone: string; // IANA tz name the usage-scan hour is evaluated in
@@ -165,7 +165,7 @@ export const DEFAULT_SETTINGS: Settings = {
   sshPortStart: 50000,
   sshPortEnd: 51000,
   usageScanEnabled: true,
-  usageScanHour: 3,
+  usageScanHour: 0, // midnight (in usageScanTimezone)
   usageScanTimezone: "UTC",
   smtpHost: "",
   smtpPort: 587,

--- a/controller/src/lib/stats.ts
+++ b/controller/src/lib/stats.ts
@@ -3,12 +3,13 @@
  * separately-cadenced kinds of data, both read from the latest `storage_samples` row per (lab,
  * student, pool):
  *
- *   - LIVE container-level (`LabStats.live`): the whole-container writable layer ("whole image",
- *     pool=docker, student_id NULL) plus the live lab-level fast/slow ZFS usage-vs-quota. These are
- *     re-measured on every agent heartbeat, so they are always current.
+ *   - LAB-LEVEL (`LabStats.live`): the whole-container writable layer ("whole image", pool=docker,
+ *     student_id NULL) plus the lab-level fast/slow ZFS usage-vs-quota. The agent recomputes these
+ *     on a fixed cadence (every ~5 min) and re-reports the cached snapshot on each heartbeat — they
+ *     are NOT measured per heartbeat — so they carry a freshness timestamp (`liveUpdatedAt`).
  *   - NIGHTLY per-student (`LabStats.students`): each student's docker home (installed software),
  *     scratch (fast) and cold (slow) `du`. These come from the per-student usage scan (nightly +
- *     on-demand "Scan now"), so they carry a freshness timestamp.
+ *     on-demand "Scan now"), so they carry their own freshness timestamp.
  */
 
 import { db } from "./db";
@@ -29,12 +30,14 @@ export interface LabStats {
   labName: string;
   image: string;
   students: StudentUsage[];
-  // Container + lab totals, refreshed every heartbeat (see module doc).
+  // Container + lab totals, recomputed by the agent on a fixed ~5-min cadence (see module doc).
   live: {
     image: number | null; // whole-container writable layer (SizeRw) for the lab container
     fast: { used: number | null; quota: number | null };
     slow: { used: number | null; quota: number | null };
   };
+  liveUpdatedAt: number | null; // when the lab-level totals above were last sampled (newest ts)
+  liveStale: boolean; // lab-level totals older than LIVE_STALE_MS (e.g. node offline) -> tint
   usageScannedAt: number | null; // when the per-student du breakdown was last computed
   scanStale: boolean; // no scan yet, or older than USAGE_STALE_MS -> offer a "Scan now" button
   scanPending: boolean; // a usage.scan task is queued/sent for this lab and not yet done
@@ -44,6 +47,10 @@ export interface LabStats {
 // during healthy operation data is up to ~a day old; this sits just past a day so only an actually
 // missed night (or a never-scanned lab) reads as stale, not the normal end-of-day age.
 const USAGE_STALE_MS = 25 * 60 * 60 * 1000;
+
+// The lab-level totals refresh every ~5 min; tint their "updated" stamp once it is older than a few
+// missed cycles (the usual reason is the node going offline, since a live node updates them on time).
+const LIVE_STALE_MS = 15 * 60 * 1000;
 
 export interface NodeStats {
   node: string;
@@ -55,6 +62,7 @@ export interface NodeStats {
 interface Cell {
   used: number;
   quota: number | null;
+  ts: number;
 }
 
 /** Latest sample per (lab, student|lab-level, pool), indexed for O(1) lookup while building. */
@@ -62,17 +70,17 @@ function latestSamples(): Map<string, Cell> {
   const rows = db()
     .prepare(
       `SELECT s.lab_id AS lab_id, s.student_id AS student_id, s.pool AS pool,
-              s.used_bytes AS used, s.quota_bytes AS quota
+              s.used_bytes AS used, s.quota_bytes AS quota, s.ts AS ts
        FROM storage_samples s
        WHERE s.ts = (SELECT MAX(ts) FROM storage_samples s2
                      WHERE s2.lab_id = s.lab_id AND s2.pool = s.pool
                        AND ((s2.student_id IS NULL AND s.student_id IS NULL)
                             OR s2.student_id = s.student_id))`,
     )
-    .all() as { lab_id: number; student_id: number | null; pool: string; used: number; quota: number | null }[];
+    .all() as { lab_id: number; student_id: number | null; pool: string; used: number; quota: number | null; ts: number }[];
   const map = new Map<string, Cell>();
   for (const r of rows) {
-    map.set(`${r.lab_id}:${r.student_id ?? "L"}:${r.pool}`, { used: r.used, quota: r.quota });
+    map.set(`${r.lab_id}:${r.student_id ?? "L"}:${r.pool}`, { used: r.used, quota: r.quota, ts: r.ts });
   }
   return map;
 }
@@ -155,6 +163,11 @@ export function buildStats(): NodeStats[] {
     students.sort((a, b) => (b.docker ?? 0) - (a.docker ?? 0) || a.username.localeCompare(b.username));
 
     const usageScannedAt = lab.usage_scanned_at ?? null;
+    // Freshness of the lab-level totals: newest ts among the lab-level docker/fast/slow samples.
+    const liveTs = (["docker", "fast", "slow"] as const)
+      .map((p) => samples.get(`${lab.id}:L:${p}`)?.ts)
+      .filter((t): t is number => typeof t === "number");
+    const liveUpdatedAt = liveTs.length ? Math.max(...liveTs) : null;
     const labStats: LabStats = {
       labId: lab.id,
       labName: lab.name,
@@ -165,6 +178,8 @@ export function buildStats(): NodeStats[] {
         fast: cell(lab.id, "fast"),
         slow: cell(lab.id, "slow"),
       },
+      liveUpdatedAt,
+      liveStale: liveUpdatedAt === null || now - liveUpdatedAt > LIVE_STALE_MS,
       usageScannedAt,
       scanStale: usageScannedAt === null || now - usageScannedAt > USAGE_STALE_MS,
       scanPending: isScanPending(scans.get(`${lab.node_name}::${lab.name}`), usageScannedAt, now),

--- a/controller/tests/phase2.test.ts
+++ b/controller/tests/phase2.test.ts
@@ -40,7 +40,7 @@ beforeAll(async () => {
 
 describe("settings", () => {
   it("roundtrips and falls back to defaults", () => {
-    expect(settings.getSetting("usageScanHour")).toBe(3);
+    expect(settings.getSetting("usageScanHour")).toBe(0); // midnight default
     settings.setSetting("usageScanHour", 5);
     expect(settings.getSetting("usageScanHour")).toBe(5);
   });

--- a/controller/tests/settings.test.ts
+++ b/controller/tests/settings.test.ts
@@ -28,9 +28,9 @@ describe("getSetting / setSetting", () => {
   it("returns the typed default when unset", () => {
     expect(settings.getSetting("fastQuotaDefaultBytes")).toBe(2 * settings.TIB);
     expect(settings.getSetting("alertLevel")).toBe("ERROR");
-    // Nightly per-student usage-scan defaults (enabled, 03:00 UTC).
+    // Nightly per-student usage-scan defaults (enabled, midnight UTC).
     expect(settings.getSetting("usageScanEnabled")).toBe(true);
-    expect(settings.getSetting("usageScanHour")).toBe(3);
+    expect(settings.getSetting("usageScanHour")).toBe(0);
   });
 
   it("roundtrips a value through JSON", () => {
@@ -61,7 +61,7 @@ describe("getSetting / setSetting", () => {
         "INSERT INTO settings (key, value) VALUES ('usageScanHour', 'not json') ON CONFLICT(key) DO UPDATE SET value=excluded.value",
       )
       .run();
-    expect(settings.getSetting("usageScanHour")).toBe(3);
+    expect(settings.getSetting("usageScanHour")).toBe(0);
   });
 });
 

--- a/controller/tests/stats.test.ts
+++ b/controller/tests/stats.test.ts
@@ -83,6 +83,9 @@ describe("buildStats", () => {
     expect(lab.live.image).toBe(300);
     expect(lab.live.fast).toEqual({ used: 500, quota: 2000 });
     expect(lab.live.slow).toEqual({ used: 200, quota: 3000 });
+    // Freshness of the lab-level row is the newest ts among its docker/fast/slow samples.
+    expect(lab.liveUpdatedAt).toBe(200);
+    expect(lab.liveStale).toBe(true); // ts=200 (epoch) is far older than LIVE_STALE_MS
   });
 });
 


### PR DESCRIPTION
## Problem

The lab-level row on the Stats page (image writable layer + Fast/Cold) was labelled **"Live · refreshed every heartbeat / always current"**, but that was false:

- the agent re-measured it (`zfs list` + `docker inspect --size`) on **every 15s heartbeat**, yet
- the controller throttles lab-level storage samples to **5-minute** granularity (`STORAGE_SAMPLE_MIN_INTERVAL_MS`),

so the displayed Fast/Cold could lag up to 5 minutes with no freshness indicator, while the agent burned measurement work every 15s for numbers that only moved every 5 min.

## Changes

**Agent** — lab-level usage genuinely computed every 5 min and reported:
- New dedicated 5-min loop (`_lab_usage_loop`, `lab_usage_interval_s=300`) computes lab-level usage (image + Fast/Cold ZFS) into a cache; the heartbeat re-reports the cached snapshot instead of re-measuring every 15s.
- **"Scan now" fires both** — refreshes the lab-level cache *and* runs the per-student `du` scan, so one trigger updates the whole page.

**Controller**:
- Drops all "live / every heartbeat / always current" wording on the Stats and Settings pages.
- Lab-level row now shows an honest **"updated Xm ago"** (amber when stale), derived from the newest lab-level sample ts (`liveUpdatedAt` / `liveStale`).
- Per-student nightly scan defaults to **midnight** (`usageScanHour` 3 → 0); still once/day, still adjustable in Settings.

Net behaviour: **lab-level = every 5 min + on trigger; per-student = midnight daily + on trigger.**

## Tests
- Agent: 207 passed (ruff clean)
- Controller: 163 passed (eslint + tsc clean)

> Note for existing deployments: the midnight default only applies where `usageScanHour` is unset. A controller with a stored value (e.g. 3) keeps it — change it in Settings → Per-student usage scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)