### PR TITLE
Editable email templates, announcement-template CRUD, pool-based per-node usage

### DIFF
--- a/controller/src/app/(app)/announcements/_components/AnnouncementComposer.tsx
+++ b/controller/src/app/(app)/announcements/_components/AnnouncementComposer.tsx
@@ -25,8 +25,8 @@ export function AnnouncementComposer({ templates, vars, counts, action }: Props)
   const [body, setBody] = useState("");
   const bodyRef = useRef<HTMLTextAreaElement>(null);
 
-  function applyTemplate(name: string) {
-    const tpl = templates.find((t) => t.name === name);
+  function applyTemplate(id: string) {
+    const tpl = templates.find((t) => String(t.id) === id);
     if (!tpl) return;
     setSubject(tpl.subject);
     setBody(tpl.body);
@@ -64,7 +64,7 @@ export function AnnouncementComposer({ templates, vars, counts, action }: Props)
         >
           <option value="">— blank message —</option>
           {templates.map((t) => (
-            <option key={t.name} value={t.name}>
+            <option key={t.id} value={t.id}>
               {t.name}
             </option>
           ))}

--- a/controller/src/app/(app)/announcements/page.tsx
+++ b/controller/src/app/(app)/announcements/page.tsx
@@ -1,4 +1,4 @@
-import { ANNOUNCEMENT_TEMPLATES, ANNOUNCEMENT_VARS, audienceCounts, recentAnnouncements } from "@/lib/announcements";
+import { ANNOUNCEMENT_VARS, audienceCounts, listAnnouncementTemplates, recentAnnouncements } from "@/lib/announcements";
 import { isSmtpConfigured } from "@/lib/settings";
 import { ago } from "@/lib/format";
 import { sendAnnouncementAction } from "./actions";
@@ -17,6 +17,7 @@ export default async function AnnouncementsPage({
   const msg = typeof sp.msg === "string" ? sp.msg : undefined;
   const counts = audienceCounts();
   const history = recentAnnouncements();
+  const templates = listAnnouncementTemplates();
   const smtpOk = isSmtpConfigured();
 
   return (
@@ -49,7 +50,7 @@ export default async function AnnouncementsPage({
         <CardContent className="space-y-3">
           <h3 className="text-base font-semibold">Send a service announcement</h3>
           <AnnouncementComposer
-            templates={ANNOUNCEMENT_TEMPLATES}
+            templates={templates}
             vars={ANNOUNCEMENT_VARS}
             counts={counts}
             action={sendAnnouncementAction}
@@ -57,7 +58,7 @@ export default async function AnnouncementsPage({
           <p className="text-xs text-muted-foreground">
             Sent by email to the distinct addresses in the selected audiences (a PI who is also a user
             is mailed once). <code>{"{name}"}</code> and <code>{"{email}"}</code> are filled in per
-            recipient. See all templates and variables under{" "}
+            recipient. Manage the prebuilt templates and see every email variable under{" "}
             <a href="/email-templates" className="underline">Email templates</a>.
           </p>
         </CardContent>

--- a/controller/src/app/(app)/email-templates/actions.ts
+++ b/controller/src/app/(app)/email-templates/actions.ts
@@ -1,0 +1,97 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { revalidatePath } from "next/cache";
+import { requireAdmin } from "@/lib/auth";
+import { setSetting } from "@/lib/settings";
+import {
+  createAnnouncementTemplate,
+  deleteAnnouncementTemplate,
+  updateAnnouncementTemplate,
+} from "@/lib/announcements";
+import { putFlash } from "@/lib/flash";
+
+// Every email the controller can send is edited here. Subjects are trimmed (a blank field falls back
+// to the built-in default at render time); bodies are stored verbatim so intentional leading/trailing
+// whitespace in a template is preserved. Each save revalidates the Templates page.
+
+export async function saveWelcomeEmailAction(formData: FormData) {
+  await requireAdmin();
+  setSetting("welcomeEmailSubject", String(formData.get("subject") ?? "").trim());
+  setSetting("welcomeEmailBody", String(formData.get("body") ?? ""));
+  revalidatePath("/email-templates");
+}
+
+export async function saveGpuWarnEmailAction(formData: FormData) {
+  await requireAdmin();
+  setSetting("gpuWarnEmailSubject", String(formData.get("subject") ?? "").trim());
+  setSetting("gpuWarnEmailBody", String(formData.get("body") ?? ""));
+  revalidatePath("/email-templates");
+}
+
+export async function saveGpuKillEmailAction(formData: FormData) {
+  await requireAdmin();
+  setSetting("gpuKillEmailSubject", String(formData.get("subject") ?? "").trim());
+  setSetting("gpuKillEmailBody", String(formData.get("body") ?? ""));
+  revalidatePath("/email-templates");
+}
+
+export async function saveRemovalEmailAction(formData: FormData) {
+  await requireAdmin();
+  setSetting("removalEmailSubject", String(formData.get("subject") ?? "").trim());
+  setSetting("removalEmailBody", String(formData.get("body") ?? ""));
+  revalidatePath("/email-templates");
+}
+
+export async function saveQuotaEmailAction(formData: FormData) {
+  await requireAdmin();
+  setSetting("quotaEmailSubject", String(formData.get("subject") ?? "").trim());
+  setSetting("quotaEmailBody", String(formData.get("body") ?? ""));
+  revalidatePath("/email-templates");
+}
+
+export async function saveTestEmailAction(formData: FormData) {
+  await requireAdmin();
+  setSetting("testEmailSubject", String(formData.get("subject") ?? "").trim());
+  setSetting("testEmailBody", String(formData.get("body") ?? ""));
+  revalidatePath("/email-templates");
+}
+
+/** Run an announcement-template mutation, surfacing any error as a flash on the Templates page. */
+async function withTemplateFlash(fn: () => void): Promise<void> {
+  await requireAdmin();
+  try {
+    fn();
+  } catch (e) {
+    const fid = putFlash(e instanceof Error ? e.message : "Could not save announcement template");
+    redirect(`/email-templates?error=${fid}`);
+  }
+  revalidatePath("/email-templates");
+  revalidatePath("/announcements");
+}
+
+export async function createAnnouncementTemplateAction(formData: FormData) {
+  await withTemplateFlash(() =>
+    createAnnouncementTemplate({
+      name: String(formData.get("name") ?? ""),
+      subject: String(formData.get("subject") ?? ""),
+      body: String(formData.get("body") ?? ""),
+    }),
+  );
+}
+
+export async function updateAnnouncementTemplateAction(formData: FormData) {
+  const id = Number(formData.get("id"));
+  await withTemplateFlash(() =>
+    updateAnnouncementTemplate(id, {
+      name: String(formData.get("name") ?? ""),
+      subject: String(formData.get("subject") ?? ""),
+      body: String(formData.get("body") ?? ""),
+    }),
+  );
+}
+
+export async function deleteAnnouncementTemplateAction(formData: FormData) {
+  const id = Number(formData.get("id"));
+  await withTemplateFlash(() => deleteAnnouncementTemplate(id));
+}

--- a/controller/src/app/(app)/email-templates/page.tsx
+++ b/controller/src/app/(app)/email-templates/page.tsx
@@ -1,32 +1,36 @@
 import Link from "next/link";
-import {
-  ANNOUNCEMENT_TEMPLATES,
-  ANNOUNCEMENT_VARS,
-} from "@/lib/announcements";
+import { ANNOUNCEMENT_VARS, listAnnouncementTemplates, type AnnouncementTemplate } from "@/lib/announcements";
 import {
   GPU_EMAIL_VARS,
+  QUOTA_EMAIL_VARS,
+  REMOVAL_EMAIL_VARS,
   WELCOME_EMAIL_VARS,
   getSettings,
 } from "@/lib/settings";
-import { Badge } from "@/components/ui/badge";
+import { takeFlash } from "@/lib/flash";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { ConfirmButton } from "../_components/ConfirmButton";
+import {
+  createAnnouncementTemplateAction,
+  deleteAnnouncementTemplateAction,
+  saveGpuKillEmailAction,
+  saveGpuWarnEmailAction,
+  saveQuotaEmailAction,
+  saveRemovalEmailAction,
+  saveTestEmailAction,
+  saveWelcomeEmailAction,
+  updateAnnouncementTemplateAction,
+} from "./actions";
 
 export const dynamic = "force-dynamic";
 
 interface Variable {
   key: string;
   desc: string;
-}
-
-interface TemplateDoc {
-  name: string;
-  trigger: string;
-  /** Where the admin edits this template, or null if it is fixed in code. */
-  editable: { href: string; label: string } | null;
-  vars: Variable[];
-  subject: string;
-  body: string;
-  note?: string;
 }
 
 function VarList({ vars }: { vars: Variable[] }) {
@@ -45,134 +49,111 @@ function VarList({ vars }: { vars: Variable[] }) {
   );
 }
 
-function TemplateCard({ tpl }: { tpl: TemplateDoc }) {
+interface EditableTemplateProps {
+  name: string;
+  trigger: string;
+  /** Server action the subject/body form submits to. */
+  action: (formData: FormData) => void | Promise<void>;
+  subject: string;
+  body: string;
+  vars: Variable[];
+  bodyRows?: number;
+  note?: string;
+}
+
+/** A card with an inline form to edit one email's subject + body, plus its variable reference. */
+function EditableTemplate({ name, trigger, action, subject, body, vars, bodyRows = 10, note }: EditableTemplateProps) {
   return (
     <Card>
       <CardContent className="space-y-3">
-        <div className="flex flex-wrap items-center gap-2">
-          <h3 className="text-base font-semibold">{tpl.name}</h3>
-          {tpl.editable ? (
-            <Badge variant="ok">editable</Badge>
-          ) : (
-            <Badge variant="warn">fixed</Badge>
-          )}
+        <div className="space-y-1">
+          <h3 className="text-base font-semibold">{name}</h3>
+          <p className="text-sm text-muted-foreground">{trigger}</p>
         </div>
-        <p className="text-sm text-muted-foreground">{tpl.trigger}</p>
-        {tpl.editable && (
-          <p className="text-sm">
-            Edit at{" "}
-            <Link href={tpl.editable.href} className="text-primary hover:underline">
-              {tpl.editable.label}
-            </Link>
-            .
-          </p>
-        )}
-
-        <div className="space-y-1.5">
-          <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-            Available variables
-          </div>
-          <VarList vars={tpl.vars} />
-        </div>
-
-        <div className="space-y-2">
+        <form action={action} className="grid max-w-2xl gap-3">
           <div>
-            <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Subject</div>
-            <div className="mt-1 overflow-x-auto rounded-md border border-border/60 bg-muted/30 px-3 py-2 font-mono text-xs">
-              {tpl.subject}
+            <Label>Subject</Label>
+            <Input name="subject" defaultValue={subject} />
+          </div>
+          <div>
+            <Label>Body</Label>
+            <Textarea name="body" rows={bodyRows} defaultValue={body} className="font-mono text-xs" />
+          </div>
+          <div className="space-y-1.5">
+            <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+              Available variables
             </div>
+            <VarList vars={vars} />
           </div>
+          {note && <p className="text-xs text-muted-foreground">{note}</p>}
           <div>
-            <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Body</div>
-            <pre className="mt-1 overflow-x-auto whitespace-pre-wrap break-words rounded-md border border-border/60 bg-muted/30 px-3 py-2 font-mono text-xs">
-              {tpl.body}
-            </pre>
+            <Button type="submit">Save template</Button>
           </div>
-        </div>
-
-        {tpl.note && <p className="text-xs text-muted-foreground">{tpl.note}</p>}
+        </form>
       </CardContent>
     </Card>
   );
 }
 
-export default async function EmailTemplatesPage() {
+/** One editable prebuilt announcement template (name + subject + body), with a delete control. */
+function AnnouncementTemplateCard({ tpl }: { tpl: AnnouncementTemplate }) {
+  return (
+    <div className="space-y-3 rounded-md border border-border/60 p-3">
+      <form action={updateAnnouncementTemplateAction} className="grid gap-3">
+        <input type="hidden" name="id" value={tpl.id} />
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div>
+            <Label>Template name</Label>
+            <Input name="name" defaultValue={tpl.name} maxLength={80} required />
+          </div>
+          <div>
+            <Label>Subject</Label>
+            <Input name="subject" defaultValue={tpl.subject} maxLength={200} />
+          </div>
+        </div>
+        <div>
+          <Label>Body</Label>
+          <Textarea name="body" rows={8} defaultValue={tpl.body} required className="font-mono text-xs" />
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button type="submit" size="sm">Save</Button>
+        </div>
+      </form>
+      <form action={deleteAnnouncementTemplateAction}>
+        <input type="hidden" name="id" value={tpl.id} />
+        <ConfirmButton
+          size="sm"
+          variant="ghost"
+          title={`Delete template "${tpl.name}"?`}
+          confirmLabel="Delete template"
+          confirm={`Delete the announcement template "${tpl.name}"? This only removes the prebuilt starting point; it does not affect any announcement already sent.`}
+        >
+          Delete
+        </ConfirmButton>
+      </form>
+    </div>
+  );
+}
+
+export default async function EmailTemplatesPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string }>;
+}) {
+  const { error } = await searchParams;
+  const errorMsg = error ? takeFlash(error) : null;
   const s = getSettings();
   const gpuKillVars = GPU_EMAIL_VARS.filter((v) => v.key !== "grace_minutes");
-
-  const templates: TemplateDoc[] = [
-    {
-      name: "Welcome / credentials",
-      trigger: "Sent to a student once they are successfully provisioned on a node — carries their login and SSH connection details.",
-      editable: { href: "/settings", label: "Settings → Email" },
-      vars: WELCOME_EMAIL_VARS,
-      subject: s.welcomeEmailSubject,
-      body: s.welcomeEmailBody,
-    },
-    {
-      name: "GPU idle warning",
-      trigger: "Sent to a user whose process is holding GPU memory while idle, before it is terminated.",
-      editable: { href: "/settings", label: "Settings → GPU policy" },
-      vars: GPU_EMAIL_VARS,
-      subject: s.gpuWarnEmailSubject,
-      body: s.gpuWarnEmailBody,
-    },
-    {
-      name: "GPU process terminated",
-      trigger: "Sent to a user after their idle GPU process has been terminated to free the GPU.",
-      editable: { href: "/settings", label: "Settings → GPU policy" },
-      vars: gpuKillVars,
-      subject: s.gpuKillEmailSubject,
-      body: s.gpuKillEmailBody,
-    },
-    {
-      name: "Service announcement",
-      trigger: "Composed by an admin and broadcast to all students and/or all PIs.",
-      editable: { href: "/announcements", label: "Announcements" },
-      vars: ANNOUNCEMENT_VARS,
-      subject: "(composed per send)",
-      body: `(composed per send — ${ANNOUNCEMENT_TEMPLATES.length} prebuilt starting points are offered on the Announcements page)\n\nPrebuilt templates:\n${ANNOUNCEMENT_TEMPLATES.map((t) => `  • ${t.name}`).join("\n")}`,
-      note: "A fixed “— Lab Manager” signature is appended to every announcement.",
-    },
-    {
-      name: "Removed from lab",
-      trigger: "Sent to a student when they are removed from a lab (notes whether their data was deleted).",
-      editable: null,
-      vars: [{ key: "lab", desc: "lab name (substituted into the fixed text)" }],
-      subject: "Removed from lab {lab}",
-      body: `You have been removed from the lab "{lab}". <your data was deleted | your data has been retained for now>.\n\n— Lab Manager`,
-    },
-    {
-      name: "Storage quota alert",
-      trigger: "Sent to a lab's PI when one of its pools crosses the quota-alert threshold (Settings → Alerts).",
-      editable: null,
-      vars: [
-        { key: "lab", desc: "lab name" },
-        { key: "pool", desc: "pool that crossed the threshold (fast/cold)" },
-        { key: "pct", desc: "percent of quota used" },
-        { key: "used / quota", desc: "human-readable used and total" },
-      ],
-      subject: "Lab {lab} is at {pct}% of its {pool} quota",
-      body: `Lab "{lab}" has reached {pct}% of its {pool} storage quota ({used} of {quota}).\n\nPer-student usage on the {pool} pool:\n  <username>  <used>\n  …\n\n— Lab Manager`,
-    },
-    {
-      name: "Test email",
-      trigger: "Sent when an admin clicks “Send test” under Settings → Email to verify SMTP.",
-      editable: null,
-      vars: [],
-      subject: "Lab Manager test email",
-      body: "This is a test email from the Lab Manager controller. SMTP is configured correctly.",
-    },
-  ];
+  const announcementTemplates = listAnnouncementTemplates();
 
   return (
     <div className="space-y-4">
       <div className="space-y-2">
         <h1 className="text-2xl font-semibold tracking-tight">Email templates</h1>
         <p className="text-sm text-muted-foreground">
-          Every email the controller can send, with the <code>{"{variables}"}</code> each one
-          understands. Editable templates fall back to the built-in default when left blank; an unknown{" "}
-          <code>{"{token}"}</code> is left in the text as-is so typos are visible. All email requires SMTP
+          Every email the controller sends is edited here. Use the <code>{"{variables}"}</code> listed
+          under each one; an unknown <code>{"{token}"}</code> is left in the text as-is so typos are
+          visible, and a blank subject falls back to the built-in default. All email requires SMTP
           configured under{" "}
           <Link href="/settings" className="text-primary hover:underline">
             Settings → Email
@@ -181,9 +162,122 @@ export default async function EmailTemplatesPage() {
         </p>
       </div>
 
-      {templates.map((tpl) => (
-        <TemplateCard key={tpl.name} tpl={tpl} />
-      ))}
+      <EditableTemplate
+        name="Welcome / credentials"
+        trigger="Sent to a student once they are provisioned on a node — carries their login and SSH connection details."
+        action={saveWelcomeEmailAction}
+        subject={s.welcomeEmailSubject}
+        body={s.welcomeEmailBody}
+        vars={WELCOME_EMAIL_VARS}
+        bodyRows={16}
+      />
+
+      <EditableTemplate
+        name="GPU idle warning"
+        trigger="Sent to a user whose process is holding GPU memory while idle, before it is terminated."
+        action={saveGpuWarnEmailAction}
+        subject={s.gpuWarnEmailSubject}
+        body={s.gpuWarnEmailBody}
+        vars={GPU_EMAIL_VARS}
+        bodyRows={8}
+      />
+
+      <EditableTemplate
+        name="GPU process terminated"
+        trigger="Sent to a user after their idle GPU process has been terminated to free the GPU."
+        action={saveGpuKillEmailAction}
+        subject={s.gpuKillEmailSubject}
+        body={s.gpuKillEmailBody}
+        vars={gpuKillVars}
+        bodyRows={8}
+      />
+
+      <EditableTemplate
+        name="Removed from lab"
+        trigger="Sent to a student when they are removed from a lab. {data_status} resolves to a sentence noting whether their data was deleted or retained."
+        action={saveRemovalEmailAction}
+        subject={s.removalEmailSubject}
+        body={s.removalEmailBody}
+        vars={REMOVAL_EMAIL_VARS}
+        bodyRows={6}
+      />
+
+      <EditableTemplate
+        name="Storage quota alert"
+        trigger="Sent to a lab's PI when one of its pools crosses the quota-alert threshold (Settings → Alerts)."
+        action={saveQuotaEmailAction}
+        subject={s.quotaEmailSubject}
+        body={s.quotaEmailBody}
+        vars={QUOTA_EMAIL_VARS}
+        bodyRows={12}
+      />
+
+      <EditableTemplate
+        name="Test email"
+        trigger="Sent when an admin clicks “Send test” under Settings → Email to verify SMTP."
+        action={saveTestEmailAction}
+        subject={s.testEmailSubject}
+        body={s.testEmailBody}
+        vars={[]}
+        bodyRows={4}
+      />
+
+      <Card>
+        <CardContent className="space-y-4">
+          <div className="space-y-1">
+            <h3 className="text-base font-semibold">Announcement templates</h3>
+            <p className="text-sm text-muted-foreground">
+              Prebuilt starting points offered in the{" "}
+              <Link href="/announcements" className="text-primary hover:underline">
+                Announcements
+              </Link>{" "}
+              compose form. Picking one fills the subject/body, which the admin edits before sending. A
+              fixed “— Lab Manager” signature is appended to every announcement on send.
+            </p>
+            <div className="space-y-1.5 pt-1">
+              <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                Variables (rendered per recipient)
+              </div>
+              <VarList vars={ANNOUNCEMENT_VARS} />
+              <p className="text-xs text-muted-foreground">
+                ALL-CAPS spans in <code>[BRACKETS]</code> are placeholders for the admin to fill in by
+                hand before sending.
+              </p>
+            </div>
+          </div>
+
+          {errorMsg && <p className="text-sm text-destructive">{errorMsg}</p>}
+
+          {announcementTemplates.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No templates yet — add one below.</p>
+          ) : (
+            announcementTemplates.map((tpl) => <AnnouncementTemplateCard key={tpl.id} tpl={tpl} />)
+          )}
+
+          <form action={createAnnouncementTemplateAction} className="grid gap-3 border-t border-border pt-4">
+            <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+              Add a template
+            </div>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div>
+                <Label>Template name</Label>
+                <Input name="name" placeholder="e.g. Holiday closure" maxLength={80} required />
+              </div>
+              <div>
+                <Label>Subject</Label>
+                <Input name="subject" placeholder="e.g. Cluster closed [DATE]–[DATE]" maxLength={200} />
+              </div>
+            </div>
+            <div>
+              <Label>Body</Label>
+              <Textarea name="body" rows={6} required className="font-mono text-xs" placeholder="Hello {name}, …" />
+            </div>
+            <div>
+              <Button type="submit" size="sm">Add template</Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/controller/src/app/(app)/settings/actions.ts
+++ b/controller/src/app/(app)/settings/actions.ts
@@ -91,14 +91,6 @@ export async function saveSmtpSettingsAction(formData: FormData) {
   revalidatePath("/settings");
 }
 
-export async function saveWelcomeEmailAction(formData: FormData) {
-  await requireAdmin();
-  // Empty falls back to the built-in default at render time, so store the trimmed value as-is.
-  setSetting("welcomeEmailSubject", String(formData.get("welcomeEmailSubject") ?? "").trim());
-  setSetting("welcomeEmailBody", String(formData.get("welcomeEmailBody") ?? ""));
-  revalidatePath("/settings");
-}
-
 export async function saveAlertSettingsAction(formData: FormData) {
   await requireAdmin();
   setSetting("alertsEnabled", formData.get("alertsEnabled") === "on");
@@ -137,16 +129,6 @@ export async function saveGpuPolicyAction(formData: FormData) {
   setSetting("gpuWhitelistLabs", String(formData.get("gpuWhitelistLabs") ?? "").trim());
   // Push the new policy to every node immediately.
   broadcastGpuPolicy(who);
-  revalidatePath("/settings");
-}
-
-export async function saveGpuEmailsAction(formData: FormData) {
-  await requireAdmin();
-  // Empty falls back to the built-in default at render time, so store the trimmed value as-is.
-  setSetting("gpuWarnEmailSubject", String(formData.get("gpuWarnEmailSubject") ?? "").trim());
-  setSetting("gpuWarnEmailBody", String(formData.get("gpuWarnEmailBody") ?? ""));
-  setSetting("gpuKillEmailSubject", String(formData.get("gpuKillEmailSubject") ?? "").trim());
-  setSetting("gpuKillEmailBody", String(formData.get("gpuKillEmailBody") ?? ""));
   revalidatePath("/settings");
 }
 

--- a/controller/src/app/(app)/settings/page.tsx
+++ b/controller/src/app/(app)/settings/page.tsx
@@ -1,4 +1,5 @@
-import { getSettings, GPU_EMAIL_VARS, TIB, WELCOME_EMAIL_VARS } from "@/lib/settings";
+import Link from "next/link";
+import { getSettings, TIB } from "@/lib/settings";
 import { db } from "@/lib/db";
 import { fmtBytes } from "@/lib/format";
 import { logsContentBytes } from "@/lib/maintenance";
@@ -7,18 +8,15 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select } from "@/components/ui/select";
-import { Textarea } from "@/components/ui/textarea";
 import { ConfirmButton } from "../_components/ConfirmButton";
 import {
   clearLogsAction,
   saveAlertSettingsAction,
-  saveGpuEmailsAction,
   saveGpuPolicyAction,
   saveScrubSettingsAction,
   saveSmtpSettingsAction,
   saveStorageSettingsAction,
   saveUsageScanSettingsAction,
-  saveWelcomeEmailAction,
   scrubNowAction,
   testEmailAction,
 } from "./actions";
@@ -159,42 +157,14 @@ export default async function SettingsPage({
               Send test
             </Button>
           </form>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardContent className="space-y-3">
-          <div className="space-y-1">
-            <h3 className="text-base font-semibold">Welcome email template</h3>
-            <p className="text-xs text-muted-foreground">
-              Sent to a student (with an email on file) when they are added to a lab. Use{" "}
-              <code>{"{placeholder}"}</code> tokens below; unknown tokens are left as-is. Leave a field
-              blank to use the built-in default.
-            </p>
-          </div>
-          <form action={saveWelcomeEmailAction} className="grid max-w-2xl gap-3">
-            <div>
-              <Label>Subject</Label>
-              <Input name="welcomeEmailSubject" defaultValue={s.welcomeEmailSubject} />
-            </div>
-            <div>
-              <Label>Body</Label>
-              <Textarea name="welcomeEmailBody" rows={16} defaultValue={s.welcomeEmailBody} className="font-mono text-xs" />
-            </div>
-            <div>
-              <Label>Available variables</Label>
-              <ul className="m-0 list-disc pl-5 text-xs text-muted-foreground">
-                {WELCOME_EMAIL_VARS.map((v) => (
-                  <li key={v.key}>
-                    <code>{`{${v.key}}`}</code> — {v.desc}
-                  </li>
-                ))}
-              </ul>
-            </div>
-            <div>
-              <Button type="submit">Save template</Button>
-            </div>
-          </form>
+          <p className="text-xs text-muted-foreground">
+            The wording of every email the controller sends — welcome, GPU notifications, removal,
+            quota alerts, the test email, and announcement starting points — is edited under{" "}
+            <Link href="/email-templates" className="text-primary hover:underline">
+              Templates
+            </Link>
+            .
+          </p>
         </CardContent>
       </Card>
 
@@ -233,50 +203,6 @@ export default async function SettingsPage({
             </div>
             <div className="sm:col-span-2">
               <Button type="submit">Save &amp; push to nodes</Button>
-            </div>
-          </form>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardContent className="space-y-3">
-          <div className="space-y-1">
-            <h3 className="text-base font-semibold">GPU notification emails</h3>
-            <p className="text-xs text-muted-foreground">
-              Emailed to a student (with an email on file) when the idle killer warns about or
-              terminates their GPU process. Use <code>{"{placeholder}"}</code> tokens below; unknown
-              tokens are left as-is. Leave a field blank to use the built-in default.
-            </p>
-          </div>
-          <form action={saveGpuEmailsAction} className="grid max-w-2xl gap-3">
-            <div>
-              <Label>Warning email subject</Label>
-              <Input name="gpuWarnEmailSubject" defaultValue={s.gpuWarnEmailSubject} />
-            </div>
-            <div>
-              <Label>Warning email body</Label>
-              <Textarea name="gpuWarnEmailBody" rows={8} defaultValue={s.gpuWarnEmailBody} className="font-mono text-xs" />
-            </div>
-            <div>
-              <Label>Termination email subject</Label>
-              <Input name="gpuKillEmailSubject" defaultValue={s.gpuKillEmailSubject} />
-            </div>
-            <div>
-              <Label>Termination email body</Label>
-              <Textarea name="gpuKillEmailBody" rows={8} defaultValue={s.gpuKillEmailBody} className="font-mono text-xs" />
-            </div>
-            <div>
-              <Label>Available variables</Label>
-              <ul className="m-0 list-disc pl-5 text-xs text-muted-foreground">
-                {GPU_EMAIL_VARS.map((v) => (
-                  <li key={v.key}>
-                    <code>{`{${v.key}}`}</code> — {v.desc}
-                  </li>
-                ))}
-              </ul>
-            </div>
-            <div>
-              <Button type="submit">Save GPU emails</Button>
             </div>
           </form>
         </CardContent>

--- a/controller/src/app/(app)/stats/actions.ts
+++ b/controller/src/app/(app)/stats/actions.ts
@@ -6,7 +6,18 @@ import { requireAdmin } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { putFlash } from "@/lib/flash";
 import { createNodeGroup, deleteNodeGroup, renameNodeGroup, setNodeGroupMembers } from "@/lib/nodegroups";
+import { listAllPlacements } from "@/lib/placements";
 import { enqueueTask } from "@/lib/queue";
+
+/** Usernames enrolled in a lab, for the usage.scan payload. */
+function labUsernames(labId: number): string[] {
+  return (db()
+    .prepare(
+      `SELECT students.username AS username FROM lab_members
+       JOIN students ON students.id = lab_members.student_id WHERE lab_members.lab_id = ?`,
+    )
+    .all(labId) as { username: string }[]).map((r) => r.username);
+}
 
 /**
  * Trigger an on-demand storage scan for one placement (a lab on a node). The agent runs the
@@ -25,13 +36,24 @@ export async function usageScanAction(formData: FormData) {
     )
     .get(placementId) as { lab: string; node: string; lab_id: number } | undefined;
   if (!placement) return;
-  const users = (db()
-    .prepare(
-      `SELECT students.username AS username FROM lab_members
-       JOIN students ON students.id = lab_members.student_id WHERE lab_members.lab_id = ?`,
-    )
-    .all(placement.lab_id) as { username: string }[]).map((r) => r.username);
+  const users = labUsernames(placement.lab_id);
   enqueueTask(placement.node, "usage.scan", { lab: placement.lab, users }, who);
+  revalidatePath("/stats");
+}
+
+/**
+ * Global refresh for the whole Stats page. Per-node pool usage is reported every heartbeat, so
+ * re-rendering already shows the newest pool numbers; on top of that this kicks a fresh usage.scan on
+ * every placement whose node is online (the agent runs the per-student du breakdown AND recomputes
+ * the lab-level totals on that one path), so a single click refreshes everything the page shows. With
+ * no online placements it simply re-pulls the latest telemetry.
+ */
+export async function refreshAllAction() {
+  const who = (await requireAdmin()).email;
+  for (const p of listAllPlacements()) {
+    if (p.online !== 1) continue;
+    enqueueTask(p.node_name, "usage.scan", { lab: p.lab_name, users: labUsernames(p.lab_id) }, who);
+  }
   revalidatePath("/stats");
 }
 

--- a/controller/src/app/(app)/stats/page.tsx
+++ b/controller/src/app/(app)/stats/page.tsx
@@ -15,6 +15,7 @@ import { ScanAutoRefresh } from "./_components/ScanAutoRefresh";
 import {
   createNodeGroupAction,
   deleteNodeGroupAction,
+  refreshAllAction,
   renameNodeGroupAction,
   setNodeGroupMembersAction,
   usageScanAction,
@@ -298,9 +299,10 @@ function PerNodeUsageSection({
         <div className="space-y-1">
           <h3 className="text-base font-semibold">Per-node usage</h3>
           <p className="text-sm text-muted-foreground">
-            Total storage used on each node, summed across its labs. Normal nodes show fast and cold;
-            an SMB node shows fast only — its cold lives on the linked normal node. Create named groups
-            to roll up usage across nodes.
+            Storage used on each node&apos;s ZFS pools — fast and cold — reported by the agent every
+            heartbeat (used vs. total capacity), so it reflects real on-disk usage even before any lab
+            is placed. An SMB node shows fast only; its cold lives on the linked normal node. Create
+            named groups to roll up usage across nodes.
           </p>
         </div>
 
@@ -349,17 +351,24 @@ export default async function StatsPage({
   return (
     <div className="space-y-4">
       <ScanAutoRefresh active={anyScanPending} />
-      <div className="space-y-2">
-        <h1 className="text-2xl font-semibold tracking-tight">Storage stats</h1>
-        <p className="text-sm text-muted-foreground">
-          Two kinds of data, shown separately per lab. The{" "}
-          <strong className="text-foreground">Lab storage</strong> row (container image writable
-          layer, plus Fast/Cold usage against the lab quota) is recomputed on the node about every 5
-          minutes. The <strong className="text-foreground">Per-student</strong> table (each
-          student&apos;s installed software, scratch and cold-storage) comes from a once-a-day scan
-          (by default at midnight). Both carry an &ldquo;updated&rdquo; time, and{" "}
-          <strong className="text-foreground">Scan now</strong> refreshes both on demand.
-        </p>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-2">
+          <h1 className="text-2xl font-semibold tracking-tight">Storage stats</h1>
+          <p className="text-sm text-muted-foreground">
+            Two kinds of data, shown separately per lab. The{" "}
+            <strong className="text-foreground">Lab storage</strong> row (container image writable
+            layer, plus Fast/Cold usage against the lab quota) is recomputed on the node about every 5
+            minutes. The <strong className="text-foreground">Per-student</strong> table (each
+            student&apos;s installed software, scratch and cold-storage) comes from a once-a-day scan
+            (by default at midnight). Both carry an &ldquo;updated&rdquo; time, and{" "}
+            <strong className="text-foreground">Scan now</strong> refreshes both on demand.
+          </p>
+        </div>
+        <form action={refreshAllAction} className="shrink-0">
+          <SubmitButton variant="outline" size="sm" icon={<RefreshCw />} pendingText="Refreshing…">
+            Refresh all
+          </SubmitButton>
+        </form>
       </div>
 
       <PerNodeUsageSection usage={nodeUsage} groups={groups} flash={errorMsg} />

--- a/controller/src/lib/announcements.ts
+++ b/controller/src/lib/announcements.ts
@@ -27,57 +27,62 @@ export const ANNOUNCEMENT_VARS: { key: string; desc: string }[] = [
   { key: "email", desc: "recipient's email address" },
 ];
 
+/**
+ * A prebuilt starting point for the compose form, editable on the Templates page (stored in the
+ * `announcement_templates` table; seeded with the built-in defaults in migration 0017). {tokens}
+ * render per recipient and ALL-CAPS bracketed spans are placeholders for the admin to fill in by
+ * hand.
+ */
 export interface AnnouncementTemplate {
+  id: number;
   name: string;
   subject: string;
   body: string;
 }
 
-/** Prebuilt starting points for the compose form. Edit freely before sending; {tokens} render per
- * recipient and ALL-CAPS bracketed spans are placeholders for the admin to fill in by hand. */
-export const ANNOUNCEMENT_TEMPLATES: AnnouncementTemplate[] = [
-  {
-    name: "Scheduled maintenance",
-    subject: "Scheduled maintenance on [DATE]",
-    body: `Hello {name},
+/** All prebuilt announcement templates, in display order, for the compose picker and editor. */
+export function listAnnouncementTemplates(): AnnouncementTemplate[] {
+  return db()
+    .prepare("SELECT id, name, subject, body FROM announcement_templates ORDER BY sort, id")
+    .all() as AnnouncementTemplate[];
+}
 
-The lab cluster will be unavailable for scheduled maintenance on [DATE] from [START] to [END] ([TIMEZONE]).
+/** Add a prebuilt template; appended to the end of the display order. Returns the new id. */
+export function createAnnouncementTemplate(input: { name: string; subject: string; body: string }): number {
+  const name = input.name.trim();
+  const subject = input.subject.trim();
+  const body = input.body.trim();
+  if (!name) throw new Error("template name is required");
+  if (!body) throw new Error("template body is required");
+  const maxSort = (db().prepare("SELECT COALESCE(MAX(sort), -1) AS m FROM announcement_templates").get() as {
+    m: number;
+  }).m;
+  const res = db()
+    .prepare("INSERT INTO announcement_templates (name, subject, body, sort) VALUES (?, ?, ?, ?)")
+    .run(name, subject, body, maxSort + 1);
+  return Number(res.lastInsertRowid);
+}
 
-Please save your work and log out before the window begins. Long-running jobs should be checkpointed or paused — anything still running may be interrupted.
+/** Edit an existing prebuilt template in place. */
+export function updateAnnouncementTemplate(
+  id: number,
+  input: { name: string; subject: string; body: string },
+): void {
+  const name = input.name.trim();
+  const subject = input.subject.trim();
+  const body = input.body.trim();
+  if (!name) throw new Error("template name is required");
+  if (!body) throw new Error("template body is required");
+  const res = db()
+    .prepare("UPDATE announcement_templates SET name = ?, subject = ?, body = ? WHERE id = ?")
+    .run(name, subject, body, id);
+  if (res.changes === 0) throw new Error("template not found");
+}
 
-We'll email again once everything is back online.`,
-  },
-  {
-    name: "Storage cleanup request",
-    subject: "Action needed: free up storage in your lab",
-    body: `Hello {name},
-
-Storage on the cluster is running low. Please review the data in your scratch and cold-storage directories and remove anything you no longer need.
-
-You can check your usage by logging in and running:
-    du -sh ~/scratch ~/cold-storage
-
-Thanks for helping keep the cluster healthy.`,
-  },
-  {
-    name: "New capacity available",
-    subject: "New compute capacity available",
-    body: `Hello {name},
-
-We've added new capacity to the cluster. If your work has been waiting on resources, you should now have more room to run jobs.
-
-Let us know if you'd like help making use of it.`,
-  },
-  {
-    name: "Access expiring",
-    subject: "Your cluster access expires on [DATE]",
-    body: `Hello {name},
-
-Your access to the lab cluster ({email}) is scheduled to end on [DATE].
-
-If you need to keep your account active, please reply to this message before then. After that date your account and data may be removed.`,
-  },
-];
+/** Remove a prebuilt template. */
+export function deleteAnnouncementTemplate(id: number): void {
+  db().prepare("DELETE FROM announcement_templates WHERE id = ?").run(id);
+}
 
 /** Distinct recipients (email + display name) for the given audience, deduped by email. */
 function audienceRecipients(audience: Audience): Recipient[] {

--- a/controller/src/lib/db.ts
+++ b/controller/src/lib/db.ts
@@ -473,6 +473,53 @@ const MIGRATIONS: { id: string; sql?: string; fn?: (conn: Database.Database) => 
     );
     `,
   },
+  {
+    // Admin-editable prebuilt announcement templates (the compose-form starting points). Previously
+    // a hardcoded list in lib/announcements.ts; now stored in the DB so admins can add/edit/delete
+    // them on the Templates page. Seeded with the built-in defaults (Access expiring / New capacity
+    // available were dropped). `sort` drives display order; subject may be blank.
+    id: "0017_announcement_templates",
+    fn: (conn) => {
+      conn.exec(`
+        CREATE TABLE announcement_templates (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          name TEXT NOT NULL,
+          subject TEXT NOT NULL DEFAULT '',
+          body TEXT NOT NULL,
+          sort INTEGER NOT NULL DEFAULT 0
+        );
+      `);
+      const seed: { name: string; subject: string; body: string }[] = [
+        {
+          name: "Scheduled maintenance",
+          subject: "Scheduled maintenance on [DATE]",
+          body: `Hello {name},
+
+The lab cluster will be unavailable for scheduled maintenance on [DATE] from [START] to [END] ([TIMEZONE]).
+
+Please save your work and log out before the window begins. Long-running jobs should be checkpointed or paused — anything still running may be interrupted.
+
+We'll email again once everything is back online.`,
+        },
+        {
+          name: "Storage cleanup request",
+          subject: "Action needed: free up storage in your lab",
+          body: `Hello {name},
+
+Storage on the cluster is running low. Please review the data in your scratch and cold-storage directories and remove anything you no longer need.
+
+You can check your usage by logging in and running:
+    du -sh ~/scratch ~/cold-storage
+
+Thanks for helping keep the cluster healthy.`,
+        },
+      ];
+      const ins = conn.prepare(
+        "INSERT INTO announcement_templates (name, subject, body, sort) VALUES (?, ?, ?, ?)",
+      );
+      seed.forEach((t, i) => ins.run(t.name, t.subject, t.body, i));
+    },
+  },
 ];
 
 function migrate(conn: Database.Database): void {

--- a/controller/src/lib/mailer.ts
+++ b/controller/src/lib/mailer.ts
@@ -11,8 +11,16 @@ import {
   DEFAULT_GPU_KILL_SUBJECT,
   DEFAULT_GPU_WARN_BODY,
   DEFAULT_GPU_WARN_SUBJECT,
+  DEFAULT_QUOTA_BODY,
+  DEFAULT_QUOTA_SUBJECT,
+  DEFAULT_REMOVAL_BODY,
+  DEFAULT_REMOVAL_SUBJECT,
+  DEFAULT_TEST_BODY,
+  DEFAULT_TEST_SUBJECT,
   DEFAULT_WELCOME_BODY,
   DEFAULT_WELCOME_SUBJECT,
+  REMOVAL_DATA_DELETED,
+  REMOVAL_DATA_RETAINED,
   getSetting,
   isSmtpConfigured,
 } from "./settings";
@@ -49,23 +57,25 @@ export async function sendMail(to: string, subject: string, text: string): Promi
 }
 
 export async function sendTestEmail(to: string): Promise<SendResult> {
-  return sendMail(
-    to,
-    "Lab Manager test email",
-    "This is a test email from the Lab Manager controller. SMTP is configured correctly.",
-  );
+  const subject = getSetting("testEmailSubject").trim() || DEFAULT_TEST_SUBJECT;
+  const body = getSetting("testEmailBody").trim() || DEFAULT_TEST_BODY;
+  return sendMail(to, subject, body);
+}
+
+/** Render the removal email from the admin-editable template (or its default). */
+export function renderRemovalEmail(lab: string, dataDeleted: boolean): { subject: string; body: string } {
+  const vars = {
+    lab,
+    data_status: dataDeleted ? REMOVAL_DATA_DELETED : REMOVAL_DATA_RETAINED,
+  };
+  const subject = getSetting("removalEmailSubject").trim() || DEFAULT_REMOVAL_SUBJECT;
+  const body = getSetting("removalEmailBody").trim() || DEFAULT_REMOVAL_BODY;
+  return { subject: renderTemplate(subject, vars), body: renderTemplate(body, vars) };
 }
 
 export async function sendRemovalEmail(to: string, lab: string, dataDeleted: boolean): Promise<SendResult> {
-  return sendMail(
-    to,
-    `Removed from lab ${lab}`,
-    `You have been removed from the lab "${lab}". ` +
-      (dataDeleted
-        ? "Your scratch and cold-storage data in this lab has been deleted."
-        : "Your data has been retained for now; contact an admin if you need it.") +
-      "\n\n— Lab Manager",
-  );
+  const { subject, body } = renderRemovalEmail(lab, dataDeleted);
+  return sendMail(to, subject, body);
 }
 
 export interface CredentialEmail {
@@ -135,20 +145,32 @@ export interface QuotaEmail {
   breakdown: { username: string; usedHuman: string }[];
 }
 
-export async function sendQuotaEmail(info: QuotaEmail): Promise<SendResult> {
-  const lines = info.breakdown.length
+/** Build the {placeholder} substitution map for the quota-alert email. */
+export function quotaEmailVars(info: Omit<QuotaEmail, "to">): Record<string, string | number> {
+  const breakdown = info.breakdown.length
     ? info.breakdown.map((b) => `  ${b.username.padEnd(20)} ${b.usedHuman}`).join("\n")
     : "  (no per-student usage reported yet)";
-  const text = `Lab "${info.lab}" has reached ${info.pct}% of its ${info.pool} storage quota` +
-    ` (${info.usedHuman} of ${info.quotaHuman}).
+  return {
+    lab: info.lab,
+    pool: info.pool,
+    pct: info.pct,
+    used: info.usedHuman,
+    quota: info.quotaHuman,
+    breakdown,
+  };
+}
 
-Per-student usage on the ${info.pool} pool:
-${lines}
+/** Render the quota-alert email's subject + body from the admin-editable template (or its default). */
+export function renderQuotaEmail(info: Omit<QuotaEmail, "to">): { subject: string; body: string } {
+  const vars = quotaEmailVars(info);
+  const subject = getSetting("quotaEmailSubject").trim() || DEFAULT_QUOTA_SUBJECT;
+  const body = getSetting("quotaEmailBody").trim() || DEFAULT_QUOTA_BODY;
+  return { subject: renderTemplate(subject, vars), body: renderTemplate(body, vars) };
+}
 
-You may want to ask students to clean up unneeded data, or request a larger quota.
-
-— Lab Manager`;
-  return sendMail(info.to, `Lab ${info.lab} is at ${info.pct}% of its ${info.pool} quota`, text);
+export async function sendQuotaEmail(info: QuotaEmail): Promise<SendResult> {
+  const { subject, body } = renderQuotaEmail(info);
+  return sendMail(info.to, subject, body);
 }
 
 /** Build the {placeholder} substitution map for the welcome email from a credential payload. */

--- a/controller/src/lib/settings.ts
+++ b/controller/src/lib/settings.ts
@@ -55,6 +55,17 @@ export interface Settings {
   gpuWarnEmailBody: string;
   gpuKillEmailSubject: string;
   gpuKillEmailBody: string;
+  // Email sent to a student when they are removed from a lab. Supports {placeholder} substitution
+  // (see REMOVAL_EMAIL_VARS / renderRemovalEmail in lib/mailer.ts). Empty falls back to the default.
+  removalEmailSubject: string;
+  removalEmailBody: string;
+  // Email sent to a lab's PI when one of its pools crosses the quota-alert threshold. Supports
+  // {placeholder} substitution (see QUOTA_EMAIL_VARS / renderQuotaEmail in lib/mailer.ts).
+  quotaEmailSubject: string;
+  quotaEmailBody: string;
+  // The "Send test" email under Settings → Email. No variables. Empty falls back to the default.
+  testEmailSubject: string;
+  testEmailBody: string;
   // Alerting + logs.
   alertsEnabled: boolean;
   alertLevel: "WARN" | "ERROR"; // minimum log level that triggers an admin alert
@@ -159,6 +170,48 @@ Please checkpoint long-running work and keep the GPU active, or ask an admin to 
 
 — Lab Manager`;
 
+/** Placeholders the removal email understands, shown to the admin in the Templates UI. */
+export const REMOVAL_EMAIL_VARS: { key: string; desc: string }[] = [
+  { key: "lab", desc: "lab name the student was removed from" },
+  { key: "data_status", desc: "sentence noting whether their data was deleted or retained" },
+];
+
+export const DEFAULT_REMOVAL_SUBJECT = "Removed from lab {lab}";
+
+export const DEFAULT_REMOVAL_BODY = `You have been removed from the lab "{lab}". {data_status}
+
+— Lab Manager`;
+
+/** The two fixed sentences {data_status} resolves to (chosen by whether the data was deleted). */
+export const REMOVAL_DATA_DELETED = "Your scratch and cold-storage data in this lab has been deleted.";
+export const REMOVAL_DATA_RETAINED = "Your data has been retained for now; contact an admin if you need it.";
+
+/** Placeholders the quota-alert email understands, shown to the admin in the Templates UI. */
+export const QUOTA_EMAIL_VARS: { key: string; desc: string }[] = [
+  { key: "lab", desc: "lab name" },
+  { key: "pool", desc: "pool that crossed the threshold (fast/cold)" },
+  { key: "pct", desc: "percent of quota used" },
+  { key: "used", desc: "human-readable amount used" },
+  { key: "quota", desc: "human-readable quota total" },
+  { key: "breakdown", desc: "indented per-student usage lines for the pool" },
+];
+
+export const DEFAULT_QUOTA_SUBJECT = "Lab {lab} is at {pct}% of its {pool} quota";
+
+export const DEFAULT_QUOTA_BODY = `Lab "{lab}" has reached {pct}% of its {pool} storage quota ({used} of {quota}).
+
+Per-student usage on the {pool} pool:
+{breakdown}
+
+You may want to ask students to clean up unneeded data, or request a larger quota.
+
+— Lab Manager`;
+
+export const DEFAULT_TEST_SUBJECT = "Lab Manager test email";
+
+export const DEFAULT_TEST_BODY =
+  "This is a test email from the Lab Manager controller. SMTP is configured correctly.";
+
 export const DEFAULT_SETTINGS: Settings = {
   fastQuotaDefaultBytes: 2 * TIB,
   slowQuotaDefaultBytes: 3 * TIB,
@@ -187,6 +240,12 @@ export const DEFAULT_SETTINGS: Settings = {
   gpuWarnEmailBody: DEFAULT_GPU_WARN_BODY,
   gpuKillEmailSubject: DEFAULT_GPU_KILL_SUBJECT,
   gpuKillEmailBody: DEFAULT_GPU_KILL_BODY,
+  removalEmailSubject: DEFAULT_REMOVAL_SUBJECT,
+  removalEmailBody: DEFAULT_REMOVAL_BODY,
+  quotaEmailSubject: DEFAULT_QUOTA_SUBJECT,
+  quotaEmailBody: DEFAULT_QUOTA_BODY,
+  testEmailSubject: DEFAULT_TEST_SUBJECT,
+  testEmailBody: DEFAULT_TEST_BODY,
   alertsEnabled: true,
   alertLevel: "ERROR",
   alertDedupMinutes: 15,

--- a/controller/src/lib/stats.ts
+++ b/controller/src/lib/stats.ts
@@ -179,10 +179,12 @@ export function buildStats(): NodeStats[] {
   return nodes;
 }
 
-/** Per-node total storage usage, summed across the node's placements. Includes every node (even ones
- * with no placements yet) so node groups can reference the whole fleet. A normal (local_zfs) node
- * reports both fast and cold; an SMB-client node reports fast only — its cold lives on, and is counted
- * against, its linked owner node, named in `coldOwnerName`. */
+/** Per-node storage usage, read from the node's live ZFS pools (the `pools` telemetry the agent
+ * reports every heartbeat), so it reflects real on-disk usage even before any lab is placed. Includes
+ * every node so node groups can reference the whole fleet. `fastUsed`/`coldUsed` are the pool's
+ * allocated bytes and `fastQuota`/`coldQuota` are the pool's total capacity (used vs. size, not a lab
+ * quota). A normal (local_zfs) node reports both fast and cold pools; an SMB-client node reports its
+ * fast pool only — its cold lives on, and is counted against, its linked owner node (`coldOwnerName`). */
 export interface NodeUsage {
   nodeId: number;
   name: string;
@@ -190,18 +192,39 @@ export interface NodeUsage {
   online: number;
   coldBackend: "local_zfs" | "smb";
   coldOwnerName: string | null; // for SMB nodes: the linked normal node hosting their cold storage
-  fastUsed: number | null;
-  fastQuota: number | null;
-  coldUsed: number | null; // null on SMB nodes (cold is counted on the owner)
-  coldQuota: number | null;
+  fastUsed: number | null; // fast pool allocated bytes
+  fastQuota: number | null; // fast pool total capacity
+  coldUsed: number | null; // cold pool allocated bytes (null on SMB nodes; cold is counted on the owner)
+  coldQuota: number | null; // cold pool total capacity
+}
+
+interface PoolInfo {
+  name: string;
+  size: number; // total pool capacity
+  alloc: number; // allocated (used)
+  free: number;
+}
+
+/** Parse the node's `pools` telemetry JSON, keeping only well-formed entries. */
+function parsePools(raw: string | null): PoolInfo[] {
+  if (!raw) return [];
+  try {
+    const arr = JSON.parse(raw) as unknown;
+    if (!Array.isArray(arr)) return [];
+    return arr.filter(
+      (p): p is PoolInfo =>
+        !!p && typeof p === "object" && typeof (p as PoolInfo).alloc === "number" && typeof (p as PoolInfo).size === "number",
+    );
+  } catch {
+    return [];
+  }
 }
 
 export function buildNodeUsage(): NodeUsage[] {
-  const samples = latestSamples();
   const rows = db()
     .prepare(
       `SELECT n.id AS id, n.name AS name, n.alias AS alias, n.online AS online,
-              n.cold_backend AS cold_backend, owner.name AS owner_name
+              n.cold_backend AS cold_backend, n.pools AS pools, owner.name AS owner_name
        FROM nodes n LEFT JOIN nodes owner ON owner.id = n.cold_owner_node_id
        ORDER BY n.name`,
     )
@@ -211,30 +234,18 @@ export function buildNodeUsage(): NodeUsage[] {
     alias: string | null;
     online: number;
     cold_backend: "local_zfs" | "smb";
+    pools: string | null;
     owner_name: string | null;
   }[];
 
-  // node_id -> running totals (used summed only over placements that have a sample; quota over those
-  // that report one). `null` stays null until at least one sample contributes.
-  interface Acc { fastUsed: number | null; fastQuota: number | null; coldUsed: number | null; coldQuota: number | null }
-  const acc = new Map<number, Acc>();
-  const add = (cur: number | null, v: number | null | undefined) =>
-    v === null || v === undefined ? cur : (cur ?? 0) + v;
-
-  for (const p of listAllPlacements()) {
-    const a = acc.get(p.node_id) ?? { fastUsed: null, fastQuota: null, coldUsed: null, coldQuota: null };
-    const fast = samples.get(`${p.id}:L:fast`);
-    const slow = samples.get(`${p.id}:L:slow`);
-    a.fastUsed = add(a.fastUsed, fast?.used);
-    a.fastQuota = add(a.fastQuota, fast?.quota);
-    a.coldUsed = add(a.coldUsed, slow?.used);
-    a.coldQuota = add(a.coldQuota, slow?.quota);
-    acc.set(p.node_id, a);
-  }
-
   return rows.map((r) => {
-    const a = acc.get(r.id);
+    const pools = parsePools(r.pools);
     const isSmb = r.cold_backend === "smb";
+    // The agent reports its ZFS pools fast-first (and slow second, only on a local-ZFS node), so the
+    // fast pool is pools[0] and cold is pools[1]. An SMB node has no local cold pool — its cold lives
+    // on the linked owner node, which counts it against its own slow pool.
+    const fast = pools[0] ?? null;
+    const cold = isSmb ? null : (pools[1] ?? null);
     return {
       nodeId: r.id,
       name: r.name,
@@ -242,10 +253,10 @@ export function buildNodeUsage(): NodeUsage[] {
       online: r.online,
       coldBackend: r.cold_backend,
       coldOwnerName: isSmb ? r.owner_name : null,
-      fastUsed: a?.fastUsed ?? null,
-      fastQuota: a?.fastQuota ?? null,
-      coldUsed: isSmb ? null : (a?.coldUsed ?? null),
-      coldQuota: isSmb ? null : (a?.coldQuota ?? null),
+      fastUsed: fast ? fast.alloc : null,
+      fastQuota: fast ? fast.size : null,
+      coldUsed: cold ? cold.alloc : null,
+      coldQuota: cold ? cold.size : null,
     };
   });
 }

--- a/controller/tests/actions-auth.test.ts
+++ b/controller/tests/actions-auth.test.ts
@@ -25,6 +25,7 @@ describe("Server Actions reject unauthenticated callers", () => {
   let labs: typeof import("../src/app/(app)/labs/actions.js");
   let students: typeof import("../src/app/(app)/students/actions.js");
   let settings: typeof import("../src/app/(app)/settings/actions.js");
+  let templates: typeof import("../src/app/(app)/email-templates/actions.js");
   let backups: typeof import("../src/app/(app)/backups/actions.js");
   let stats: typeof import("../src/app/(app)/stats/actions.js");
 
@@ -32,6 +33,7 @@ describe("Server Actions reject unauthenticated callers", () => {
     labs = await import("../src/app/(app)/labs/actions.js");
     students = await import("../src/app/(app)/students/actions.js");
     settings = await import("../src/app/(app)/settings/actions.js");
+    templates = await import("../src/app/(app)/email-templates/actions.js");
     backups = await import("../src/app/(app)/backups/actions.js");
     stats = await import("../src/app/(app)/stats/actions.js");
   });
@@ -56,12 +58,20 @@ describe("Server Actions reject unauthenticated callers", () => {
       settings.saveStorageSettingsAction(fd()),
       settings.saveUsageScanSettingsAction(fd()),
       settings.saveSmtpSettingsAction(fd()),
-      settings.saveWelcomeEmailAction(fd()),
       settings.saveAlertSettingsAction(fd()),
       settings.saveGpuPolicyAction(fd()),
       settings.saveScrubSettingsAction(fd()),
       settings.scrubNowAction(),
       settings.testEmailAction(fd()),
+      templates.saveWelcomeEmailAction(fd()),
+      templates.saveGpuWarnEmailAction(fd()),
+      templates.saveGpuKillEmailAction(fd()),
+      templates.saveRemovalEmailAction(fd()),
+      templates.saveQuotaEmailAction(fd()),
+      templates.saveTestEmailAction(fd()),
+      templates.createAnnouncementTemplateAction(fd()),
+      templates.updateAnnouncementTemplateAction(fd()),
+      templates.deleteAnnouncementTemplateAction(fd()),
       backups.saveWebdavSettingsAction(fd()),
       backups.saveScheduleAction(fd()),
       backups.testConnectionAction(),

--- a/controller/tests/announcements.test.ts
+++ b/controller/tests/announcements.test.ts
@@ -110,3 +110,36 @@ describe("sendAnnouncement", () => {
     expect(row.skipped).toBe(1);
   });
 });
+
+describe("announcement templates", () => {
+  it("seeds the built-in defaults without the dropped templates", () => {
+    const names = ann.listAnnouncementTemplates().map((t) => t.name);
+    expect(names).toContain("Scheduled maintenance");
+    expect(names).toContain("Storage cleanup request");
+    expect(names).not.toContain("Access expiring");
+    expect(names).not.toContain("New capacity available");
+  });
+
+  it("creates, updates, and deletes a template", () => {
+    const before = ann.listAnnouncementTemplates().length;
+    const id = ann.createAnnouncementTemplate({ name: "Holiday", subject: "Closed", body: "Hello {name}" });
+    const created = ann.listAnnouncementTemplates().find((t) => t.id === id)!;
+    expect(created).toMatchObject({ name: "Holiday", subject: "Closed", body: "Hello {name}" });
+    // Appended to the end of the display order.
+    expect(ann.listAnnouncementTemplates().at(-1)!.id).toBe(id);
+
+    ann.updateAnnouncementTemplate(id, { name: "Holiday closure", subject: "We're closed", body: "Bye {name}" });
+    const updated = ann.listAnnouncementTemplates().find((t) => t.id === id)!;
+    expect(updated).toMatchObject({ name: "Holiday closure", subject: "We're closed", body: "Bye {name}" });
+
+    ann.deleteAnnouncementTemplate(id);
+    expect(ann.listAnnouncementTemplates()).toHaveLength(before);
+    expect(ann.listAnnouncementTemplates().find((t) => t.id === id)).toBeUndefined();
+  });
+
+  it("rejects a blank name or body, and updating a missing row", () => {
+    expect(() => ann.createAnnouncementTemplate({ name: "  ", subject: "s", body: "b" })).toThrow(/name/);
+    expect(() => ann.createAnnouncementTemplate({ name: "n", subject: "s", body: "  " })).toThrow(/body/);
+    expect(() => ann.updateAnnouncementTemplate(99999, { name: "n", subject: "s", body: "b" })).toThrow(/not found/);
+  });
+});

--- a/controller/tests/mailer.test.ts
+++ b/controller/tests/mailer.test.ts
@@ -149,4 +149,32 @@ describe("templated emails", () => {
     await mailer.sendRemovalEmail("a@uga.edu", "bio", false);
     expect(sent[1].text).toContain("retained");
   });
+
+  it("removal, quota, and test emails honor admin-editable templates", async () => {
+    settings.setSetting("removalEmailSubject", "Bye from {lab}");
+    settings.setSetting("removalEmailBody", "Lab {lab}: {data_status}");
+    await mailer.sendRemovalEmail("a@uga.edu", "bio", true);
+    expect(sent[0].subject).toBe("Bye from bio");
+    expect(sent[0].text).toBe("Lab bio: Your scratch and cold-storage data in this lab has been deleted.");
+
+    settings.setSetting("quotaEmailSubject", "{lab} {pct}% full");
+    settings.setSetting("quotaEmailBody", "{used}/{quota} on {pool}\n{breakdown}");
+    await mailer.sendQuotaEmail({
+      to: "pi@uga.edu", lab: "bio", pool: "fast", pct: 91,
+      usedHuman: "1.8 TB", quotaHuman: "2.0 TB", breakdown: [{ username: "alice", usedHuman: "1.0 TB" }],
+    });
+    expect(sent[1].subject).toBe("bio 91% full");
+    expect(sent[1].text).toContain("1.8 TB/2.0 TB on fast");
+    expect(sent[1].text).toContain("alice");
+
+    settings.setSetting("testEmailSubject", "ping");
+    settings.setSetting("testEmailBody", "pong");
+    await mailer.sendTestEmail("a@uga.edu");
+    expect(sent[2]).toMatchObject({ subject: "ping", text: "pong" });
+
+    // Restore defaults so later tests / runs see the built-in templates.
+    for (const k of ["removalEmailSubject", "removalEmailBody", "quotaEmailSubject", "quotaEmailBody", "testEmailSubject", "testEmailBody"] as const) {
+      settings.setSetting(k, "");
+    }
+  });
 });

--- a/controller/tests/nodegroups.test.ts
+++ b/controller/tests/nodegroups.test.ts
@@ -34,23 +34,26 @@ beforeAll(async () => {
      VALUES (2, 1, 2, 1000, NULL, 50002, 'img', 'active', 0, 0)`,
   ).run();
 
-  const sample = (pid: number, pool: string, used: number, quota: number | null) =>
-    d.prepare(
-      "INSERT INTO storage_samples (placement_id, student_id, pool, used_bytes, quota_bytes, ts) VALUES (?, NULL, ?, ?, ?, 100)",
-    ).run(pid, pool, used, quota);
-  sample(1, "fast", 500, 2000);
-  sample(1, "slow", 200, 3000);
-  sample(2, "fast", 300, 1000);
-  sample(2, "slow", 999, null); // SMB cold — must be ignored (counted on the owner instead)
+  // Per-node usage comes from the agent's live `pools` telemetry (fast pool first, cold pool second
+  // on a local-ZFS node; an SMB client reports its fast pool only). `node-empty` reports none.
+  const setPools = (name: string, pools: { name: string; size: number; alloc: number; free: number }[]) =>
+    d.prepare("UPDATE nodes SET pools = ? WHERE name = ?").run(JSON.stringify(pools), name);
+  setPools("node-a", [
+    { name: "fast", size: 2000, alloc: 500, free: 1500 },
+    { name: "cold", size: 3000, alloc: 200, free: 2800 },
+  ]);
+  setPools("node-smb", [{ name: "fast", size: 1000, alloc: 300, free: 700 }]);
 });
 
 describe("buildNodeUsage", () => {
-  it("sums fast + cold for a normal node and fast-only for an SMB node", () => {
+  it("reports fast + cold pool usage for a normal node and fast-only for an SMB node", () => {
     const usage = stats.buildNodeUsage();
     const a = usage.find((n) => n.name === "node-a")!;
     expect(a.coldBackend).toBe("local_zfs");
     expect(a.fastUsed).toBe(500);
+    expect(a.fastQuota).toBe(2000);
     expect(a.coldUsed).toBe(200);
+    expect(a.coldQuota).toBe(3000);
     expect(a.coldOwnerName).toBeNull();
 
     const smb = usage.find((n) => n.name === "node-smb")!;
@@ -60,7 +63,7 @@ describe("buildNodeUsage", () => {
     expect(smb.coldOwnerName).toBe("node-a");
   });
 
-  it("lists nodes with no placements with null totals", () => {
+  it("lists nodes that report no pools with null usage", () => {
     const empty = stats.buildNodeUsage().find((n) => n.name === "node-empty")!;
     expect(empty.fastUsed).toBeNull();
     expect(empty.coldUsed).toBeNull();


### PR DESCRIPTION
## Summary

Makes **every** email the controller sends editable from one place (the Templates tab), turns the announcement prebuilts into full CRUD, and fixes per-node storage usage so it works before any lab exists.

### Templates tab — all emails editable
- Welcome / credentials, GPU idle warning, GPU process terminated (moved here from Settings)
- **Removed from lab**, **Storage quota alert**, **Test email** — previously hardcoded & labelled "fixed"; now admin-editable, backed by new settings keys and rendered through `renderTemplate` with `{placeholder}` substitution (removal gains `{lab}`/`{data_status}`; quota gains `{lab}`/`{pool}`/`{pct}`/`{used}`/`{quota}`/`{breakdown}`)
- Blank subject falls back to the built-in default; unknown `{tokens}` are left as-is

### Announcement templates — full CRUD
- New `announcement_templates` table (migration `0017`), seeded with the two defaults
- **Removed** the "Access expiring" and "New capacity available" starters
- Add / edit / delete on the Templates tab; the Announcements compose picker reads from the DB

### Settings tab
- Removed the Welcome-email and GPU-notification-email editors; added a pointer to Templates (the SMTP "Send test" button stays under Settings → Email)

### Per-node usage + global refresh (Stats)
- `buildNodeUsage` now reads each node's live ZFS **pool telemetry** (fast/cold used-vs-capacity) instead of summing across labs, so it populates even with zero labs
- New **"Refresh all"** button: re-pulls telemetry and enqueues `usage.scan` on every online placement

## Notes
- Migration `0017` runs automatically on controller start (creates + seeds the table).
- Per-node usage reflects the same ZFS pool data shown on the Nodes page "Pools" column — requires the node to have `fast`/`cold` ZFS pools.

## Test plan
- `npm run lint` ✓ · `npm run typecheck` ✓ · `npm test` (230 passing) ✓ · `npm run build` ✓
- Added coverage: pool-based `buildNodeUsage`, announcement-template CRUD + validation, editable removal/quota/test rendering, and auth-gating for the new Templates server actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)