### PR TITLE
feat(controller): per-lab roster import, per-node usage + node groups, email templates

### DIFF
--- a/controller/src/app/(app)/_components/ConfirmButton.tsx
+++ b/controller/src/app/(app)/_components/ConfirmButton.tsx
@@ -16,6 +16,8 @@ type Props = Omit<ButtonProps, "onClick"> & {
   confirm: string;
   /** Heading for the dialog. */
   title?: string;
+  /** Destructive action label. Defaults to a generic confirmation label. */
+  confirmLabel?: string;
 };
 
 /**
@@ -27,6 +29,7 @@ type Props = Omit<ButtonProps, "onClick"> & {
 export function ConfirmButton({
   confirm: message,
   title = "Are you sure?",
+  confirmLabel = "Confirm",
   children,
   variant = "outline",
   ...rest
@@ -45,17 +48,17 @@ export function ConfirmButton({
         {children}
       </Button>
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent>
-          <DialogHeader>
+        <DialogContent className="flex max-h-[calc(100dvh-1.5rem)] flex-col gap-0 overflow-hidden p-0 sm:max-h-[calc(100dvh-3rem)]">
+          <DialogHeader className="min-h-0 overflow-y-auto p-5 pr-12 sm:p-6 sm:pr-12">
             <DialogTitle>{title}</DialogTitle>
             <DialogDescription>{message}</DialogDescription>
           </DialogHeader>
-          <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+          <DialogFooter className="shrink-0 border-t border-border bg-card p-4 sm:p-5">
+            <Button type="button" variant="outline" className="w-full sm:w-auto" onClick={() => setOpen(false)}>
               Cancel
             </Button>
-            <Button type="button" variant="destructive" onClick={onConfirm}>
-              Confirm
+            <Button type="button" variant="destructive" className="w-full sm:w-auto" onClick={onConfirm}>
+              {confirmLabel}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/controller/src/app/(app)/_components/NavLinks.tsx
+++ b/controller/src/app/(app)/_components/NavLinks.tsx
@@ -8,6 +8,7 @@ import {
   FlaskConical,
   HardDrive,
   LayoutDashboard,
+  Mail,
   ScrollText,
   Server,
   Settings,
@@ -25,6 +26,7 @@ const NAV: [string, string, LucideIcon][] = [
   ["/gpu", "GPU", Cpu],
   ["/logs", "Logs", ScrollText],
   ["/announcements", "Announce", Bell],
+  ["/email-templates", "Templates", Mail],
   ["/backups", "Backups", DatabaseBackup],
   ["/settings", "Settings", Settings],
 ];

--- a/controller/src/app/(app)/announcements/_components/AnnouncementComposer.tsx
+++ b/controller/src/app/(app)/announcements/_components/AnnouncementComposer.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useRef, useState } from "react";
+import type { AnnouncementTemplate } from "@/lib/announcements";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+
+interface Props {
+  templates: AnnouncementTemplate[];
+  vars: { key: string; desc: string }[];
+  counts: { students: number; pis: number };
+  action: (formData: FormData) => void | Promise<void>;
+}
+
+/**
+ * Compose form for a service announcement. A prebuilt-template picker fills the subject/body fields,
+ * and the variable chips insert {tokens} at the cursor — both are starting points the admin edits
+ * before sending. The fields stay controlled so the picker/inserts and the user's typing agree; the
+ * form still submits straight to the server action.
+ */
+export function AnnouncementComposer({ templates, vars, counts, action }: Props) {
+  const [subject, setSubject] = useState("");
+  const [body, setBody] = useState("");
+  const bodyRef = useRef<HTMLTextAreaElement>(null);
+
+  function applyTemplate(name: string) {
+    const tpl = templates.find((t) => t.name === name);
+    if (!tpl) return;
+    setSubject(tpl.subject);
+    setBody(tpl.body);
+  }
+
+  /** Insert {key} at the cursor in the body textarea (or append if it isn't focused). */
+  function insertVar(key: string) {
+    const token = `{${key}}`;
+    const el = bodyRef.current;
+    if (!el) {
+      setBody((b) => b + token);
+      return;
+    }
+    const start = el.selectionStart ?? body.length;
+    const end = el.selectionEnd ?? body.length;
+    const next = body.slice(0, start) + token + body.slice(end);
+    setBody(next);
+    // Restore focus and place the caret just after the inserted token.
+    requestAnimationFrame(() => {
+      el.focus();
+      const pos = start + token.length;
+      el.setSelectionRange(pos, pos);
+    });
+  }
+
+  return (
+    <form action={action} className="space-y-3">
+      <div>
+        <Label htmlFor="ann-template">Start from a template</Label>
+        <select
+          id="ann-template"
+          defaultValue=""
+          onChange={(e) => applyTemplate(e.target.value)}
+          className="flex h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:w-72"
+        >
+          <option value="">— blank message —</option>
+          {templates.map((t) => (
+            <option key={t.name} value={t.name}>
+              {t.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <Label>Subject</Label>
+        <Input
+          name="subject"
+          required
+          maxLength={200}
+          value={subject}
+          onChange={(e) => setSubject(e.target.value)}
+          placeholder="e.g. Scheduled maintenance Saturday"
+        />
+      </div>
+
+      <div>
+        <Label>Message</Label>
+        <Textarea
+          ref={bodyRef}
+          name="body"
+          required
+          rows={8}
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          placeholder="Write your announcement…"
+        />
+        <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+          <span className="text-xs text-muted-foreground">Insert variable:</span>
+          {vars.map((v) => (
+            <button
+              key={v.key}
+              type="button"
+              onClick={() => insertVar(v.key)}
+              title={v.desc}
+              className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs hover:bg-accent hover:text-accent-foreground"
+            >
+              {`{${v.key}}`}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <fieldset className="rounded-md border border-border p-3">
+        <legend className="px-1 text-xs text-muted-foreground">Recipients</legend>
+        <div className="flex flex-wrap gap-x-6 gap-y-2">
+          <label className="flex items-center gap-1.5 text-sm">
+            <input type="checkbox" name="students" defaultChecked className="accent-primary" />
+            All users ({counts.students})
+          </label>
+          <label className="flex items-center gap-1.5 text-sm">
+            <input type="checkbox" name="pis" className="accent-primary" />
+            All PIs ({counts.pis})
+          </label>
+        </div>
+      </fieldset>
+
+      <Button type="submit">Send announcement</Button>
+    </form>
+  );
+}

--- a/controller/src/app/(app)/announcements/page.tsx
+++ b/controller/src/app/(app)/announcements/page.tsx
@@ -1,12 +1,9 @@
-import { audienceCounts, recentAnnouncements } from "@/lib/announcements";
+import { ANNOUNCEMENT_TEMPLATES, ANNOUNCEMENT_VARS, audienceCounts, recentAnnouncements } from "@/lib/announcements";
 import { isSmtpConfigured } from "@/lib/settings";
 import { ago } from "@/lib/format";
 import { sendAnnouncementAction } from "./actions";
-import { Button } from "@/components/ui/button";
+import { AnnouncementComposer } from "./_components/AnnouncementComposer";
 import { Card, CardContent } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 
 export const dynamic = "force-dynamic";
@@ -51,33 +48,17 @@ export default async function AnnouncementsPage({
       <Card>
         <CardContent className="space-y-3">
           <h3 className="text-base font-semibold">Send a service announcement</h3>
-          <form action={sendAnnouncementAction} className="space-y-3">
-            <div>
-              <Label>Subject</Label>
-              <Input name="subject" required maxLength={200} placeholder="e.g. Scheduled maintenance Saturday" />
-            </div>
-            <div>
-              <Label>Message</Label>
-              <Textarea name="body" required rows={6} placeholder="Write your announcement…" />
-            </div>
-            <fieldset className="rounded-md border border-border p-3">
-              <legend className="px-1 text-xs text-muted-foreground">Recipients</legend>
-              <div className="flex flex-wrap gap-x-6 gap-y-2">
-                <label className="flex items-center gap-1.5 text-sm">
-                  <input type="checkbox" name="students" defaultChecked className="accent-primary" />
-                  All users ({counts.students})
-                </label>
-                <label className="flex items-center gap-1.5 text-sm">
-                  <input type="checkbox" name="pis" className="accent-primary" />
-                  All PIs ({counts.pis})
-                </label>
-              </div>
-            </fieldset>
-            <Button type="submit">Send announcement</Button>
-          </form>
+          <AnnouncementComposer
+            templates={ANNOUNCEMENT_TEMPLATES}
+            vars={ANNOUNCEMENT_VARS}
+            counts={counts}
+            action={sendAnnouncementAction}
+          />
           <p className="text-xs text-muted-foreground">
-            Sent by email to the distinct addresses in the selected audiences. A PI who is also a user
-            is mailed once.
+            Sent by email to the distinct addresses in the selected audiences (a PI who is also a user
+            is mailed once). <code>{"{name}"}</code> and <code>{"{email}"}</code> are filled in per
+            recipient. See all templates and variables under{" "}
+            <a href="/email-templates" className="underline">Email templates</a>.
           </p>
         </CardContent>
       </Card>

--- a/controller/src/app/(app)/email-templates/page.tsx
+++ b/controller/src/app/(app)/email-templates/page.tsx
@@ -1,0 +1,189 @@
+import Link from "next/link";
+import {
+  ANNOUNCEMENT_TEMPLATES,
+  ANNOUNCEMENT_VARS,
+} from "@/lib/announcements";
+import {
+  GPU_EMAIL_VARS,
+  WELCOME_EMAIL_VARS,
+  getSettings,
+} from "@/lib/settings";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+
+export const dynamic = "force-dynamic";
+
+interface Variable {
+  key: string;
+  desc: string;
+}
+
+interface TemplateDoc {
+  name: string;
+  trigger: string;
+  /** Where the admin edits this template, or null if it is fixed in code. */
+  editable: { href: string; label: string } | null;
+  vars: Variable[];
+  subject: string;
+  body: string;
+  note?: string;
+}
+
+function VarList({ vars }: { vars: Variable[] }) {
+  if (vars.length === 0) {
+    return <p className="text-sm text-muted-foreground">No variables — this message is fixed text.</p>;
+  }
+  return (
+    <ul className="grid grid-cols-1 gap-x-6 gap-y-1.5 sm:grid-cols-2">
+      {vars.map((v) => (
+        <li key={v.key} className="flex flex-wrap items-baseline gap-x-2 text-sm">
+          <code className="rounded bg-muted px-1.5 py-0.5 text-xs">{`{${v.key}}`}</code>
+          <span className="text-muted-foreground">{v.desc}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function TemplateCard({ tpl }: { tpl: TemplateDoc }) {
+  return (
+    <Card>
+      <CardContent className="space-y-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <h3 className="text-base font-semibold">{tpl.name}</h3>
+          {tpl.editable ? (
+            <Badge variant="ok">editable</Badge>
+          ) : (
+            <Badge variant="warn">fixed</Badge>
+          )}
+        </div>
+        <p className="text-sm text-muted-foreground">{tpl.trigger}</p>
+        {tpl.editable && (
+          <p className="text-sm">
+            Edit at{" "}
+            <Link href={tpl.editable.href} className="text-primary hover:underline">
+              {tpl.editable.label}
+            </Link>
+            .
+          </p>
+        )}
+
+        <div className="space-y-1.5">
+          <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            Available variables
+          </div>
+          <VarList vars={tpl.vars} />
+        </div>
+
+        <div className="space-y-2">
+          <div>
+            <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Subject</div>
+            <div className="mt-1 overflow-x-auto rounded-md border border-border/60 bg-muted/30 px-3 py-2 font-mono text-xs">
+              {tpl.subject}
+            </div>
+          </div>
+          <div>
+            <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Body</div>
+            <pre className="mt-1 overflow-x-auto whitespace-pre-wrap break-words rounded-md border border-border/60 bg-muted/30 px-3 py-2 font-mono text-xs">
+              {tpl.body}
+            </pre>
+          </div>
+        </div>
+
+        {tpl.note && <p className="text-xs text-muted-foreground">{tpl.note}</p>}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default async function EmailTemplatesPage() {
+  const s = getSettings();
+  const gpuKillVars = GPU_EMAIL_VARS.filter((v) => v.key !== "grace_minutes");
+
+  const templates: TemplateDoc[] = [
+    {
+      name: "Welcome / credentials",
+      trigger: "Sent to a student once they are successfully provisioned on a node — carries their login and SSH connection details.",
+      editable: { href: "/settings", label: "Settings → Email" },
+      vars: WELCOME_EMAIL_VARS,
+      subject: s.welcomeEmailSubject,
+      body: s.welcomeEmailBody,
+    },
+    {
+      name: "GPU idle warning",
+      trigger: "Sent to a user whose process is holding GPU memory while idle, before it is terminated.",
+      editable: { href: "/settings", label: "Settings → GPU policy" },
+      vars: GPU_EMAIL_VARS,
+      subject: s.gpuWarnEmailSubject,
+      body: s.gpuWarnEmailBody,
+    },
+    {
+      name: "GPU process terminated",
+      trigger: "Sent to a user after their idle GPU process has been terminated to free the GPU.",
+      editable: { href: "/settings", label: "Settings → GPU policy" },
+      vars: gpuKillVars,
+      subject: s.gpuKillEmailSubject,
+      body: s.gpuKillEmailBody,
+    },
+    {
+      name: "Service announcement",
+      trigger: "Composed by an admin and broadcast to all students and/or all PIs.",
+      editable: { href: "/announcements", label: "Announcements" },
+      vars: ANNOUNCEMENT_VARS,
+      subject: "(composed per send)",
+      body: `(composed per send — ${ANNOUNCEMENT_TEMPLATES.length} prebuilt starting points are offered on the Announcements page)\n\nPrebuilt templates:\n${ANNOUNCEMENT_TEMPLATES.map((t) => `  • ${t.name}`).join("\n")}`,
+      note: "A fixed “— Lab Manager” signature is appended to every announcement.",
+    },
+    {
+      name: "Removed from lab",
+      trigger: "Sent to a student when they are removed from a lab (notes whether their data was deleted).",
+      editable: null,
+      vars: [{ key: "lab", desc: "lab name (substituted into the fixed text)" }],
+      subject: "Removed from lab {lab}",
+      body: `You have been removed from the lab "{lab}". <your data was deleted | your data has been retained for now>.\n\n— Lab Manager`,
+    },
+    {
+      name: "Storage quota alert",
+      trigger: "Sent to a lab's PI when one of its pools crosses the quota-alert threshold (Settings → Alerts).",
+      editable: null,
+      vars: [
+        { key: "lab", desc: "lab name" },
+        { key: "pool", desc: "pool that crossed the threshold (fast/cold)" },
+        { key: "pct", desc: "percent of quota used" },
+        { key: "used / quota", desc: "human-readable used and total" },
+      ],
+      subject: "Lab {lab} is at {pct}% of its {pool} quota",
+      body: `Lab "{lab}" has reached {pct}% of its {pool} storage quota ({used} of {quota}).\n\nPer-student usage on the {pool} pool:\n  <username>  <used>\n  …\n\n— Lab Manager`,
+    },
+    {
+      name: "Test email",
+      trigger: "Sent when an admin clicks “Send test” under Settings → Email to verify SMTP.",
+      editable: null,
+      vars: [],
+      subject: "Lab Manager test email",
+      body: "This is a test email from the Lab Manager controller. SMTP is configured correctly.",
+    },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold tracking-tight">Email templates</h1>
+        <p className="text-sm text-muted-foreground">
+          Every email the controller can send, with the <code>{"{variables}"}</code> each one
+          understands. Editable templates fall back to the built-in default when left blank; an unknown{" "}
+          <code>{"{token}"}</code> is left in the text as-is so typos are visible. All email requires SMTP
+          configured under{" "}
+          <Link href="/settings" className="text-primary hover:underline">
+            Settings → Email
+          </Link>
+          .
+        </p>
+      </div>
+
+      {templates.map((tpl) => (
+        <TemplateCard key={tpl.name} tpl={tpl} />
+      ))}
+    </div>
+  );
+}

--- a/controller/src/app/(app)/labs/[id]/page.tsx
+++ b/controller/src/app/(app)/labs/[id]/page.tsx
@@ -8,6 +8,7 @@ import { listPlacements, type Placement } from "@/lib/placements";
 import { listMembers } from "@/lib/students";
 import { getSettings, TIB } from "@/lib/settings";
 import { PlacementForm, type NodeOpt } from "../_components/PlacementForm";
+import { RosterImportForm } from "../_components/RosterImportForm";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -16,8 +17,10 @@ import { Label } from "@/components/ui/label";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import {
   addMemberAction,
+  applyRosterImportAction,
   destroyLabAction,
   grantNodeAccessAction,
+  previewRosterImportAction,
   removeMemberAction,
   updateLabMetaAction,
 } from "../actions";
@@ -262,11 +265,24 @@ export default async function LabDetail({
       </Card>
 
       <Card>
+        <CardContent className="space-y-3">
+          <h3 className="text-base font-semibold">Import roster from CSV</h3>
+          <RosterImportForm
+            labId={lab.id}
+            preview={previewRosterImportAction}
+            apply={applyRosterImportAction}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
         <CardContent className="flex flex-wrap items-center gap-3">
           <form action={destroyLabAction}>
             <input type="hidden" name="labId" value={lab.id} />
             <ConfirmButton
               variant="destructive"
+              title={`Delete ${lab.name}?`}
+              confirmLabel="Delete lab"
               confirm={
                 placements.length > 0
                   ? `Delete lab "${lab.name}"? Its ${placements.length} placement(s) are torn down first (container + data on each node); the lab is removed once every node confirms.`

--- a/controller/src/app/(app)/labs/_components/RosterImportForm.tsx
+++ b/controller/src/app/(app)/labs/_components/RosterImportForm.tsx
@@ -1,31 +1,40 @@
 "use client";
 
 import { useRef, useState, useTransition } from "react";
-import type { ImportPlan, ImportResult } from "@/lib/labimport";
+import type { RosterImportPlan, RosterImportResult } from "@/lib/labimport";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 
-const SAMPLE = `lab_name,pi_name,pi_email,student_id,username,student_name,student_email
-smith-lab,Dr. Jane Smith,jane.smith@example.edu,100001,jdoe,John Doe,jdoe@example.edu
-smith-lab,Dr. Jane Smith,jane.smith@example.edu,100002,asmith,Alice Smith,asmith@example.edu
-empty-lab,Dr. Mary Lee,mary.lee@example.edu,,,,`;
+const SAMPLE = `role,username,email,name,student_id
+pi,,jane.smith@example.edu,Dr. Jane Smith,
+student,jdoe,jdoe@example.edu,John Doe,100001
+student,asmith,asmith@example.edu,Alice Smith,100002`;
 
 interface Props {
-  preview: (text: string) => Promise<ImportPlan>;
-  apply: (text: string) => Promise<{ result?: ImportResult; error?: string }>;
+  labId: number;
+  preview: (labId: number, text: string) => Promise<RosterImportPlan>;
+  apply: (labId: number, text: string) => Promise<{ result?: RosterImportResult; error?: string }>;
 }
 
-function Summary({ plan }: { plan: ImportPlan }) {
-  const rows: [string, number][] = [
-    ["Labs to create", plan.labsToCreate.length],
-    ["Labs to update", plan.labsToUpdate.length],
+function planChangeCount(plan: RosterImportPlan): number {
+  return (
+    (plan.piUpdate ? 1 : 0) +
+    plan.studentsToCreate.length +
+    plan.studentsToUpdate.length +
+    plan.membershipsToAdd.length
+  );
+}
+
+function Summary({ plan }: { plan: RosterImportPlan }) {
+  const rows: [string, string | number][] = [
+    ["PI metadata", plan.piUpdate ? "changes" : "unchanged"],
     ["Students to create", plan.studentsToCreate.length],
     ["Students to update", plan.studentsToUpdate.length],
-    ["Memberships to add", plan.membershipsToAdd.length],
+    ["Members to add", plan.membershipsToAdd.length],
   ];
   return (
     <div className="space-y-3 text-sm">
-      <div className="grid grid-cols-2 gap-x-4 gap-y-1 sm:grid-cols-3">
+      <div className="grid grid-cols-2 gap-x-4 gap-y-1 sm:grid-cols-4">
         {rows.map(([label, n]) => (
           <div key={label} className="flex justify-between gap-2">
             <span className="text-muted-foreground">{label}</span>
@@ -57,9 +66,9 @@ function Summary({ plan }: { plan: ImportPlan }) {
   );
 }
 
-export function LabImportForm({ preview, apply }: Props) {
+export function RosterImportForm({ labId, preview, apply }: Props) {
   const [text, setText] = useState("");
-  const [plan, setPlan] = useState<ImportPlan | null>(null);
+  const [plan, setPlan] = useState<RosterImportPlan | null>(null);
   const [done, setDone] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [pending, start] = useTransition();
@@ -70,7 +79,7 @@ export function LabImportForm({ preview, apply }: Props) {
     setDone(null);
     start(async () => {
       try {
-        setPlan(await preview(text));
+        setPlan(await preview(labId, text));
       } catch (e) {
         setErr(e instanceof Error ? e.message : "preview failed");
       }
@@ -80,14 +89,15 @@ export function LabImportForm({ preview, apply }: Props) {
   function onApply() {
     setErr(null);
     start(async () => {
-      const res = await apply(text);
+      const res = await apply(labId, text);
       if (res.error) {
         setErr(res.error);
       } else if (res.result) {
         const r = res.result;
         setDone(
-          `Imported: ${r.labsCreated} labs created, ${r.labsUpdated} updated; ${r.studentsCreated} students created, ${r.studentsUpdated} updated; ${r.membershipsAdded} memberships added` +
-            (r.provisioned ? `; ${r.provisioned} queued on existing placements (credentials follow agent confirmation)` : ""),
+          `Imported: ${r.studentsCreated} students created, ${r.studentsUpdated} updated; ${r.membershipsAdded} added to the roster` +
+            (r.piUpdated ? "; PI metadata updated" : "") +
+            (r.provisioned ? `; ${r.provisioned} queued on existing nodes (credentials follow agent confirmation)` : ""),
         );
         setPlan(null);
         setText("");
@@ -103,9 +113,10 @@ export function LabImportForm({ preview, apply }: Props) {
   return (
     <div className="space-y-3">
       <p className="text-xs text-muted-foreground">
-        Columns: <code>lab_name,pi_name,pi_email,student_id,username,student_name,student_email</code>.
-        One row per membership; leave the student columns blank to create an empty lab. The whole file
-        is validated before anything is written, and re-importing is idempotent.
+        Columns: <code>role,username,email,name,student_id</code>. <code>role</code> is{" "}
+        <code>student</code> (the default) or <code>pi</code>; a single <code>pi</code> row sets this
+        lab&apos;s PI (no need to repeat it on every student row). The whole file is validated before
+        anything is written, and re-importing is idempotent.
       </p>
       <Textarea
         value={text}
@@ -122,7 +133,7 @@ export function LabImportForm({ preview, apply }: Props) {
         <Button type="button" onClick={onPreview} disabled={pending || !text.trim()}>
           {pending ? "Working…" : "Preview"}
         </Button>
-        {plan && plan.ok && plan.membershipsToAdd.length + plan.labsToCreate.length + plan.labsToUpdate.length + plan.studentsToCreate.length + plan.studentsToUpdate.length > 0 && (
+        {plan && plan.ok && planChangeCount(plan) > 0 && (
           <Button type="button" onClick={onApply} disabled={pending}>
             Apply import
           </Button>
@@ -137,7 +148,7 @@ export function LabImportForm({ preview, apply }: Props) {
               Not committable — fix the issues below and preview again.
             </p>
           )}
-          {plan.ok && plan.labsToCreate.length + plan.labsToUpdate.length + plan.studentsToCreate.length + plan.studentsToUpdate.length + plan.membershipsToAdd.length === 0 && (
+          {plan.ok && planChangeCount(plan) === 0 && (
             <p className="mb-2 text-sm text-muted-foreground">Nothing to change — already up to date.</p>
           )}
           <Summary plan={plan} />

--- a/controller/src/app/(app)/labs/actions.ts
+++ b/controller/src/app/(app)/labs/actions.ts
@@ -4,7 +4,7 @@ import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
 import { requireAdmin } from "@/lib/auth";
 import { putFlash } from "@/lib/flash";
-import { applyLabImport, type ImportPlan, type ImportResult, planLabImport } from "@/lib/labimport";
+import { applyRosterImport, type RosterImportPlan, type RosterImportResult, planRosterImport } from "@/lib/labimport";
 import { createLab, destroyLab, getLab, updateLabMeta } from "@/lib/labs";
 import {
   type ContainerOptions,
@@ -262,18 +262,21 @@ export async function addMemberAction(formData: FormData) {
   redirect(`/labs/${labId}?saved=${fid}`);
 }
 
-/** Preview a lab+roster CSV import: validate the whole file against the DB without writing anything. */
-export async function previewLabImportAction(text: string): Promise<ImportPlan> {
+/** Preview a per-lab roster CSV import: validate the whole file against the DB without writing anything. */
+export async function previewRosterImportAction(labId: number, text: string): Promise<RosterImportPlan> {
   await requireAdmin();
-  return planLabImport(String(text ?? ""));
+  return planRosterImport(Number(labId), String(text ?? ""));
 }
 
-/** Apply a previewed lab+roster CSV import in one transaction. */
-export async function applyLabImportAction(text: string): Promise<{ result?: ImportResult; error?: string }> {
+/** Apply a previewed per-lab roster CSV import in one transaction. */
+export async function applyRosterImportAction(
+  labId: number,
+  text: string,
+): Promise<{ result?: RosterImportResult; error?: string }> {
   const who = await actor();
   try {
-    const result = await applyLabImport(String(text ?? ""), who);
-    revalidatePath("/labs");
+    const result = await applyRosterImport(Number(labId), String(text ?? ""), who);
+    revalidatePath(`/labs/${Number(labId)}`);
     revalidatePath("/students");
     return { result };
   } catch (e) {

--- a/controller/src/app/(app)/labs/page.tsx
+++ b/controller/src/app/(app)/labs/page.tsx
@@ -1,9 +1,8 @@
 import { takeFlash } from "@/lib/flash";
 import { listLabPlacementSummaries, listLabs } from "@/lib/labs";
 import Link from "next/link";
-import { applyLabImportAction, createLabAction, previewLabImportAction } from "./actions";
+import { createLabAction } from "./actions";
 import { CreateLabForm, type LabTemplate } from "./_components/CreateLabForm";
-import { LabImportForm } from "./_components/LabImportForm";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
@@ -48,13 +47,6 @@ export default async function LabsPage({
             </p>
           </div>
           <CreateLabForm labs={templates} action={createLabAction} />
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardContent className="space-y-3">
-          <h3 className="text-base font-semibold">Import labs &amp; rosters from CSV</h3>
-          <LabImportForm preview={previewLabImportAction} apply={applyLabImportAction} />
         </CardContent>
       </Card>
 

--- a/controller/src/app/(app)/layout.tsx
+++ b/controller/src/app/(app)/layout.tsx
@@ -24,13 +24,15 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
         <SidebarContent email={admin.email} logout={logout} />
       </aside>
 
-      <div className="flex min-h-screen flex-col md:pl-64">
+      <div className="flex min-h-screen min-w-0 flex-col md:pl-64">
         {/* Hamburger top bar on mobile; the same sidebar body slides in as a Sheet */}
         <MobileNav>
           <SidebarContent email={admin.email} logout={logout} />
         </MobileNav>
 
-        <main className="w-full max-w-6xl flex-1 px-4 py-6 sm:px-6 lg:px-8">{children}</main>
+        <main className="mx-auto w-full min-w-0 max-w-[100rem] flex-1 px-4 py-6 sm:px-6 lg:px-8">
+          {children}
+        </main>
       </div>
     </div>
   );

--- a/controller/src/app/(app)/nodes/page.tsx
+++ b/controller/src/app/(app)/nodes/page.tsx
@@ -189,20 +189,15 @@ export default async function NodesPage({
           {nodes.length === 0 ? (
             <p className="text-sm text-muted-foreground">No nodes have connected yet.</p>
           ) : (
-            <Table>
+            <Table className="min-w-[52rem]">
               <TableHeader>
                 <TableRow>
                   <TableHead>Node</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead>Auth</TableHead>
-                  <TableHead>GPUs</TableHead>
-                  <TableHead>Pools</TableHead>
+                  <TableHead>State</TableHead>
+                  <TableHead>Storage</TableHead>
                   <TableHead>Cold storage</TableHead>
-                  <TableHead>Dependencies</TableHead>
-                  <TableHead>Scrub</TableHead>
-                  <TableHead>Issues</TableHead>
-                  <TableHead>Last seen</TableHead>
-                  <TableHead>Token</TableHead>
+                  <TableHead>Health</TableHead>
+                  <TableHead>Activity</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -212,7 +207,7 @@ export default async function NodesPage({
                   const scrub = scrubSummary(n.scrub_status);
                   return (
                     <TableRow key={n.name}>
-                      <TableCell>
+                      <TableCell className="w-44 align-top">
                         {n.alias ? (
                           <>
                             <div>{n.alias}</div>
@@ -235,21 +230,38 @@ export default async function NodesPage({
                           </Button>
                         </form>
                       </TableCell>
-                      <TableCell>
-                        <Badge variant={n.online ? "ok" : "err"}>
-                          {n.online ? "online" : "offline"}
-                        </Badge>
+                      <TableCell className="w-28 align-top">
+                        <div className="space-y-2">
+                          <Badge variant={n.online ? "ok" : "err"}>
+                            {n.online ? "online" : "offline"}
+                          </Badge>
+                          <dl className="space-y-1 text-xs">
+                            <div>
+                              <dt className="text-muted-foreground">Auth</dt>
+                              <dd className={n.allowed !== 1 ? "text-warn" : undefined}>{authLabel(n)}</dd>
+                            </div>
+                            <div>
+                              <dt className="text-muted-foreground">GPUs</dt>
+                              <dd>{caps.gpu_count ?? 0}</dd>
+                            </div>
+                          </dl>
+                        </div>
                       </TableCell>
-                      <TableCell className={n.allowed !== 1 ? "text-warn" : undefined}>
-                        {authLabel(n)}
+                      <TableCell className="w-36 align-top text-xs">
+                        {pools.length === 0 ? (
+                          "—"
+                        ) : (
+                          <div className="space-y-1.5">
+                            {pools.map((p: any) => (
+                              <div key={p.name}>
+                                <div className="font-medium text-foreground">{p.name}</div>
+                                <div className="whitespace-nowrap text-muted-foreground">{fmtBytes(p.free)} free</div>
+                              </div>
+                            ))}
+                          </div>
+                        )}
                       </TableCell>
-                      <TableCell>{caps.gpu_count ?? 0}</TableCell>
-                      <TableCell>
-                        {pools.length === 0
-                          ? "—"
-                          : pools.map((p: any) => `${p.name}: ${fmtBytes(p.free)} free`).join(", ")}
-                      </TableCell>
-                      <TableCell>
+                      <TableCell className="w-40 align-top">
                         {n.cold_backend === "smb" ? (
                           <span>Managed by {n.owner_name ?? <span className="text-warn">no owner</span>}</span>
                         ) : (
@@ -273,24 +285,33 @@ export default async function NodesPage({
                           </div>
                         )}
                       </TableCell>
-                      <TableCell className="min-w-40 text-xs">
-                        {n.hosted_labs ? <div><span className="text-muted-foreground">Labs:</span> {n.hosted_labs}</div> : null}
-                        {n.client_nodes ? <div><span className="text-muted-foreground">SMB clients:</span> {n.client_nodes}</div> : null}
-                        {!n.hosted_labs && !n.client_nodes ? "—" : null}
+                      <TableCell className="w-44 align-top text-xs">
+                        <dl className="space-y-2">
+                          <div>
+                            <dt className="text-muted-foreground">Dependencies</dt>
+                            <dd>
+                              {n.hosted_labs ? <div><span className="text-muted-foreground">Labs:</span> {n.hosted_labs}</div> : null}
+                              {n.client_nodes ? <div><span className="text-muted-foreground">SMB clients:</span> {n.client_nodes}</div> : null}
+                              {!n.hosted_labs && !n.client_nodes ? "—" : null}
+                            </dd>
+                          </div>
+                          <div>
+                            <dt className="text-muted-foreground">Scrub</dt>
+                            <dd className={scrub.bad ? "text-warn" : undefined}>{scrub.text}</dd>
+                          </div>
+                          <div>
+                            <dt className="text-muted-foreground">Issues</dt>
+                            <dd className={caps.issues && caps.issues.length > 0 ? "text-warn" : undefined}>
+                              {caps.issues && caps.issues.length > 0 ? caps.issues.length : "—"}
+                            </dd>
+                          </div>
+                        </dl>
                       </TableCell>
-                      <TableCell className={scrub.bad ? "text-warn" : undefined}>{scrub.text}</TableCell>
-                      <TableCell>
-                        {caps.issues && caps.issues.length > 0 ? (
-                          <span className="text-warn">{caps.issues.length}</span>
-                        ) : (
-                          "—"
-                        )}
-                      </TableCell>
-                      <TableCell className="whitespace-nowrap text-muted-foreground">
-                        {ago(n.last_seen)}
-                      </TableCell>
-                      <TableCell className="whitespace-nowrap">
-                        <div className="flex gap-1.5">
+                      <TableCell className="w-44 align-top">
+                        <div className="mb-2 whitespace-nowrap text-xs text-muted-foreground">
+                          Last seen {ago(n.last_seen)}
+                        </div>
+                        <div className="flex flex-wrap gap-1.5">
                           <form action={rotateNodeTokenAction}>
                             <input type="hidden" name="name" value={n.name} />
                             <Button type="submit" variant="secondary" size="sm">
@@ -312,6 +333,7 @@ export default async function NodesPage({
                               size="sm"
                               className="text-err"
                               confirm={`Delete node "${n.name}"? This removes it from the controller (it fails if any labs are still pinned to it).`}
+                              confirmLabel="Delete node"
                             >
                               Delete
                             </ConfirmButton>

--- a/controller/src/app/(app)/stats/actions.ts
+++ b/controller/src/app/(app)/stats/actions.ts
@@ -1,8 +1,11 @@
 "use server";
 
+import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
 import { requireAdmin } from "@/lib/auth";
 import { db } from "@/lib/db";
+import { putFlash } from "@/lib/flash";
+import { createNodeGroup, deleteNodeGroup, renameNodeGroup, setNodeGroupMembers } from "@/lib/nodegroups";
 import { enqueueTask } from "@/lib/queue";
 
 /**
@@ -30,4 +33,38 @@ export async function usageScanAction(formData: FormData) {
     .all(placement.lab_id) as { username: string }[]).map((r) => r.username);
   enqueueTask(placement.node, "usage.scan", { lab: placement.lab, users }, who);
   revalidatePath("/stats");
+}
+
+/** Run a node-group mutation, surfacing any error as a flash on the Stats page. */
+async function withGroupFlash(fn: (who: string) => void): Promise<void> {
+  const who = (await requireAdmin()).email;
+  try {
+    fn(who);
+  } catch (e) {
+    const fid = putFlash(e instanceof Error ? e.message : "Could not update node groups");
+    redirect(`/stats?error=${fid}`);
+  }
+  revalidatePath("/stats");
+}
+
+export async function createNodeGroupAction(formData: FormData) {
+  const name = String(formData.get("name") ?? "");
+  await withGroupFlash((who) => createNodeGroup(name, who));
+}
+
+export async function renameNodeGroupAction(formData: FormData) {
+  const groupId = Number(formData.get("groupId"));
+  const name = String(formData.get("name") ?? "");
+  await withGroupFlash((who) => renameNodeGroup(groupId, name, who));
+}
+
+export async function deleteNodeGroupAction(formData: FormData) {
+  const groupId = Number(formData.get("groupId"));
+  await withGroupFlash((who) => deleteNodeGroup(groupId, who));
+}
+
+export async function setNodeGroupMembersAction(formData: FormData) {
+  const groupId = Number(formData.get("groupId"));
+  const nodeIds = formData.getAll("nodeId").map((v) => Number(v)).filter((n) => Number.isFinite(n));
+  await withGroupFlash((who) => setNodeGroupMembers(groupId, nodeIds, who));
 }

--- a/controller/src/app/(app)/stats/page.tsx
+++ b/controller/src/app/(app)/stats/page.tsx
@@ -1,13 +1,24 @@
 import type { ReactNode } from "react";
 import { Loader2, RefreshCw } from "lucide-react";
+import { ConfirmButton } from "../_components/ConfirmButton";
+import { takeFlash } from "@/lib/flash";
 import { ago, fmtBytes, pct } from "@/lib/format";
-import { buildStats, type LabStats } from "@/lib/stats";
+import { listNodeGroups, type NodeGroup } from "@/lib/nodegroups";
+import { buildNodeUsage, buildStats, type LabStats, type NodeUsage } from "@/lib/stats";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 import { SubmitButton } from "@/components/SubmitButton";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { ScanAutoRefresh } from "./_components/ScanAutoRefresh";
-import { usageScanAction } from "./actions";
+import {
+  createNodeGroupAction,
+  deleteNodeGroupAction,
+  renameNodeGroupAction,
+  setNodeGroupMembersAction,
+  usageScanAction,
+} from "./actions";
 
 export const dynamic = "force-dynamic";
 
@@ -151,8 +162,187 @@ function LabBlock({ lab }: { lab: LabStats }) {
   );
 }
 
-export default async function StatsPage() {
+function sumUsed(nodes: NodeUsage[], key: "fastUsed" | "coldUsed"): number | null {
+  return nodes.reduce<number | null>((s, n) => (n[key] === null ? s : (s ?? 0) + n[key]!), null);
+}
+
+function NodeName({ n }: { n: NodeUsage }) {
+  return (
+    <span className="flex flex-wrap items-center gap-x-1.5">
+      <span className="font-medium">{n.name}</span>
+      {n.alias && <span className="text-xs text-muted-foreground">· {n.alias}</span>}
+      <Badge variant={n.online ? "ok" : "err"}>{n.online ? "online" : "offline"}</Badge>
+    </span>
+  );
+}
+
+/** Cold cell for a node: SMB clients have no local cold — show the linked normal node instead. */
+function coldCell(n: NodeUsage) {
+  if (n.coldBackend === "smb") {
+    return (
+      <span className="text-muted-foreground">
+        on {n.coldOwnerName ?? <span className="text-amber-500">no owner</span>}
+      </span>
+    );
+  }
+  return quotaCell(n.coldUsed, n.coldQuota);
+}
+
+function NodeUsageTable({ nodes }: { nodes: NodeUsage[] }) {
+  if (nodes.length === 0) {
+    return <p className="text-sm text-muted-foreground">No nodes.</p>;
+  }
+  const fastTotal = sumUsed(nodes, "fastUsed");
+  const coldTotal = sumUsed(nodes, "coldUsed");
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Node</TableHead>
+          <TableHead>Fast</TableHead>
+          <TableHead>Cold</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {nodes.map((n) => (
+          <TableRow key={n.nodeId}>
+            <TableCell><NodeName n={n} /></TableCell>
+            <TableCell className="tabular-nums">{quotaCell(n.fastUsed, n.fastQuota)}</TableCell>
+            <TableCell className="tabular-nums">{coldCell(n)}</TableCell>
+          </TableRow>
+        ))}
+        {nodes.length > 1 && (
+          <TableRow className="border-t-2">
+            <TableCell className="font-semibold">Total ({nodes.length} nodes)</TableCell>
+            <TableCell className="font-semibold tabular-nums">{fastTotal === null ? "—" : fmtBytes(fastTotal)}</TableCell>
+            <TableCell className="font-semibold tabular-nums">{coldTotal === null ? "—" : fmtBytes(coldTotal)}</TableCell>
+          </TableRow>
+        )}
+      </TableBody>
+    </Table>
+  );
+}
+
+function GroupBlock({ group, allNodes }: { group: NodeGroup; allNodes: NodeUsage[] }) {
+  const memberSet = new Set(group.nodeIds);
+  const members = allNodes.filter((n) => memberSet.has(n.nodeId));
+  return (
+    <div className="space-y-3 rounded-md border border-border/60 p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h4 className="text-sm font-semibold">
+          {group.name}{" "}
+          <span className="font-normal text-muted-foreground">· {members.length} node{members.length === 1 ? "" : "s"}</span>
+        </h4>
+        <form action={deleteNodeGroupAction}>
+          <input type="hidden" name="groupId" value={group.id} />
+          <ConfirmButton
+            size="sm"
+            variant="ghost"
+            title={`Delete group "${group.name}"?`}
+            confirmLabel="Delete group"
+            confirm={`Delete the node group "${group.name}"? This only removes the grouping; the nodes and their data are untouched.`}
+          >
+            Delete
+          </ConfirmButton>
+        </form>
+      </div>
+
+      <NodeUsageTable nodes={members} />
+
+      <details className="text-sm">
+        <summary className="cursor-pointer text-muted-foreground hover:text-foreground">Edit group</summary>
+        <div className="mt-3 space-y-4">
+          <form action={renameNodeGroupAction} className="flex flex-wrap items-end gap-2">
+            <input type="hidden" name="groupId" value={group.id} />
+            <Input name="name" defaultValue={group.name} className="h-9 w-48" aria-label="Group name" />
+            <Button type="submit" size="sm" variant="secondary">Rename</Button>
+          </form>
+          <form action={setNodeGroupMembersAction} className="space-y-2">
+            <input type="hidden" name="groupId" value={group.id} />
+            <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-2 lg:grid-cols-3">
+              {allNodes.map((n) => (
+                <label key={n.nodeId} className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    name="nodeId"
+                    value={n.nodeId}
+                    defaultChecked={memberSet.has(n.nodeId)}
+                    className="accent-primary"
+                  />
+                  <span>{n.name}{n.alias ? <span className="text-muted-foreground"> · {n.alias}</span> : null}</span>
+                </label>
+              ))}
+            </div>
+            <Button type="submit" size="sm">Save nodes</Button>
+          </form>
+        </div>
+      </details>
+    </div>
+  );
+}
+
+function PerNodeUsageSection({
+  usage,
+  groups,
+  flash,
+}: {
+  usage: NodeUsage[];
+  groups: NodeGroup[];
+  flash: string | null;
+}) {
+  const grouped = new Set(groups.flatMap((g) => g.nodeIds));
+  const ungrouped = usage.filter((n) => !grouped.has(n.nodeId));
+  return (
+    <Card>
+      <CardContent className="space-y-4">
+        <div className="space-y-1">
+          <h3 className="text-base font-semibold">Per-node usage</h3>
+          <p className="text-sm text-muted-foreground">
+            Total storage used on each node, summed across its labs. Normal nodes show fast and cold;
+            an SMB node shows fast only — its cold lives on the linked normal node. Create named groups
+            to roll up usage across nodes.
+          </p>
+        </div>
+
+        {flash && <p className="text-sm text-destructive">{flash}</p>}
+
+        {usage.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No nodes yet.</p>
+        ) : (
+          <>
+            {groups.map((g) => (
+              <GroupBlock key={g.id} group={g} allNodes={usage} />
+            ))}
+
+            <div className="space-y-3 rounded-md border border-border/60 p-3">
+              <h4 className="text-sm font-semibold">
+                {groups.length === 0 ? "All nodes" : "Ungrouped"}{" "}
+                <span className="font-normal text-muted-foreground">· {ungrouped.length} node{ungrouped.length === 1 ? "" : "s"}</span>
+              </h4>
+              <NodeUsageTable nodes={ungrouped} />
+            </div>
+          </>
+        )}
+
+        <form action={createNodeGroupAction} className="flex flex-wrap items-end gap-2 border-t border-border pt-4">
+          <Input name="name" placeholder="New group name" className="h-9 w-56" aria-label="New group name" required />
+          <Button type="submit" size="sm">Create group</Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default async function StatsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string }>;
+}) {
+  const { error } = await searchParams;
+  const errorMsg = error ? takeFlash(error) : null;
   const nodes = buildStats();
+  const nodeUsage = buildNodeUsage();
+  const groups = listNodeGroups();
   const totalLabs = nodes.reduce((n, x) => n + x.labs.length, 0);
   const anyScanPending = nodes.some((n) => n.labs.some((l) => l.scanPending));
 
@@ -171,6 +361,10 @@ export default async function StatsPage() {
           <strong className="text-foreground">Scan now</strong> refreshes both on demand.
         </p>
       </div>
+
+      <PerNodeUsageSection usage={nodeUsage} groups={groups} flash={errorMsg} />
+
+      <h2 className="pt-2 text-lg font-semibold tracking-tight">Per-lab breakdown</h2>
 
       {totalLabs === 0 ? (
         <Card>

--- a/controller/src/app/globals.css
+++ b/controller/src/app/globals.css
@@ -136,4 +136,9 @@
     font-family: var(--font-sans);
     -webkit-font-smoothing: antialiased;
   }
+  /* Long command/CSV signatures must wrap inside cards on narrow screens. Code blocks retain their
+     own preformatted, horizontally scrollable behavior. */
+  :where(:not(pre)) > code {
+    overflow-wrap: anywhere;
+  }
 }

--- a/controller/src/components/ui/card.tsx
+++ b/controller/src/components/ui/card.tsx
@@ -26,7 +26,7 @@ function CardDescription({ className, ...props }: React.HTMLAttributes<HTMLParag
 }
 
 function CardContent({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("p-5", className)} {...props} />;
+  return <div className={cn("min-w-0 p-5", className)} {...props} />;
 }
 
 export { Card, CardHeader, CardTitle, CardDescription, CardContent };

--- a/controller/src/components/ui/dialog.tsx
+++ b/controller/src/components/ui/dialog.tsx
@@ -34,7 +34,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-1/2 top-1/2 z-50 grid w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl border border-border bg-card p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        "fixed left-1/2 top-1/2 z-50 grid max-h-[calc(100dvh-2rem)] w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 overflow-y-auto overscroll-contain rounded-xl border border-border bg-card p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
         className,
       )}
       {...props}

--- a/controller/src/components/ui/table.tsx
+++ b/controller/src/components/ui/table.tsx
@@ -1,11 +1,15 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
-/** Table wrapped in a horizontal-scroll container so wide tables never break the mobile layout. */
+/**
+ * Table wrapped in its own horizontal-scroll region. The table keeps at least the width of its
+ * container while page-specific minimum widths can preserve dense columns without squeezing words
+ * into vertical stacks.
+ */
 function Table({ className, ...props }: React.HTMLAttributes<HTMLTableElement>) {
   return (
-    <div className="relative w-full overflow-x-auto">
-      <table className={cn("w-full caption-bottom text-sm", className)} {...props} />
+    <div className="relative w-full max-w-full overflow-x-auto overscroll-x-contain [scrollbar-gutter:stable]">
+      <table className={cn("min-w-full caption-bottom text-sm", className)} {...props} />
     </div>
   );
 }
@@ -40,7 +44,7 @@ function TableHead({ className, ...props }: React.ThHTMLAttributes<HTMLTableCell
 }
 
 function TableCell({ className, ...props }: React.TdHTMLAttributes<HTMLTableCellElement>) {
-  return <td className={cn("px-3 py-2.5 align-middle", className)} {...props} />;
+  return <td className={cn("break-normal px-3 py-2.5 align-middle", className)} {...props} />;
 }
 
 export { Table, TableHeader, TableBody, TableRow, TableHead, TableCell };

--- a/controller/src/lib/announcements.ts
+++ b/controller/src/lib/announcements.ts
@@ -11,23 +11,95 @@ import { audit } from "./labs";
 import { db } from "./db";
 import { sendMail } from "./mailer";
 import { isSmtpConfigured } from "./settings";
+import { renderTemplate } from "./template";
 
 export type Audience = "students" | "pis";
 
-/** Distinct, non-empty email addresses for the given audience. */
-function audienceEmails(audience: Audience): string[] {
+/** A resolved recipient: the email plus a best-effort display name for {name} substitution. */
+export interface Recipient {
+  email: string;
+  name: string;
+}
+
+/** Placeholders an announcement template understands, rendered per recipient. */
+export const ANNOUNCEMENT_VARS: { key: string; desc: string }[] = [
+  { key: "name", desc: "recipient's name (falls back to username, then email)" },
+  { key: "email", desc: "recipient's email address" },
+];
+
+export interface AnnouncementTemplate {
+  name: string;
+  subject: string;
+  body: string;
+}
+
+/** Prebuilt starting points for the compose form. Edit freely before sending; {tokens} render per
+ * recipient and ALL-CAPS bracketed spans are placeholders for the admin to fill in by hand. */
+export const ANNOUNCEMENT_TEMPLATES: AnnouncementTemplate[] = [
+  {
+    name: "Scheduled maintenance",
+    subject: "Scheduled maintenance on [DATE]",
+    body: `Hello {name},
+
+The lab cluster will be unavailable for scheduled maintenance on [DATE] from [START] to [END] ([TIMEZONE]).
+
+Please save your work and log out before the window begins. Long-running jobs should be checkpointed or paused — anything still running may be interrupted.
+
+We'll email again once everything is back online.`,
+  },
+  {
+    name: "Storage cleanup request",
+    subject: "Action needed: free up storage in your lab",
+    body: `Hello {name},
+
+Storage on the cluster is running low. Please review the data in your scratch and cold-storage directories and remove anything you no longer need.
+
+You can check your usage by logging in and running:
+    du -sh ~/scratch ~/cold-storage
+
+Thanks for helping keep the cluster healthy.`,
+  },
+  {
+    name: "New capacity available",
+    subject: "New compute capacity available",
+    body: `Hello {name},
+
+We've added new capacity to the cluster. If your work has been waiting on resources, you should now have more room to run jobs.
+
+Let us know if you'd like help making use of it.`,
+  },
+  {
+    name: "Access expiring",
+    subject: "Your cluster access expires on [DATE]",
+    body: `Hello {name},
+
+Your access to the lab cluster ({email}) is scheduled to end on [DATE].
+
+If you need to keep your account active, please reply to this message before then. After that date your account and data may be removed.`,
+  },
+];
+
+/** Distinct recipients (email + display name) for the given audience, deduped by email. */
+function audienceRecipients(audience: Audience): Recipient[] {
   const sql =
     audience === "students"
-      ? "SELECT DISTINCT email FROM students WHERE email IS NOT NULL AND TRIM(email) <> ''"
-      : "SELECT DISTINCT pi_email AS email FROM labs WHERE pi_email IS NOT NULL AND TRIM(pi_email) <> ''";
-  return (db().prepare(sql).all() as { email: string }[]).map((r) => r.email.trim()).filter(Boolean);
+      ? "SELECT email, name, username FROM students WHERE email IS NOT NULL AND TRIM(email) <> '' ORDER BY username"
+      : "SELECT pi_email AS email, pi_name AS name FROM labs WHERE pi_email IS NOT NULL AND TRIM(pi_email) <> '' ORDER BY name";
+  const rows = db().prepare(sql).all() as { email: string; name: string | null; username?: string }[];
+  const byEmail = new Map<string, Recipient>();
+  for (const r of rows) {
+    const email = r.email.trim();
+    if (!email || byEmail.has(email)) continue;
+    byEmail.set(email, { email, name: r.name?.trim() || r.username?.trim() || email });
+  }
+  return [...byEmail.values()];
 }
 
 /** How many addressable recipients each audience currently has (for the compose UI). */
 export function audienceCounts(): { students: number; pis: number } {
   return {
-    students: audienceEmails("students").length,
-    pis: audienceEmails("pis").length,
+    students: audienceRecipients("students").length,
+    pis: audienceRecipients("pis").length,
   };
 }
 
@@ -71,13 +143,24 @@ export async function sendAnnouncement(input: {
   if (!body) throw new Error("message is required");
   if (input.audiences.length === 0) throw new Error("pick at least one audience");
 
-  const recipients = [...new Set(input.audiences.flatMap(audienceEmails))];
+  // Union of the selected audiences, deduped by email (a PI who is also a student is mailed once).
+  const byEmail = new Map<string, Recipient>();
+  for (const a of input.audiences) {
+    for (const r of audienceRecipients(a)) if (!byEmail.has(r.email)) byEmail.set(r.email, r);
+  }
+  const recipients = [...byEmail.values()];
   const skipped = !isSmtpConfigured();
 
-  const text = `${body}\n\n— Lab Manager`;
+  // {name}/{email} are substituted per recipient; the signature is fixed.
+  const template = `${body}\n\n— Lab Manager`;
   let sent = 0;
   if (!skipped) {
-    const results = await Promise.all(recipients.map((to) => sendMail(to, subject, text)));
+    const results = await Promise.all(
+      recipients.map((r) => {
+        const vars = { name: r.name, email: r.email };
+        return sendMail(r.email, renderTemplate(subject, vars), renderTemplate(template, vars));
+      }),
+    );
     sent = results.filter((r) => r.sent).length;
   }
 

--- a/controller/src/lib/db.ts
+++ b/controller/src/lib/db.ts
@@ -455,6 +455,24 @@ const MIGRATIONS: { id: string; sql?: string; fn?: (conn: Database.Database) => 
     ALTER TABLE placement_members ADD COLUMN credential_delivered_at INTEGER;
     `,
   },
+  {
+    // User-defined named groupings of nodes, shown on the Stats page for per-node usage roll-ups.
+    // Membership is many-to-many (a node can be in several groups); both FKs cascade so deleting a
+    // group or a node cleans up its membership rows automatically.
+    id: "0016_node_groups",
+    sql: `
+    CREATE TABLE node_groups (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL UNIQUE,
+      created_at INTEGER NOT NULL
+    );
+    CREATE TABLE node_group_members (
+      group_id INTEGER NOT NULL REFERENCES node_groups(id) ON DELETE CASCADE,
+      node_id INTEGER NOT NULL REFERENCES nodes(id) ON DELETE CASCADE,
+      PRIMARY KEY (group_id, node_id)
+    );
+    `,
+  },
 ];
 
 function migrate(conn: Database.Database): void {

--- a/controller/src/lib/labimport.ts
+++ b/controller/src/lib/labimport.ts
@@ -1,19 +1,25 @@
 /**
- * Lab + roster CSV import (Phase 2). One row per lab/student membership:
+ * Per-lab roster CSV import (Phase 2, role-based). The import is scoped to a single lab (run from that
+ * lab's page), so the lab is never named in the file and PI info is not repeated on every row. Columns:
  *
- *   lab_name,pi_name,pi_email,student_id,username,student_name,student_email
+ *   role,username,email,name,student_id
+ *
+ * `role` is `student` (the default when the column is blank or absent) or `pi`. A `pi` row carries the
+ * lab's PI metadata only — its `name`/`email` become the lab's PI name/email and any username/student_id
+ * on it is ignored (the PI is not a roster member). `student` rows create/update the global student
+ * record and add a membership to THIS lab.
  *
  * The whole file is parsed and validated against the current DB BEFORE any write, producing a plan
- * (labs/students to create or update, memberships to add, plus conflicts / invalid rows). The plan is
+ * (PI change, students to create/update, memberships to add, plus conflicts / invalid rows). The plan is
  * shown as a preview; applying it re-derives the plan and commits everything in one transaction, then
- * records an audit row. Imports are idempotent (re-running changes nothing) and never delete a lab or
- * membership merely because it is absent from a later CSV. Node/quota/image config is NOT in the CSV.
+ * records an audit row. Imports are idempotent (re-running changes nothing) and never remove a member
+ * merely because they are absent from a later CSV. Node/quota/image config is NOT in the CSV.
  */
 
 import { audit } from "./audit";
 import { parseCsv } from "./csv";
 import { db } from "./db";
-import { isValidLabName } from "./labs";
+import { getLab } from "./labs";
 import { listPlacements, provisionMemberOnPlacement, type ProvisionStudent } from "./placements";
 
 export const MAX_IMPORT_BYTES = 1_000_000; // 1 MB
@@ -28,16 +34,6 @@ export interface ImportIssue {
   message: string;
 }
 
-export interface LabCreate {
-  name: string;
-  piName: string | null;
-  piEmail: string | null;
-}
-export interface LabUpdate {
-  name: string;
-  piName?: string;
-  piEmail?: string;
-}
 export interface StudentCreate {
   username: string;
   studentId: string | null;
@@ -50,17 +46,18 @@ export interface StudentUpdate {
   name?: string;
   email?: string;
 }
-export interface MembershipAdd {
-  lab: string;
-  username: string;
+/** The PI fields that would change on this lab (only changed, non-blank fields are present). */
+export interface PiUpdate {
+  piName?: string;
+  piEmail?: string;
 }
 
-export interface ImportPlan {
-  labsToCreate: LabCreate[];
-  labsToUpdate: LabUpdate[];
+export interface RosterImportPlan {
+  lab: string; // target lab name, for display
+  piUpdate: PiUpdate | null;
   studentsToCreate: StudentCreate[];
   studentsToUpdate: StudentUpdate[];
-  membershipsToAdd: MembershipAdd[];
+  membershipsToAdd: string[]; // usernames to add to this lab's roster
   conflicts: ImportIssue[];
   invalid: ImportIssue[];
   ok: boolean; // committable: no conflicts and no invalid rows
@@ -68,14 +65,11 @@ export interface ImportPlan {
 
 interface ValidRow {
   line: number;
-  lab: string;
-  piName: string | null;
-  piEmail: string | null;
-  sid: string | null;
+  role: "student" | "pi";
   user: string | null;
+  sid: string | null;
   sname: string | null;
   semail: string | null;
-  hasStudent: boolean;
 }
 
 interface DbStudent {
@@ -85,19 +79,14 @@ interface DbStudent {
   email: string | null;
   name: string | null;
 }
-interface DbLab {
-  id: number;
-  pi_name: string | null;
-  pi_email: string | null;
-}
 
 const norm = (v: string | undefined) => (v ?? "").trim();
 const lower = (v: string | undefined) => norm(v).toLowerCase();
 
-function emptyPlan(issue?: ImportIssue): ImportPlan {
+function emptyPlan(lab: string, issue?: ImportIssue): RosterImportPlan {
   return {
-    labsToCreate: [],
-    labsToUpdate: [],
+    lab,
+    piUpdate: null,
     studentsToCreate: [],
     studentsToUpdate: [],
     membershipsToAdd: [],
@@ -107,81 +96,84 @@ function emptyPlan(issue?: ImportIssue): ImportPlan {
   };
 }
 
-/** Compute an import plan from CSV text WITHOUT writing anything. Reads current DB state. */
-export function planLabImport(text: string): ImportPlan {
+/** Compute a per-lab roster import plan from CSV text WITHOUT writing anything. Reads current DB state. */
+export function planRosterImport(labId: number, text: string): RosterImportPlan {
+  const lab = getLab(labId);
+  if (!lab) return emptyPlan("", { line: 0, message: "Unknown lab" });
   if (text.length > MAX_IMPORT_BYTES) {
-    return emptyPlan({ line: 0, message: `File too large (${text.length} bytes; max ${MAX_IMPORT_BYTES})` });
+    return emptyPlan(lab.name, { line: 0, message: `File too large (${text.length} bytes; max ${MAX_IMPORT_BYTES})` });
   }
   const parsed = parseCsv(text);
-  if (parsed.headers.length === 0) return emptyPlan({ line: 0, message: "Empty CSV" });
-  if (!parsed.headers.includes("lab_name")) {
-    return emptyPlan({ line: 1, message: "Missing required column 'lab_name'" });
+  if (parsed.headers.length === 0) return emptyPlan(lab.name, { line: 0, message: "Empty CSV" });
+  if (!parsed.headers.includes("username")) {
+    return emptyPlan(lab.name, { line: 1, message: "Missing required column 'username'" });
   }
   if (parsed.rows.length > MAX_IMPORT_ROWS) {
-    return emptyPlan({ line: 0, message: `Too many rows (${parsed.rows.length}; max ${MAX_IMPORT_ROWS})` });
+    return emptyPlan(lab.name, { line: 0, message: `Too many rows (${parsed.rows.length}; max ${MAX_IMPORT_ROWS})` });
   }
 
   const invalid: ImportIssue[] = [];
   const conflicts: ImportIssue[] = [];
   const valid: ValidRow[] = [];
 
-  // Phase A — per-row field validation.
+  // Phase A — per-row field validation. `role` defaults to student when blank/absent.
   parsed.rows.forEach((r, i) => {
     const line = i + 2; // +1 header, +1 to 1-base
     const bad = (message: string) => invalid.push({ line, message });
-    const lab = norm(r.lab_name);
-    if (!lab) return void bad("missing lab_name");
-    if (!isValidLabName(lab)) return void bad(`invalid lab_name '${lab}'`);
-    const piName = norm(r.pi_name) || null;
-    const piEmail = lower(r.pi_email) || null;
-    if (piEmail && !EMAIL_RE.test(piEmail)) return void bad("invalid pi_email");
-    const sid = norm(r.student_id) || null;
+    const roleRaw = lower(r.role) || "student";
+    if (roleRaw !== "student" && roleRaw !== "pi") return void bad(`unknown role '${roleRaw}' (use 'student' or 'pi')`);
+    const role = roleRaw;
     const user = lower(r.username) || null;
-    const sname = norm(r.student_name) || null;
-    const semail = lower(r.student_email) || null;
-    const hasStudent = !!(sid || user || sname || semail);
-    if (hasStudent && !user) return void bad("username required when any student field is present");
-    if (user && !USERNAME_RE.test(user)) return void bad(`invalid username '${user}'`);
+    const sid = norm(r.student_id) || null;
+    const sname = norm(r.name) || null;
+    const semail = lower(r.email) || null;
+
+    if (role === "pi") {
+      if (!sname && !semail) return void bad("a 'pi' row needs a name or email");
+      if (semail && !EMAIL_RE.test(semail)) return void bad("invalid pi email");
+      valid.push({ line, role, user: null, sid: null, sname, semail });
+      return;
+    }
+    // student row
+    if (!user) return void bad("username required on a student row");
+    if (!USERNAME_RE.test(user)) return void bad(`invalid username '${user}'`);
     if (sid && !STUDENT_ID_RE.test(sid)) return void bad(`invalid student_id '${sid}'`);
-    if (semail && !EMAIL_RE.test(semail)) return void bad("invalid student_email");
-    valid.push({ line, lab, piName, piEmail, sid, user, sname, semail, hasStudent });
+    if (semail && !EMAIL_RE.test(semail)) return void bad("invalid email");
+    valid.push({ line, role, user, sid, sname, semail });
   });
 
-  // Phase B — PI consistency per lab (repeated PI info for one lab must match).
-  const labPI = new Map<string, { piName: string | null; piEmail: string | null }>();
+  // Phase B — PI metadata: at most one effective PI (repeated 'pi' rows must agree).
+  let piName: string | null = null;
+  let piEmail: string | null = null;
   for (const r of valid) {
-    const cur = labPI.get(r.lab);
-    if (!cur) {
-      labPI.set(r.lab, { piName: r.piName, piEmail: r.piEmail });
-      continue;
+    if (r.role !== "pi") continue;
+    if (r.sname) {
+      if (piName && piName !== r.sname) conflicts.push({ line: r.line, message: "conflicting PI name in 'pi' rows" });
+      else piName = r.sname;
     }
-    if (r.piName && cur.piName && r.piName !== cur.piName) conflicts.push({ line: r.line, message: `PI name mismatch for lab '${r.lab}'` });
-    else if (r.piName && !cur.piName) cur.piName = r.piName;
-    if (r.piEmail && cur.piEmail && r.piEmail !== cur.piEmail) conflicts.push({ line: r.line, message: `PI email mismatch for lab '${r.lab}'` });
-    else if (r.piEmail && !cur.piEmail) cur.piEmail = r.piEmail;
+    if (r.semail) {
+      if (piEmail && piEmail !== r.semail) conflicts.push({ line: r.line, message: "conflicting PI email in 'pi' rows" });
+      else piEmail = r.semail;
+    }
   }
 
-  // Load current DB state.
-  const dbLabs = new Map<string, DbLab>();
-  for (const l of db().prepare("SELECT id, name, pi_name, pi_email FROM labs").all() as (DbLab & { name: string })[]) {
-    dbLabs.set(l.name, { id: l.id, pi_name: l.pi_name, pi_email: l.pi_email });
-  }
+  // Load current DB state for this lab.
   const dbByName = new Map<string, DbStudent>();
   const dbById = new Map<string, DbStudent>();
   for (const s of db().prepare("SELECT id, student_id, username, email, name FROM students").all() as DbStudent[]) {
     dbByName.set(s.username, s);
     if (s.student_id) dbById.set(s.student_id, s);
   }
-  const dbMembers = new Set<string>();
-  for (const m of db().prepare("SELECT lab_id, student_id FROM lab_members").all() as { lab_id: number; student_id: number }[]) {
-    dbMembers.add(`${m.lab_id}:${m.student_id}`);
+  const dbMembers = new Set<number>();
+  for (const m of db().prepare("SELECT student_id FROM lab_members WHERE lab_id = ?").all(labId) as { student_id: number }[]) {
+    dbMembers.add(m.student_id);
   }
 
   // Phase C — merge student rows by username, detecting in-batch conflicts.
   interface BatchStudent { sid: string | null; name: string | null; email: string | null; line: number }
   const batch = new Map<string, BatchStudent>();
   for (const r of valid) {
-    if (!r.hasStudent || !r.user) continue;
+    if (r.role !== "student" || !r.user) continue;
     const prev = batch.get(r.user);
     if (!prev) {
       batch.set(r.user, { sid: r.sid, name: r.sname, email: r.semail, line: r.line });
@@ -227,38 +219,27 @@ export function planLabImport(text: string): ImportPlan {
     if (upd.name !== undefined || upd.email !== undefined || upd.studentId !== undefined) studentsToUpdate.push(upd);
   }
 
-  // Phase D — labs to create / update (only changed, non-blank PI fields).
-  const labsToCreate: LabCreate[] = [];
-  const labsToUpdate: LabUpdate[] = [];
-  for (const [lab, pi] of labPI) {
-    const existing = dbLabs.get(lab);
-    if (!existing) {
-      labsToCreate.push({ name: lab, piName: pi.piName, piEmail: pi.piEmail });
-    } else {
-      const upd: LabUpdate = { name: lab };
-      if (pi.piName !== null && pi.piName !== existing.pi_name) upd.piName = pi.piName;
-      if (pi.piEmail !== null && pi.piEmail !== existing.pi_email) upd.piEmail = pi.piEmail;
-      if (upd.piName !== undefined || upd.piEmail !== undefined) labsToUpdate.push(upd);
-    }
-  }
+  // PI update — only changed, non-blank fields relative to the lab's current PI.
+  let piUpdate: PiUpdate | null = null;
+  const pi: PiUpdate = {};
+  if (piName !== null && piName !== lab.pi_name) pi.piName = piName;
+  if (piEmail !== null && piEmail !== lab.pi_email) pi.piEmail = piEmail;
+  if (pi.piName !== undefined || pi.piEmail !== undefined) piUpdate = pi;
 
-  // Phase E — memberships to add (dedup; skip ones that already exist in the DB).
-  const membershipsToAdd: MembershipAdd[] = [];
+  // Memberships to add (dedup; skip students already in this lab's roster).
+  const membershipsToAdd: string[] = [];
   const seenMember = new Set<string>();
-  for (const r of valid) {
-    if (!r.hasStudent || !r.user) continue;
-    const key = `${r.lab} ${r.user}`;
-    if (seenMember.has(key)) continue;
-    seenMember.add(key);
-    const dbLab = dbLabs.get(r.lab);
-    const dbStudent = dbByName.get(r.user) ?? (r.sid ? dbById.get(r.sid) : undefined);
-    if (dbLab && dbStudent && dbMembers.has(`${dbLab.id}:${dbStudent.id}`)) continue; // already a member -> idempotent
-    membershipsToAdd.push({ lab: r.lab, username: r.user });
+  for (const [user] of batch) {
+    if (seenMember.has(user)) continue;
+    seenMember.add(user);
+    const existing = dbByName.get(user) ?? (batch.get(user)?.sid ? dbById.get(batch.get(user)!.sid!) : undefined);
+    if (existing && dbMembers.has(existing.id)) continue; // already a member -> idempotent
+    membershipsToAdd.push(user);
   }
 
   return {
-    labsToCreate,
-    labsToUpdate,
+    lab: lab.name,
+    piUpdate,
     studentsToCreate,
     studentsToUpdate,
     membershipsToAdd,
@@ -268,9 +249,8 @@ export function planLabImport(text: string): ImportPlan {
   };
 }
 
-export interface ImportResult {
-  labsCreated: number;
-  labsUpdated: number;
+export interface RosterImportResult {
+  piUpdated: boolean;
   studentsCreated: number;
   studentsUpdated: number;
   membershipsAdded: number;
@@ -278,12 +258,13 @@ export interface ImportResult {
 }
 
 /**
- * Apply an import: re-derive the plan from the text (never trust a client-supplied plan), commit all
- * labs/students/memberships in ONE transaction, audit it, then provision any newly-added memberships
- * on labs that already have placements (best-effort, post-commit). Throws if the plan isn't committable.
+ * Apply a per-lab roster import: re-derive the plan from the text (never trust a client-supplied plan),
+ * commit the PI change + students + memberships in ONE transaction, audit it, then provision any
+ * newly-added members on placements the lab already has (best-effort, post-commit). Throws if the plan
+ * isn't committable.
  */
-export async function applyLabImport(text: string, actor?: string): Promise<ImportResult> {
-  const plan = planLabImport(text);
+export async function applyRosterImport(labId: number, text: string, actor?: string): Promise<RosterImportResult> {
+  const plan = planRosterImport(labId, text);
   if (!plan.ok) {
     const first = [...plan.invalid, ...plan.conflicts][0];
     throw new Error(
@@ -293,62 +274,55 @@ export async function applyLabImport(text: string, actor?: string): Promise<Impo
   }
 
   const now = Date.now();
-  const labId = new Map<string, number>();
   const studentId = new Map<string, number>();
-  const added: { labId: number; student: ProvisionStudent }[] = [];
+  const added: ProvisionStudent[] = [];
 
   db().transaction(() => {
-    const dbName = (sql: string) => db().prepare(sql);
-    // Seed maps with existing rows referenced by memberships.
-    for (const l of db().prepare("SELECT id, name FROM labs").all() as { id: number; name: string }[]) labId.set(l.name, l.id);
-    for (const s of db().prepare("SELECT id, username FROM students").all() as { id: number; username: string }[]) studentId.set(s.username, s.id);
-
-    for (const l of plan.labsToCreate) {
-      const info = dbName("INSERT INTO labs (name, pi_name, pi_email, created_at, updated_at) VALUES (?, ?, ?, ?, ?)").run(l.name, l.piName, l.piEmail, now, now);
-      labId.set(l.name, Number(info.lastInsertRowid));
+    const stmt = (sql: string) => db().prepare(sql);
+    for (const s of db().prepare("SELECT id, username FROM students").all() as { id: number; username: string }[]) {
+      studentId.set(s.username, s.id);
     }
-    for (const l of plan.labsToUpdate) {
-      if (l.piName !== undefined) dbName("UPDATE labs SET pi_name = ? WHERE name = ?").run(l.piName, l.name);
-      if (l.piEmail !== undefined) dbName("UPDATE labs SET pi_email = ? WHERE name = ?").run(l.piEmail, l.name);
-      dbName("UPDATE labs SET updated_at = ? WHERE name = ?").run(now, l.name);
+
+    if (plan.piUpdate) {
+      if (plan.piUpdate.piName !== undefined) stmt("UPDATE labs SET pi_name = ? WHERE id = ?").run(plan.piUpdate.piName, labId);
+      if (plan.piUpdate.piEmail !== undefined) stmt("UPDATE labs SET pi_email = ? WHERE id = ?").run(plan.piUpdate.piEmail, labId);
+      stmt("UPDATE labs SET updated_at = ? WHERE id = ?").run(now, labId);
     }
     for (const s of plan.studentsToCreate) {
-      const info = dbName("INSERT INTO students (student_id, username, email, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)").run(s.studentId, s.username, s.email, s.name, now, now);
+      const info = stmt("INSERT INTO students (student_id, username, email, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)").run(s.studentId, s.username, s.email, s.name, now, now);
       studentId.set(s.username, Number(info.lastInsertRowid));
     }
     for (const s of plan.studentsToUpdate) {
-      if (s.studentId !== undefined) dbName("UPDATE students SET student_id = ? WHERE username = ?").run(s.studentId, s.username);
-      if (s.name !== undefined) dbName("UPDATE students SET name = ? WHERE username = ?").run(s.name, s.username);
-      if (s.email !== undefined) dbName("UPDATE students SET email = ? WHERE username = ?").run(s.email, s.username);
-      dbName("UPDATE students SET updated_at = ? WHERE username = ?").run(now, s.username);
+      if (s.studentId !== undefined) stmt("UPDATE students SET student_id = ? WHERE username = ?").run(s.studentId, s.username);
+      if (s.name !== undefined) stmt("UPDATE students SET name = ? WHERE username = ?").run(s.name, s.username);
+      if (s.email !== undefined) stmt("UPDATE students SET email = ? WHERE username = ?").run(s.email, s.username);
+      stmt("UPDATE students SET updated_at = ? WHERE username = ?").run(now, s.username);
     }
-    for (const m of plan.membershipsToAdd) {
-      const lid = labId.get(m.lab)!;
-      const sid = studentId.get(m.username)!;
-      const exists = dbName("SELECT 1 FROM lab_members WHERE lab_id = ? AND student_id = ?").get(lid, sid);
+    for (const user of plan.membershipsToAdd) {
+      const sid = studentId.get(user)!;
+      const exists = stmt("SELECT 1 FROM lab_members WHERE lab_id = ? AND student_id = ?").get(labId, sid);
       if (!exists) {
-        dbName("INSERT INTO lab_members (lab_id, student_id, created_at) VALUES (?, ?, ?)").run(lid, sid, now);
+        stmt("INSERT INTO lab_members (lab_id, student_id, created_at) VALUES (?, ?, ?)").run(labId, sid, now);
         const student = db().prepare("SELECT id, username, email, name, student_id FROM students WHERE id = ?").get(sid) as ProvisionStudent;
-        added.push({ labId: lid, student });
+        added.push(student);
       }
     }
   })();
 
-  const result: ImportResult = {
-    labsCreated: plan.labsToCreate.length,
-    labsUpdated: plan.labsToUpdate.length,
+  const result: RosterImportResult = {
+    piUpdated: plan.piUpdate !== null,
     studentsCreated: plan.studentsToCreate.length,
     studentsUpdated: plan.studentsToUpdate.length,
     membershipsAdded: added.length,
     provisioned: 0,
   };
-  audit(actor, "lab.import", undefined, JSON.stringify(result));
+  audit(actor, "lab.roster_import", plan.lab, JSON.stringify(result));
 
-  // Provision newly-added members on any placements the lab already has (no-op pre-rollout, when
-  // labs have no placements yet). Credentials are delivered only after each agent confirms success.
-  for (const a of added) {
-    for (const p of listPlacements(a.labId)) {
-      const res = await provisionMemberOnPlacement(p, a.student, actor);
+  // Provision newly-added members on any placements the lab already has. Credentials are delivered only
+  // after each agent confirms success.
+  for (const student of added) {
+    for (const p of listPlacements(labId)) {
+      const res = await provisionMemberOnPlacement(p, student, actor);
       if (res) result.provisioned += 1;
     }
   }

--- a/controller/src/lib/mailer.ts
+++ b/controller/src/lib/mailer.ts
@@ -5,6 +5,7 @@
  */
 
 import nodemailer from "nodemailer";
+import { renderTemplate } from "./template";
 import {
   DEFAULT_GPU_KILL_BODY,
   DEFAULT_GPU_KILL_SUBJECT,
@@ -16,16 +17,8 @@ import {
   isSmtpConfigured,
 } from "./settings";
 
-/**
- * Substitute {placeholder} tokens in a template. Unknown tokens are left untouched so a typo in the
- * admin's template is visible rather than silently dropped. Values are coerced to strings; a
- * null/undefined value renders as an empty string.
- */
-export function renderTemplate(template: string, vars: Record<string, string | number | null | undefined>): string {
-  return template.replace(/\{(\w+)\}/g, (whole, key: string) =>
-    Object.prototype.hasOwnProperty.call(vars, key) ? String(vars[key] ?? "") : whole,
-  );
-}
+// Re-exported for back-compat: callers (and tests) still import renderTemplate from the mailer.
+export { renderTemplate };
 
 export interface SendResult {
   sent: boolean;

--- a/controller/src/lib/nodegroups.ts
+++ b/controller/src/lib/nodegroups.ts
@@ -1,0 +1,87 @@
+/**
+ * User-defined named groupings of nodes (migration 0016). Purely organisational — a group has no
+ * bearing on auth, placement, or cold-storage topology; it only rolls up per-node usage on the Stats
+ * page. Membership is many-to-many: a node may belong to several groups, and a node in no group is
+ * shown under "Ungrouped".
+ */
+
+import { audit } from "./audit";
+import { db } from "./db";
+
+export interface NodeGroup {
+  id: number;
+  name: string;
+  created_at: number;
+  nodeIds: number[];
+}
+
+const MAX_NAME_LEN = 40;
+
+/** Trim and validate a group name (1..40 chars, must not be blank). Returns the cleaned name. */
+function cleanGroupName(name: string): string {
+  const clean = name.trim().replace(/\s+/g, " ");
+  if (!clean) throw new Error("Group name is required");
+  if (clean.length > MAX_NAME_LEN) throw new Error(`Group name must be at most ${MAX_NAME_LEN} characters`);
+  return clean;
+}
+
+/** All groups with their member node ids, ordered by name. */
+export function listNodeGroups(): NodeGroup[] {
+  const groups = db()
+    .prepare("SELECT id, name, created_at FROM node_groups ORDER BY name")
+    .all() as { id: number; name: string; created_at: number }[];
+  const members = db()
+    .prepare("SELECT group_id, node_id FROM node_group_members")
+    .all() as { group_id: number; node_id: number }[];
+  const byGroup = new Map<number, number[]>();
+  for (const m of members) {
+    const list = byGroup.get(m.group_id) ?? [];
+    list.push(m.node_id);
+    byGroup.set(m.group_id, list);
+  }
+  return groups.map((g) => ({ ...g, nodeIds: byGroup.get(g.id) ?? [] }));
+}
+
+export function createNodeGroup(name: string, actor?: string): NodeGroup {
+  const clean = cleanGroupName(name);
+  const existing = db().prepare("SELECT 1 FROM node_groups WHERE name = ?").get(clean);
+  if (existing) throw new Error(`A group named '${clean}' already exists`);
+  const info = db()
+    .prepare("INSERT INTO node_groups (name, created_at) VALUES (?, ?)")
+    .run(clean, Date.now());
+  audit(actor, "nodegroup.create", clean);
+  return { id: Number(info.lastInsertRowid), name: clean, created_at: Date.now(), nodeIds: [] };
+}
+
+export function renameNodeGroup(id: number, name: string, actor?: string): void {
+  const clean = cleanGroupName(name);
+  const group = db().prepare("SELECT name FROM node_groups WHERE id = ?").get(id) as { name: string } | undefined;
+  if (!group) throw new Error("Unknown group");
+  const clash = db().prepare("SELECT 1 FROM node_groups WHERE name = ? AND id <> ?").get(clean, id);
+  if (clash) throw new Error(`A group named '${clean}' already exists`);
+  db().prepare("UPDATE node_groups SET name = ? WHERE id = ?").run(clean, id);
+  audit(actor, "nodegroup.rename", group.name, clean);
+}
+
+export function deleteNodeGroup(id: number, actor?: string): void {
+  const group = db().prepare("SELECT name FROM node_groups WHERE id = ?").get(id) as { name: string } | undefined;
+  if (!group) return;
+  db().prepare("DELETE FROM node_groups WHERE id = ?").run(id); // cascades node_group_members
+  audit(actor, "nodegroup.delete", group.name);
+}
+
+/** Replace a group's membership with exactly `nodeIds` (unknown node ids are ignored). */
+export function setNodeGroupMembers(id: number, nodeIds: number[], actor?: string): void {
+  const group = db().prepare("SELECT name FROM node_groups WHERE id = ?").get(id) as { name: string } | undefined;
+  if (!group) throw new Error("Unknown group");
+  const valid = new Set(
+    (db().prepare("SELECT id FROM nodes").all() as { id: number }[]).map((n) => n.id),
+  );
+  const wanted = [...new Set(nodeIds)].filter((n) => valid.has(n));
+  db().transaction(() => {
+    db().prepare("DELETE FROM node_group_members WHERE group_id = ?").run(id);
+    const ins = db().prepare("INSERT INTO node_group_members (group_id, node_id) VALUES (?, ?)");
+    for (const nodeId of wanted) ins.run(id, nodeId);
+  })();
+  audit(actor, "nodegroup.members", group.name, `${wanted.length} node(s)`);
+}

--- a/controller/src/lib/stats.ts
+++ b/controller/src/lib/stats.ts
@@ -178,3 +178,74 @@ export function buildStats(): NodeStats[] {
   for (const n of nodes) n.labs.sort((a, b) => a.labName.localeCompare(b.labName));
   return nodes;
 }
+
+/** Per-node total storage usage, summed across the node's placements. Includes every node (even ones
+ * with no placements yet) so node groups can reference the whole fleet. A normal (local_zfs) node
+ * reports both fast and cold; an SMB-client node reports fast only — its cold lives on, and is counted
+ * against, its linked owner node, named in `coldOwnerName`. */
+export interface NodeUsage {
+  nodeId: number;
+  name: string;
+  alias: string | null;
+  online: number;
+  coldBackend: "local_zfs" | "smb";
+  coldOwnerName: string | null; // for SMB nodes: the linked normal node hosting their cold storage
+  fastUsed: number | null;
+  fastQuota: number | null;
+  coldUsed: number | null; // null on SMB nodes (cold is counted on the owner)
+  coldQuota: number | null;
+}
+
+export function buildNodeUsage(): NodeUsage[] {
+  const samples = latestSamples();
+  const rows = db()
+    .prepare(
+      `SELECT n.id AS id, n.name AS name, n.alias AS alias, n.online AS online,
+              n.cold_backend AS cold_backend, owner.name AS owner_name
+       FROM nodes n LEFT JOIN nodes owner ON owner.id = n.cold_owner_node_id
+       ORDER BY n.name`,
+    )
+    .all() as {
+    id: number;
+    name: string;
+    alias: string | null;
+    online: number;
+    cold_backend: "local_zfs" | "smb";
+    owner_name: string | null;
+  }[];
+
+  // node_id -> running totals (used summed only over placements that have a sample; quota over those
+  // that report one). `null` stays null until at least one sample contributes.
+  interface Acc { fastUsed: number | null; fastQuota: number | null; coldUsed: number | null; coldQuota: number | null }
+  const acc = new Map<number, Acc>();
+  const add = (cur: number | null, v: number | null | undefined) =>
+    v === null || v === undefined ? cur : (cur ?? 0) + v;
+
+  for (const p of listAllPlacements()) {
+    const a = acc.get(p.node_id) ?? { fastUsed: null, fastQuota: null, coldUsed: null, coldQuota: null };
+    const fast = samples.get(`${p.id}:L:fast`);
+    const slow = samples.get(`${p.id}:L:slow`);
+    a.fastUsed = add(a.fastUsed, fast?.used);
+    a.fastQuota = add(a.fastQuota, fast?.quota);
+    a.coldUsed = add(a.coldUsed, slow?.used);
+    a.coldQuota = add(a.coldQuota, slow?.quota);
+    acc.set(p.node_id, a);
+  }
+
+  return rows.map((r) => {
+    const a = acc.get(r.id);
+    const isSmb = r.cold_backend === "smb";
+    return {
+      nodeId: r.id,
+      name: r.name,
+      alias: r.alias,
+      online: r.online,
+      coldBackend: r.cold_backend,
+      coldOwnerName: isSmb ? r.owner_name : null,
+      fastUsed: a?.fastUsed ?? null,
+      fastQuota: a?.fastQuota ?? null,
+      coldUsed: isSmb ? null : (a?.coldUsed ?? null),
+      coldQuota: isSmb ? null : (a?.coldQuota ?? null),
+    };
+  });
+}

--- a/controller/src/lib/template.ts
+++ b/controller/src/lib/template.ts
@@ -1,0 +1,16 @@
+/**
+ * Tiny {placeholder} substitution shared by the mailer, GPU/welcome templates, and announcements.
+ * Kept in its own module (rather than in mailer.ts) so callers can render templates without pulling
+ * in nodemailer/SMTP, and so tests that mock the mailer still get the real renderer.
+ */
+
+/**
+ * Substitute {placeholder} tokens in a template. Unknown tokens are left untouched so a typo in the
+ * admin's template is visible rather than silently dropped. Values are coerced to strings; a
+ * null/undefined value renders as an empty string.
+ */
+export function renderTemplate(template: string, vars: Record<string, string | number | null | undefined>): string {
+  return template.replace(/\{(\w+)\}/g, (whole, key: string) =>
+    Object.prototype.hasOwnProperty.call(vars, key) ? String(vars[key] ?? "") : whole,
+  );
+}

--- a/controller/tests/announcements.test.ts
+++ b/controller/tests/announcements.test.ts
@@ -76,6 +76,24 @@ describe("sendAnnouncement", () => {
     expect(row.skipped).toBe(0);
   });
 
+  it("substitutes {name}/{email} per recipient and appends the signature", async () => {
+    settings.setSetting("smtpHost", "smtp.test");
+    settings.setSetting("smtpFrom", "no-reply@uga.edu");
+    sendMail.mockClear();
+
+    await ann.sendAnnouncement({
+      subject: "Hi {name}",
+      body: "Your address is {email}.",
+      audiences: ["students"],
+    });
+
+    const calls = sendMail.mock.calls as unknown as [string, string, string][];
+    const aliceCall = calls.find((c) => c[0] === "alice@uga.edu");
+    expect(aliceCall).toBeTruthy();
+    expect(aliceCall![1]).toBe("Hi alice"); // no name set → falls back to username
+    expect(aliceCall![2]).toBe("Your address is alice@uga.edu.\n\n— Lab Manager");
+  });
+
   it("skips sending when SMTP is not configured but still records", async () => {
     settings.setSetting("smtpHost", "");
     settings.setSetting("smtpFrom", "");

--- a/controller/tests/labimport.test.ts
+++ b/controller/tests/labimport.test.ts
@@ -16,145 +16,163 @@ vi.mock("../src/lib/mailer", () => ({
 
 let dbmod: typeof import("../src/lib/db");
 let imp: typeof import("../src/lib/labimport");
+let labsmod: typeof import("../src/lib/labs");
 
-const HEADER = "lab_name,pi_name,pi_email,student_id,username,student_name,student_email";
+const HEADER = "role,username,email,name,student_id";
 
 beforeAll(async () => {
   dbmod = await import("../src/lib/db");
   imp = await import("../src/lib/labimport");
+  labsmod = await import("../src/lib/labs");
 });
+
+let labId = 0;
 
 beforeEach(() => {
   const d = dbmod.db();
   for (const t of ["placement_members", "lab_members", "lab_placements", "storage_samples", "quota_alerts", "students", "labs"]) {
     d.prepare(`DELETE FROM ${t}`).run();
   }
+  labId = labsmod.createLab({ name: "smith-lab" }).id;
 });
 
 const count = (sql: string) => (dbmod.db().prepare(sql).get() as { n: number }).n;
 
-describe("planLabImport / applyLabImport", () => {
-  it("creates multiple students in one lab plus an empty lab", async () => {
+describe("planRosterImport / applyRosterImport", () => {
+  it("creates students and adds them to the target lab's roster", async () => {
     const csv = [
       HEADER,
-      "smith-lab,Dr. Jane Smith,jane@x.edu,100001,jdoe,John Doe,jdoe@x.edu",
-      "smith-lab,Dr. Jane Smith,jane@x.edu,100002,asmith,Alice Smith,asmith@x.edu",
-      "empty-lab,Dr. Mary Lee,mary@x.edu,,,,",
+      "student,jdoe,jdoe@x.edu,John Doe,100001",
+      "student,asmith,asmith@x.edu,Alice Smith,100002",
     ].join("\n");
-    const plan = imp.planLabImport(csv);
+    const plan = imp.planRosterImport(labId, csv);
     expect(plan.ok).toBe(true);
-    expect(plan.labsToCreate.map((l) => l.name).sort()).toEqual(["empty-lab", "smith-lab"]);
     expect(plan.studentsToCreate).toHaveLength(2);
-    expect(plan.membershipsToAdd).toHaveLength(2);
+    expect(plan.membershipsToAdd.sort()).toEqual(["asmith", "jdoe"]);
 
-    const res = await imp.applyLabImport(csv, "admin@x.edu");
-    expect(res).toMatchObject({ labsCreated: 2, studentsCreated: 2, membershipsAdded: 2 });
-    expect(count("SELECT COUNT(*) AS n FROM labs")).toBe(2);
-    expect(count("SELECT COUNT(*) AS n FROM lab_members")).toBe(2);
-    // empty-lab has no members.
-    expect(count("SELECT COUNT(*) AS n FROM lab_members WHERE lab_id=(SELECT id FROM labs WHERE name='empty-lab')")).toBe(0);
-    // audit row recorded with the actor.
-    expect(dbmod.db().prepare("SELECT 1 FROM audit_log WHERE action='lab.import' AND actor='admin@x.edu'").get()).toBeTruthy();
+    const res = await imp.applyRosterImport(labId, csv, "admin@x.edu");
+    expect(res).toMatchObject({ studentsCreated: 2, membershipsAdded: 2 });
+    expect(count(`SELECT COUNT(*) AS n FROM lab_members WHERE lab_id=${labId}`)).toBe(2);
+    expect(dbmod.db().prepare("SELECT 1 FROM audit_log WHERE action='lab.roster_import' AND actor='admin@x.edu'").get()).toBeTruthy();
   });
 
-  it("places one student in multiple labs (single student row, two memberships)", async () => {
+  it("defaults a row with no role column to student", async () => {
+    const csv = ["username,email,name,student_id", "alice,alice@x.edu,Alice,1"].join("\n");
+    const plan = imp.planRosterImport(labId, csv);
+    expect(plan.ok).toBe(true);
+    expect(plan.studentsToCreate).toHaveLength(1);
+    expect(plan.membershipsToAdd).toEqual(["alice"]);
+  });
+
+  it("applies a 'pi' row to the lab's PI metadata without creating a member", async () => {
     const csv = [
       HEADER,
-      "lab-a,PI A,a@x.edu,500,shared,Shared S,s@x.edu",
-      "lab-b,PI B,b@x.edu,500,shared,Shared S,s@x.edu",
+      "pi,,jane@x.edu,Dr. Jane Smith,",
+      "student,jdoe,jdoe@x.edu,John Doe,100001",
     ].join("\n");
-    await imp.applyLabImport(csv);
+    const plan = imp.planRosterImport(labId, csv);
+    expect(plan.piUpdate).toMatchObject({ piName: "Dr. Jane Smith", piEmail: "jane@x.edu" });
+    expect(plan.membershipsToAdd).toEqual(["jdoe"]);
+
+    const res = await imp.applyRosterImport(labId, csv);
+    expect(res.piUpdated).toBe(true);
+    const lab = dbmod.db().prepare("SELECT pi_name, pi_email FROM labs WHERE id=?").get(labId) as { pi_name: string; pi_email: string };
+    expect(lab).toMatchObject({ pi_name: "Dr. Jane Smith", pi_email: "jane@x.edu" });
+    expect(count(`SELECT COUNT(*) AS n FROM lab_members WHERE lab_id=${labId}`)).toBe(1);
+  });
+
+  it("is idempotent on reimport", async () => {
+    const csv = [HEADER, "pi,,pi@x.edu,PI,", "student,alice,alice@x.edu,Alice,1"].join("\n");
+    await imp.applyRosterImport(labId, csv);
+    const plan2 = imp.planRosterImport(labId, csv);
+    expect(plan2.ok).toBe(true);
+    expect(plan2.piUpdate).toBeNull();
+    expect(plan2.studentsToCreate).toHaveLength(0);
+    expect(plan2.studentsToUpdate).toHaveLength(0);
+    expect(plan2.membershipsToAdd).toHaveLength(0);
+    const res2 = await imp.applyRosterImport(labId, csv);
+    expect(res2).toMatchObject({ studentsCreated: 0, membershipsAdded: 0, piUpdated: false });
+  });
+
+  it("updates changed student metadata", async () => {
+    await imp.applyRosterImport(labId, [HEADER, "student,alice,alice@x.edu,Alice,1"].join("\n"));
+    const plan = imp.planRosterImport(labId, [HEADER, "student,alice,alice2@x.edu,Alice Anderson,1"].join("\n"));
+    expect(plan.studentsToUpdate).toHaveLength(1);
+    expect(plan.studentsToUpdate[0]).toMatchObject({ username: "alice", name: "Alice Anderson", email: "alice2@x.edu" });
+    expect(plan.membershipsToAdd).toHaveLength(0); // already a member
+  });
+
+  it("reuses an existing global student, adding only a membership to this lab", async () => {
+    const labA = labId;
+    const labB = labsmod.createLab({ name: "lab-b" }).id;
+    await imp.applyRosterImport(labA, [HEADER, "student,jdoe,j@x.edu,J Doe,777"].join("\n"));
+    const plan = imp.planRosterImport(labB, [HEADER, "student,jdoe,j@x.edu,J Doe,777"].join("\n"));
+    expect(plan.studentsToCreate).toHaveLength(0);
+    expect(plan.membershipsToAdd).toEqual(["jdoe"]);
+    await imp.applyRosterImport(labB, [HEADER, "student,jdoe,j@x.edu,J Doe,777"].join("\n"));
     expect(count("SELECT COUNT(*) AS n FROM students")).toBe(1);
     expect(count("SELECT COUNT(*) AS n FROM lab_members")).toBe(2);
   });
 
-  it("is idempotent on reimport", async () => {
-    const csv = [HEADER, "bio,PI,pi@x.edu,1,alice,Alice,alice@x.edu"].join("\n");
-    await imp.applyLabImport(csv);
-    const plan2 = imp.planLabImport(csv);
-    expect(plan2.ok).toBe(true);
-    expect(plan2.labsToCreate).toHaveLength(0);
-    expect(plan2.labsToUpdate).toHaveLength(0);
-    expect(plan2.studentsToCreate).toHaveLength(0);
-    expect(plan2.studentsToUpdate).toHaveLength(0);
-    expect(plan2.membershipsToAdd).toHaveLength(0);
-    const res2 = await imp.applyLabImport(csv);
-    expect(res2).toMatchObject({ labsCreated: 0, studentsCreated: 0, membershipsAdded: 0 });
-  });
-
-  it("updates changed lab PI and student metadata", async () => {
-    await imp.applyLabImport([HEADER, "bio,Old PI,old@x.edu,1,alice,Alice,alice@x.edu"].join("\n"));
-    const plan = imp.planLabImport([HEADER, "bio,New PI,new@x.edu,1,alice,Alice Anderson,alice2@x.edu"].join("\n"));
-    expect(plan.labsToUpdate).toEqual([{ name: "bio", piName: "New PI", piEmail: "new@x.edu" }]);
-    expect(plan.studentsToUpdate).toHaveLength(1);
-    expect(plan.studentsToUpdate[0]).toMatchObject({ username: "alice", name: "Alice Anderson", email: "alice2@x.edu" });
-    await imp.applyLabImport([HEADER, "bio,New PI,new@x.edu,1,alice,Alice Anderson,alice2@x.edu"].join("\n"));
-    const lab = dbmod.db().prepare("SELECT pi_name, pi_email FROM labs WHERE name='bio'").get() as any;
-    expect(lab).toMatchObject({ pi_name: "New PI", pi_email: "new@x.edu" });
-  });
-
-  it("matches an existing student by student_id, adding only a membership", async () => {
-    await imp.applyLabImport([HEADER, "lab-a,PI,pi@x.edu,777,jdoe,J Doe,j@x.edu"].join("\n"));
-    const plan = imp.planLabImport([HEADER, "lab-b,PI,pi2@x.edu,777,jdoe,J Doe,j@x.edu"].join("\n"));
-    expect(plan.studentsToCreate).toHaveLength(0);
-    expect(plan.membershipsToAdd).toEqual([{ lab: "lab-b", username: "jdoe" }]);
-  });
-
-  it("flags conflicting PI data for one lab", () => {
-    const plan = imp.planLabImport([
+  it("flags conflicting PI rows", () => {
+    const plan = imp.planRosterImport(labId, [
       HEADER,
-      "bio,Dr. A,a@x.edu,1,alice,Alice,alice@x.edu",
-      "bio,Dr. B,b@x.edu,2,bob,Bob,bob@x.edu",
+      "pi,,a@x.edu,Dr. A,",
+      "pi,,b@x.edu,Dr. B,",
     ].join("\n"));
     expect(plan.ok).toBe(false);
-    expect(plan.conflicts.some((c) => /PI name mismatch/.test(c.message))).toBe(true);
+    expect(plan.conflicts.some((c) => /conflicting PI/.test(c.message))).toBe(true);
   });
 
   it("flags a student_id reused across two usernames", () => {
-    const plan = imp.planLabImport([
+    const plan = imp.planRosterImport(labId, [
       HEADER,
-      "bio,PI,pi@x.edu,900,alice,Alice,alice@x.edu",
-      "bio,PI,pi@x.edu,900,bob,Bob,bob@x.edu",
+      "student,alice,alice@x.edu,Alice,900",
+      "student,bob,bob@x.edu,Bob,900",
     ].join("\n"));
     expect(plan.ok).toBe(false);
     expect(plan.conflicts.some((c) => /used by two usernames/.test(c.message))).toBe(true);
   });
 
   it("flags a student_id that already belongs to a different existing username", async () => {
-    await imp.applyLabImport([HEADER, "bio,PI,pi@x.edu,42,alice,Alice,alice@x.edu"].join("\n"));
-    const plan = imp.planLabImport([HEADER, "bio2,PI,pi@x.edu,42,bob,Bob,bob@x.edu"].join("\n"));
+    await imp.applyRosterImport(labId, [HEADER, "student,alice,alice@x.edu,Alice,42"].join("\n"));
+    const plan = imp.planRosterImport(labId, [HEADER, "student,bob,bob@x.edu,Bob,42"].join("\n"));
     expect(plan.ok).toBe(false);
     expect(plan.conflicts.some((c) => /already belongs to 'alice'/.test(c.message))).toBe(true);
   });
 
-  it("flags invalid lab names, emails, and missing username", () => {
-    const plan = imp.planLabImport([
+  it("flags unknown roles, invalid emails, and a student row with no username", () => {
+    const plan = imp.planRosterImport(labId, [
       HEADER,
-      "bad/lab,PI,pi@x.edu,,,,",
-      "ok-lab,PI,not-an-email,,,,",
-      "ok-lab,PI,pi@x.edu,123,,No Username,nouser@x.edu",
+      "teacher,carol,carol@x.edu,Carol,",
+      "student,dave,not-an-email,Dave,",
+      "student,,nouser@x.edu,No Username,123",
     ].join("\n"));
-    expect(plan.invalid.some((c) => /invalid lab_name/.test(c.message))).toBe(true);
-    expect(plan.invalid.some((c) => /invalid pi_email/.test(c.message))).toBe(true);
+    expect(plan.invalid.some((c) => /unknown role/.test(c.message))).toBe(true);
+    expect(plan.invalid.some((c) => /invalid email/.test(c.message))).toBe(true);
     expect(plan.invalid.some((c) => /username required/.test(c.message))).toBe(true);
     expect(plan.ok).toBe(false);
   });
 
-  it("enforces the row-count and size limits", () => {
-    const rows = [HEADER];
-    for (let i = 0; i < imp.MAX_IMPORT_ROWS + 1; i++) rows.push(`lab-${i},PI,pi@x.edu,,,,`);
-    const overRows = imp.planLabImport(rows.join("\n"));
-    expect(overRows.invalid.some((c) => /Too many rows/.test(c.message))).toBe(true);
-
-    const big = HEADER + "\n" + "x".repeat(imp.MAX_IMPORT_BYTES);
-    expect(imp.planLabImport(big).invalid.some((c) => /File too large/.test(c.message))).toBe(true);
+  it("rejects an unknown lab and a missing username column", () => {
+    expect(imp.planRosterImport(999999, [HEADER, "student,alice,a@x.edu,Alice,1"].join("\n")).invalid.some((c) => /Unknown lab/.test(c.message))).toBe(true);
+    expect(imp.planRosterImport(labId, ["role,email,name,student_id", "student,a@x.edu,Alice,1"].join("\n")).invalid.some((c) => /Missing required column 'username'/.test(c.message))).toBe(true);
   });
 
-  it("applyLabImport rolls back entirely when the plan is not committable", async () => {
-    const before = count("SELECT COUNT(*) AS n FROM labs");
+  it("enforces the row-count and size limits", () => {
+    const rows = [HEADER];
+    for (let i = 0; i < imp.MAX_IMPORT_ROWS + 1; i++) rows.push(`student,user${i},u${i}@x.edu,User ${i},`);
+    expect(imp.planRosterImport(labId, rows.join("\n")).invalid.some((c) => /Too many rows/.test(c.message))).toBe(true);
+
+    const big = HEADER + "\n" + "x".repeat(imp.MAX_IMPORT_BYTES);
+    expect(imp.planRosterImport(labId, big).invalid.some((c) => /File too large/.test(c.message))).toBe(true);
+  });
+
+  it("applyRosterImport rolls back entirely when the plan is not committable", async () => {
+    const before = count("SELECT COUNT(*) AS n FROM students");
     await expect(
-      imp.applyLabImport([HEADER, "bio,Dr. A,a@x.edu,1,alice,Alice,alice@x.edu", "bio,Dr. B,b@x.edu,2,bob,Bob,bob@x.edu"].join("\n")),
+      imp.applyRosterImport(labId, [HEADER, "student,alice,alice@x.edu,Alice,900", "student,bob,bob@x.edu,Bob,900"].join("\n")),
     ).rejects.toThrow(/not committable/);
-    expect(count("SELECT COUNT(*) AS n FROM labs")).toBe(before); // nothing written
+    expect(count("SELECT COUNT(*) AS n FROM students")).toBe(before); // nothing written
   });
 });

--- a/controller/tests/nodegroups.test.ts
+++ b/controller/tests/nodegroups.test.ts
@@ -1,0 +1,98 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const tmp = mkdtempSync(join(tmpdir(), "lab-ctl-nodegroups-"));
+process.env.DB_PATH = join(tmp, "controller.db");
+process.env.SIGNUP_TOKEN = "t";
+process.env.AGENT_TOKEN = "t";
+process.env.SESSION_SECRET = "test-session-secret-test-session";
+
+let dbmod: typeof import("../src/lib/db");
+let stats: typeof import("../src/lib/stats");
+let groups: typeof import("../src/lib/nodegroups");
+
+beforeAll(async () => {
+  dbmod = await import("../src/lib/db");
+  stats = await import("../src/lib/stats");
+  groups = await import("../src/lib/nodegroups");
+  const d = dbmod.db();
+  // node-a: normal (local_zfs) owner; node-smb: SMB client of node-a; node-empty: normal, no placements.
+  d.prepare("INSERT INTO nodes (id, name, online, cold_backend, created_at) VALUES (1, 'node-a', 1, 'local_zfs', 0)").run();
+  d.prepare("INSERT INTO nodes (id, name, online, cold_backend, cold_owner_node_id, created_at) VALUES (2, 'node-smb', 1, 'smb', 1, 0)").run();
+  d.prepare("INSERT INTO nodes (id, name, online, cold_backend, created_at) VALUES (3, 'node-empty', 0, 'local_zfs', 0)").run();
+
+  d.prepare("INSERT INTO labs (id, name, created_at, updated_at) VALUES (1, 'bio', 0, 0)").run();
+  // placement 1 on node-a, placement 2 on node-smb (same lab spread across two nodes).
+  d.prepare(
+    `INSERT INTO lab_placements (id, lab_id, node_id, fast_quota_bytes, cold_quota_bytes, ssh_port, image, state, created_at, updated_at)
+     VALUES (1, 1, 1, 2000, 3000, 50001, 'img', 'active', 0, 0)`,
+  ).run();
+  d.prepare(
+    `INSERT INTO lab_placements (id, lab_id, node_id, fast_quota_bytes, cold_quota_bytes, ssh_port, image, state, created_at, updated_at)
+     VALUES (2, 1, 2, 1000, NULL, 50002, 'img', 'active', 0, 0)`,
+  ).run();
+
+  const sample = (pid: number, pool: string, used: number, quota: number | null) =>
+    d.prepare(
+      "INSERT INTO storage_samples (placement_id, student_id, pool, used_bytes, quota_bytes, ts) VALUES (?, NULL, ?, ?, ?, 100)",
+    ).run(pid, pool, used, quota);
+  sample(1, "fast", 500, 2000);
+  sample(1, "slow", 200, 3000);
+  sample(2, "fast", 300, 1000);
+  sample(2, "slow", 999, null); // SMB cold — must be ignored (counted on the owner instead)
+});
+
+describe("buildNodeUsage", () => {
+  it("sums fast + cold for a normal node and fast-only for an SMB node", () => {
+    const usage = stats.buildNodeUsage();
+    const a = usage.find((n) => n.name === "node-a")!;
+    expect(a.coldBackend).toBe("local_zfs");
+    expect(a.fastUsed).toBe(500);
+    expect(a.coldUsed).toBe(200);
+    expect(a.coldOwnerName).toBeNull();
+
+    const smb = usage.find((n) => n.name === "node-smb")!;
+    expect(smb.coldBackend).toBe("smb");
+    expect(smb.fastUsed).toBe(300);
+    expect(smb.coldUsed).toBeNull(); // fast only — cold is counted on the owner
+    expect(smb.coldOwnerName).toBe("node-a");
+  });
+
+  it("lists nodes with no placements with null totals", () => {
+    const empty = stats.buildNodeUsage().find((n) => n.name === "node-empty")!;
+    expect(empty.fastUsed).toBeNull();
+    expect(empty.coldUsed).toBeNull();
+  });
+});
+
+describe("node groups", () => {
+  it("creates, lists, sets members, renames, and deletes a group", () => {
+    const g = groups.createNodeGroup("Cluster One", "admin@x.edu");
+    expect(g.name).toBe("Cluster One");
+
+    groups.setNodeGroupMembers(g.id, [1, 2, 99999], "admin@x.edu"); // unknown node id is ignored
+    const listed = groups.listNodeGroups().find((x) => x.id === g.id)!;
+    expect(listed.nodeIds.sort()).toEqual([1, 2]);
+
+    groups.renameNodeGroup(g.id, "Cluster A", "admin@x.edu");
+    expect(groups.listNodeGroups().find((x) => x.id === g.id)!.name).toBe("Cluster A");
+
+    groups.deleteNodeGroup(g.id, "admin@x.edu");
+    expect(groups.listNodeGroups().find((x) => x.id === g.id)).toBeUndefined();
+    // membership rows are gone (cascade).
+    const orphan = (dbmod.db().prepare("SELECT COUNT(*) AS n FROM node_group_members WHERE group_id = ?").get(g.id) as { n: number }).n;
+    expect(orphan).toBe(0);
+  });
+
+  it("rejects blank and duplicate names", () => {
+    const a = groups.createNodeGroup("dupe");
+    expect(() => groups.createNodeGroup("dupe")).toThrow(/already exists/);
+    expect(() => groups.createNodeGroup("   ")).toThrow(/required/);
+    const b = groups.createNodeGroup("other");
+    expect(() => groups.renameNodeGroup(b.id, "dupe")).toThrow(/already exists/);
+    groups.deleteNodeGroup(a.id);
+    groups.deleteNodeGroup(b.id);
+  });
+});


### PR DESCRIPTION
Continues the Lab Manager controller work. Three features plus the earlier layout/dialog fixes.

## Layout & responsive
- Widen/center the app shell, contain table overflow, wrap inline code.
- Lab-delete confirmation dialog is now viewport-safe on portrait/short displays (bounded height + sticky actions).

## Per-lab role-based roster import (replaces the global CSV)
- `lib/labimport.ts` rewritten to a **per-lab** importer. Columns: `role,username,email,name,student_id`.
- `role=pi` sets the lab's PI once (no more repeating PI on every row); `role=student` (the default) creates/updates the student and adds roster membership. Validated whole-file before any write; idempotent.
- Importer moved to the lab detail page (`RosterImportForm`); global import card + `LabImportForm` removed.

## Stats: per-node usage + node groups
- Migration `0016_node_groups` (`node_groups` + `node_group_members`, many-to-many, cascading).
- `buildNodeUsage()`: **fast + cold for normal nodes; fast-only + linked normal-node reference for SMB nodes**; includes nodes with no placements.
- `lib/nodegroups.ts` CRUD + stats actions. The Stats page renders per-group subtotals, an Ungrouped bucket, and inline create/rename/delete/assign-nodes controls.

## Email templates + announcements
- New **Templates** sidebar item → `/email-templates`, documenting every email and its `{variables}` (welcome, GPU warn/kill, announcement, removal, quota, test).
- Announcements gain **prebuilt templates** and **`{name}`/`{email}`** substitution rendered **per recipient**.
- Extracted `renderTemplate` into `lib/template.ts` (re-exported by the mailer).

## Verification
- `tsc --noEmit` clean · `eslint --max-warnings=0` clean · **226 tests pass** · production build succeeds.
- Ran the production server against a throwaway DB: clean boot, migration `0016` applied, all routes auth-guarded; signed up + logged in and confirmed every new/changed page renders correctly (SMB cold→owner reference, group subtotals/ungrouped split, email-templates docs, announcement composer, and the global import gone from `/labs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)