### PR TITLE
Left-align page content and fix empty space in form cards

### DIFF
--- a/controller/src/app/(app)/email-templates/page.tsx
+++ b/controller/src/app/(app)/email-templates/page.tsx
@@ -70,7 +70,7 @@ function EditableTemplate({ name, trigger, action, subject, body, vars, bodyRows
           <h3 className="text-base font-semibold">{name}</h3>
           <p className="text-sm text-muted-foreground">{trigger}</p>
         </div>
-        <form action={action} className="grid max-w-2xl gap-3">
+        <form action={action} className="grid gap-3">
           <div>
             <Label>Subject</Label>
             <Input name="subject" defaultValue={subject} />
@@ -147,7 +147,7 @@ export default async function EmailTemplatesPage({
   const announcementTemplates = listAnnouncementTemplates();
 
   return (
-    <div className="space-y-4">
+    <div className="max-w-3xl space-y-4">
       <div className="space-y-2">
         <h1 className="text-2xl font-semibold tracking-tight">Email templates</h1>
         <p className="text-sm text-muted-foreground">

--- a/controller/src/app/(app)/layout.tsx
+++ b/controller/src/app/(app)/layout.tsx
@@ -30,7 +30,7 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
           <SidebarContent email={admin.email} logout={logout} />
         </MobileNav>
 
-        <main className="mx-auto w-full min-w-0 max-w-[100rem] flex-1 px-4 py-6 sm:px-6 lg:px-8">
+        <main className="w-full min-w-0 max-w-7xl flex-1 px-4 py-6 sm:px-6 lg:px-8">
           {children}
         </main>
       </div>

--- a/controller/src/app/(app)/settings/page.tsx
+++ b/controller/src/app/(app)/settings/page.tsx
@@ -48,7 +48,7 @@ export default async function SettingsPage({
   const logCount = (db().prepare("SELECT COUNT(*) AS n FROM logs").get() as { n: number }).n;
   const logBytes = logsContentBytes();
   return (
-    <div className="space-y-4">
+    <div className="max-w-3xl space-y-4">
       <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
 
       <Card>


### PR DESCRIPTION
## What
Fixes the off-center, gap-heavy page layout (flagged on the **Email templates** page) and makes all pages left-aligned at a proper width.

## Why
The app shell centered its main content at `max-w-[100rem]` (1600px) via `mx-auto`, which floated pages off-center with uneven gaps on wide screens. On the pure-form pages (email templates, settings), each `Card` stretched to that full width while the form inside was pinned to `max-w-2xl`/`max-w-xl` — leaving the entire right half of every card empty (the wasted space in the screenshot).

## Changes
- **`(app)/layout.tsx`** — drop `mx-auto` and cap at `max-w-7xl` (1280px), so every page is **left-aligned** with a sensible content width.
- **`email-templates/page.tsx`** — constrain the page to a `max-w-3xl` reading column and remove the redundant per-form `max-w-2xl` so forms fill their cards.
- **`settings/page.tsx`** — same `max-w-3xl` column treatment (also a pure-form page).

## Notes for reviewer
- Data pages (dashboard, nodes, stats, students, logs, gpu, labs) and **backups** intentionally keep the wider `max-w-7xl` — their tables/grids genuinely use the width, and constraining them would cramp the tables.
- CSS-class-only changes; no behavior change. `npm run typecheck` and `npm run lint` both pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)