### PR TITLE
Add universal email signature

### DIFF
--- a/controller/src/app/(app)/email-templates/_components/SignatureEditor.tsx
+++ b/controller/src/app/(app)/email-templates/_components/SignatureEditor.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+
+interface Props {
+  html: string;
+  action: (formData: FormData) => void | Promise<void>;
+}
+
+/** Copy/paste HTML editor and isolated preview for the signature shared by every outbound email. */
+export function SignatureEditor({ html: initialHtml, action }: Props) {
+  const [html, setHtml] = useState(initialHtml);
+  const [clipboardStatus, setClipboardStatus] = useState("");
+
+  async function pasteFromClipboard() {
+    try {
+      if (navigator.clipboard.read) {
+        const items = await navigator.clipboard.read();
+        for (const item of items) {
+          if (item.types.includes("text/html")) {
+            setHtml(await (await item.getType("text/html")).text());
+            setClipboardStatus("Pasted the formatted HTML from your clipboard.");
+            return;
+          }
+        }
+      }
+      setHtml(await navigator.clipboard.readText());
+      setClipboardStatus("Pasted the HTML source from your clipboard.");
+    } catch {
+      setClipboardStatus("Clipboard access was blocked. Paste directly into the HTML field instead.");
+    }
+  }
+
+  async function copySignature() {
+    try {
+      const wrapper = document.createElement("div");
+      wrapper.innerHTML = html;
+      const plain = wrapper.innerText.trim();
+      await navigator.clipboard.write([
+        new ClipboardItem({
+          "text/html": new Blob([html], { type: "text/html" }),
+          "text/plain": new Blob([plain], { type: "text/plain" }),
+        }),
+      ]);
+      setClipboardStatus("Copied the formatted signature. You can paste it into an email client.");
+    } catch {
+      try {
+        await navigator.clipboard.writeText(html);
+        setClipboardStatus("Copied the signature HTML source.");
+      } catch {
+        setClipboardStatus("Clipboard access was blocked. Select and copy the HTML field manually.");
+      }
+    }
+  }
+
+  return (
+    <Card>
+      <CardContent className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-base font-semibold">Universal email signature</h2>
+          <p className="text-sm text-muted-foreground">
+            Appended to every email sent by the controller. Paste HTML from the UGA signature builder,
+            review it below, then save.
+          </p>
+        </div>
+
+        <form action={action} className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="signature-html">Signature HTML</Label>
+            <Textarea
+              id="signature-html"
+              name="signatureHtml"
+              rows={14}
+              value={html}
+              onChange={(event) => setHtml(event.target.value)}
+              className="font-mono text-xs"
+              spellCheck={false}
+            />
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button type="submit">Save signature</Button>
+            <Button type="button" variant="outline" onClick={pasteFromClipboard}>
+              Paste from clipboard
+            </Button>
+            <Button type="button" variant="outline" onClick={copySignature}>
+              Copy signature
+            </Button>
+          </div>
+          {clipboardStatus ? (
+            <p className="text-xs text-muted-foreground" role="status">
+              {clipboardStatus}
+            </p>
+          ) : null}
+        </form>
+
+        <div className="flex flex-col gap-1.5">
+          <Label>Preview</Label>
+          <iframe
+            key={html}
+            title="Universal email signature preview"
+            sandbox=""
+            srcDoc={`<!doctype html><html><body>${html}</body></html>`}
+            className="h-44 w-full rounded-md border border-input bg-white p-3"
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/controller/src/app/(app)/email-templates/actions.ts
+++ b/controller/src/app/(app)/email-templates/actions.ts
@@ -15,6 +15,12 @@ import { putFlash } from "@/lib/flash";
 // to the built-in default at render time); bodies are stored verbatim so intentional leading/trailing
 // whitespace in a template is preserved. Each save revalidates the Templates page.
 
+export async function saveUniversalSignatureAction(formData: FormData) {
+  await requireAdmin();
+  setSetting("emailSignatureHtml", String(formData.get("signatureHtml") ?? "").trim());
+  revalidatePath("/email-templates");
+}
+
 export async function saveWelcomeEmailAction(formData: FormData) {
   await requireAdmin();
   setSetting("welcomeEmailSubject", String(formData.get("subject") ?? "").trim());

--- a/controller/src/app/(app)/email-templates/page.tsx
+++ b/controller/src/app/(app)/email-templates/page.tsx
@@ -14,6 +14,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { ConfirmButton } from "../_components/ConfirmButton";
+import { SignatureEditor } from "./_components/SignatureEditor";
 import {
   createAnnouncementTemplateAction,
   deleteAnnouncementTemplateAction,
@@ -22,6 +23,7 @@ import {
   saveQuotaEmailAction,
   saveRemovalEmailAction,
   saveTestEmailAction,
+  saveUniversalSignatureAction,
   saveWelcomeEmailAction,
   updateAnnouncementTemplateAction,
 } from "./actions";
@@ -162,6 +164,8 @@ export default async function EmailTemplatesPage({
         </p>
       </div>
 
+      <SignatureEditor html={s.emailSignatureHtml} action={saveUniversalSignatureAction} />
+
       <EditableTemplate
         name="Welcome / credentials"
         trigger="Sent to a student once they are provisioned on a node — carries their login and SSH connection details."
@@ -232,7 +236,7 @@ export default async function EmailTemplatesPage({
                 Announcements
               </Link>{" "}
               compose form. Picking one fills the subject/body, which the admin edits before sending. A
-              fixed “— Lab Manager” signature is appended to every announcement on send.
+              universal signature above is appended to every announcement on send.
             </p>
             <div className="space-y-1.5 pt-1">
               <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">

--- a/controller/src/lib/announcements.ts
+++ b/controller/src/lib/announcements.ts
@@ -156,14 +156,13 @@ export async function sendAnnouncement(input: {
   const recipients = [...byEmail.values()];
   const skipped = !isSmtpConfigured();
 
-  // {name}/{email} are substituted per recipient; the signature is fixed.
-  const template = `${body}\n\n— Lab Manager`;
+  // {name}/{email} are substituted per recipient. sendMail appends the universal signature.
   let sent = 0;
   if (!skipped) {
     const results = await Promise.all(
       recipients.map((r) => {
         const vars = { name: r.name, email: r.email };
-        return sendMail(r.email, renderTemplate(subject, vars), renderTemplate(template, vars));
+        return sendMail(r.email, renderTemplate(subject, vars), renderTemplate(body, vars));
       }),
     );
     sent = results.filter((r) => r.sent).length;

--- a/controller/src/lib/db.ts
+++ b/controller/src/lib/db.ts
@@ -13,6 +13,7 @@ import Database from "better-sqlite3";
 const { existsSync, mkdirSync, renameSync, rmSync } = process.getBuiltinModule("node:fs");
 const { dirname } = process.getBuiltinModule("node:path");
 import { env } from "./env";
+import { stripLegacyEmailSignature } from "./template";
 
 /** If a WebDAV restore was staged as <dbPath>.restore, swap it in before opening. */
 function applyStagedRestore(dbPath: string): void {
@@ -518,6 +519,35 @@ Thanks for helping keep the cluster healthy.`,
         "INSERT INTO announcement_templates (name, subject, body, sort) VALUES (?, ?, ?, ?)",
       );
       seed.forEach((t, i) => ins.run(t.name, t.subject, t.body, i));
+    },
+  },
+  {
+    // Signatures are now appended once by the mailer. Remove the old fixed footer from any email
+    // bodies an admin previously saved so it does not remain visible in the template editor.
+    id: "0018_universal_email_signature",
+    fn: (conn) => {
+      const keys = [
+        "welcomeEmailBody",
+        "gpuWarnEmailBody",
+        "gpuKillEmailBody",
+        "removalEmailBody",
+        "quotaEmailBody",
+        "testEmailBody",
+      ];
+      const read = conn.prepare("SELECT value FROM settings WHERE key = ?");
+      const write = conn.prepare("UPDATE settings SET value = ? WHERE key = ?");
+      for (const key of keys) {
+        const row = read.get(key) as { value: string } | undefined;
+        if (!row) continue;
+        try {
+          const body = JSON.parse(row.value);
+          if (typeof body !== "string") continue;
+          const clean = stripLegacyEmailSignature(body);
+          if (clean !== body) write.run(JSON.stringify(clean), key);
+        } catch {
+          // Invalid setting JSON already falls back safely in getSetting; leave it untouched here.
+        }
+      }
     },
   },
 ];

--- a/controller/src/lib/mailer.ts
+++ b/controller/src/lib/mailer.ts
@@ -5,7 +5,7 @@
  */
 
 import nodemailer from "nodemailer";
-import { renderTemplate } from "./template";
+import { renderTemplate, stripLegacyEmailSignature } from "./template";
 import {
   DEFAULT_GPU_KILL_BODY,
   DEFAULT_GPU_KILL_SUBJECT,
@@ -45,11 +45,74 @@ function transport() {
   });
 }
 
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function decodeHtmlEntities(value: string): string {
+  const named: Record<string, string> = {
+    amp: "&",
+    apos: "'",
+    gt: ">",
+    lt: "<",
+    nbsp: " ",
+    quot: '"',
+  };
+  return value.replace(/&(#x[\da-f]+|#\d+|\w+);/gi, (whole, entity: string) => {
+    if (entity[0] === "#") {
+      const hex = entity[1]?.toLowerCase() === "x";
+      const codePoint = Number.parseInt(entity.slice(hex ? 2 : 1), hex ? 16 : 10);
+      return Number.isFinite(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff
+        ? String.fromCodePoint(codePoint)
+        : whole;
+    }
+    return named[entity.toLowerCase()] ?? whole;
+  });
+}
+
+/** Derive the multipart plain-text signature from the admin's HTML signature. */
+export function signatureHtmlToText(html: string): string {
+  return decodeHtmlEntities(
+    html
+      .replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi, "")
+      .replace(/<img\b[^>]*\balt\s*=\s*(["'])(.*?)\1[^>]*>/gi, "$2")
+      .replace(/<br\s*\/?\s*>/gi, "\n")
+      .replace(/<\/(div|p|li|tr|h[1-6])\s*>/gi, "\n")
+      .replace(/<[^>]+>/g, ""),
+  )
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n[ \t]+/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+/** Build text + HTML alternatives with the one universal signature appended to each. */
+export function emailContent(body: string): { text: string; html: string } {
+  const cleanBody = stripLegacyEmailSignature(body).trimEnd();
+  const signatureHtml = getSetting("emailSignatureHtml").trim();
+  const signatureText = signatureHtmlToText(signatureHtml);
+  return {
+    text: [cleanBody, signatureText].filter(Boolean).join("\n\n"),
+    html: [
+      `<div style="white-space: pre-wrap;">${escapeHtml(cleanBody)}</div>`,
+      signatureHtml,
+    ]
+      .filter(Boolean)
+      .join("<br><br>"),
+  };
+}
+
 export async function sendMail(to: string, subject: string, text: string): Promise<SendResult> {
   if (!isSmtpConfigured()) return { sent: false, skipped: true };
   if (!to) return { sent: false, skipped: true };
   try {
-    await transport().sendMail({ from: getSetting("smtpFrom"), to, subject, text });
+    const content = emailContent(text);
+    await transport().sendMail({ from: getSetting("smtpFrom"), to, subject, ...content });
     return { sent: true };
   } catch (err) {
     return { sent: false, error: err instanceof Error ? err.message : String(err) };

--- a/controller/src/lib/settings.ts
+++ b/controller/src/lib/settings.ts
@@ -33,6 +33,9 @@ export interface Settings {
   smtpPass: string;
   smtpFrom: string;
   smtpSecure: boolean; // true = implicit TLS (465); false = STARTTLS/none
+  // HTML signature appended by the mailer to every outbound email. It is edited as copy/paste HTML
+  // on the Templates page; the mailer also derives a plain-text fallback for text-only clients.
+  emailSignatureHtml: string;
   // Optional public hostname students SSH to (falls back to the node name).
   sshHostOverride: string;
   // Welcome email sent to a student when added to a lab. Both fields support {placeholder}
@@ -137,9 +140,7 @@ Your home directory contains:
   ~/scratch        fast storage for working data
   ~/cold-storage   slower storage for data you want to keep but rarely touch
 
-Please change your password after first login (run: passwd).
-
-— Lab Manager`;
+Please change your password after first login (run: passwd).`;
 
 /** Placeholders the GPU notification templates understand, shown to the admin in the settings UI. */
 export const GPU_EMAIL_VARS: { key: string; desc: string }[] = [
@@ -156,9 +157,7 @@ export const DEFAULT_GPU_WARN_BODY = `Hello {username},
 
 One of your processes (PID {pid}) on node {node} is holding GPU memory but is not using the GPU.
 
-If it stays idle it will be terminated in about {grace_minutes} minutes to free the GPU for others. If you still need it, start using the GPU again or contact an admin.
-
-— Lab Manager`;
+If it stays idle it will be terminated in about {grace_minutes} minutes to free the GPU for others. If you still need it, start using the GPU again or contact an admin.`;
 
 export const DEFAULT_GPU_KILL_SUBJECT = "Idle GPU process terminated";
 
@@ -166,9 +165,7 @@ export const DEFAULT_GPU_KILL_BODY = `Hello {username},
 
 Your idle process (PID {pid}) on node {node} was terminated because it held GPU memory without using the GPU.
 
-Please checkpoint long-running work and keep the GPU active, or ask an admin to whitelist your job.
-
-— Lab Manager`;
+Please checkpoint long-running work and keep the GPU active, or ask an admin to whitelist your job.`;
 
 /** Placeholders the removal email understands, shown to the admin in the Templates UI. */
 export const REMOVAL_EMAIL_VARS: { key: string; desc: string }[] = [
@@ -178,9 +175,7 @@ export const REMOVAL_EMAIL_VARS: { key: string; desc: string }[] = [
 
 export const DEFAULT_REMOVAL_SUBJECT = "Removed from lab {lab}";
 
-export const DEFAULT_REMOVAL_BODY = `You have been removed from the lab "{lab}". {data_status}
-
-— Lab Manager`;
+export const DEFAULT_REMOVAL_BODY = `You have been removed from the lab "{lab}". {data_status}`;
 
 /** The two fixed sentences {data_status} resolves to (chosen by whether the data was deleted). */
 export const REMOVAL_DATA_DELETED = "Your scratch and cold-storage data in this lab has been deleted.";
@@ -203,14 +198,25 @@ export const DEFAULT_QUOTA_BODY = `Lab "{lab}" has reached {pct}% of its {pool} 
 Per-student usage on the {pool} pool:
 {breakdown}
 
-You may want to ask students to clean up unneeded data, or request a larger quota.
-
-— Lab Manager`;
+You may want to ask students to clean up unneeded data, or request a larger quota.`;
 
 export const DEFAULT_TEST_SUBJECT = "Lab Manager test email";
 
 export const DEFAULT_TEST_BODY =
   "This is a test email from the Lab Manager controller. SMTP is configured correctly.";
+
+/** UGA-branded signature used by every email unless an admin replaces it on the Templates page. */
+export const DEFAULT_EMAIL_SIGNATURE_HTML = `<div id="template2" class="signature">
+  <p style="margin-bottom: 1em; font: 12px 'Georgia', 'Times', 'sans-serif';">
+    <span style="font-weight: 900;">Ningxi Cheng</span><span style="font-weight: 900;">, Graduate Research Assistant</span>
+    <br>
+    <span>School of Computing | <span style="font-style: italic;">Ph.D. Student</span></span>
+  </p>
+  <p style="margin-bottom: 1em; font: 12px 'Georgia', 'Times', 'sans-serif';">
+    <span><a href="mailto:edwardcheng@uga.edu">edwardcheng@uga.edu</a></span>
+  </p>
+  <div class="logo"><img width="160" src="https://brand.uga.edu/email-signature-builder/assets/images/uga-logo@2x.png" alt="University of Georgia"></div>
+</div>`;
 
 export const DEFAULT_SETTINGS: Settings = {
   fastQuotaDefaultBytes: 2 * TIB,
@@ -226,6 +232,7 @@ export const DEFAULT_SETTINGS: Settings = {
   smtpPass: "",
   smtpFrom: "",
   smtpSecure: false,
+  emailSignatureHtml: DEFAULT_EMAIL_SIGNATURE_HTML,
   sshHostOverride: "",
   welcomeEmailSubject: DEFAULT_WELCOME_SUBJECT,
   welcomeEmailBody: DEFAULT_WELCOME_BODY,

--- a/controller/src/lib/template.ts
+++ b/controller/src/lib/template.ts
@@ -14,3 +14,8 @@ export function renderTemplate(template: string, vars: Record<string, string | n
     Object.prototype.hasOwnProperty.call(vars, key) ? String(vars[key] ?? "") : whole,
   );
 }
+
+/** Remove the signature used by older built-in templates before the universal signature existed. */
+export function stripLegacyEmailSignature(text: string): string {
+  return text.replace(/\n*\s*—\s*Lab Manager\s*$/i, "").trimEnd();
+}

--- a/controller/tests/announcements.test.ts
+++ b/controller/tests/announcements.test.ts
@@ -76,7 +76,7 @@ describe("sendAnnouncement", () => {
     expect(row.skipped).toBe(0);
   });
 
-  it("substitutes {name}/{email} per recipient and appends the signature", async () => {
+  it("substitutes {name}/{email} before passing the body to the universal-signature mailer", async () => {
     settings.setSetting("smtpHost", "smtp.test");
     settings.setSetting("smtpFrom", "no-reply@uga.edu");
     sendMail.mockClear();
@@ -91,7 +91,7 @@ describe("sendAnnouncement", () => {
     const aliceCall = calls.find((c) => c[0] === "alice@uga.edu");
     expect(aliceCall).toBeTruthy();
     expect(aliceCall![1]).toBe("Hi alice"); // no name set → falls back to username
-    expect(aliceCall![2]).toBe("Your address is alice@uga.edu.\n\n— Lab Manager");
+    expect(aliceCall![2]).toBe("Your address is alice@uga.edu.");
   });
 
   it("skips sending when SMTP is not configured but still records", async () => {

--- a/controller/tests/mailer.test.ts
+++ b/controller/tests/mailer.test.ts
@@ -62,7 +62,9 @@ describe("sendMail gating", () => {
     configureSmtp();
     const res = await mailer.sendMail("a@uga.edu", "Subject", "Body");
     expect(res).toEqual({ sent: true });
-    expect(sent[0]).toMatchObject({ from: "labs@uga.edu", to: "a@uga.edu", subject: "Subject", text: "Body" });
+    expect(sent[0]).toMatchObject({ from: "labs@uga.edu", to: "a@uga.edu", subject: "Subject" });
+    expect(sent[0].text).toContain("Body\n\nNingxi Cheng, Graduate Research Assistant");
+    expect(sent[0].html).toContain("uga-logo@2x.png");
   });
 
   it("returns the error message when the transport throws", async () => {
@@ -101,7 +103,7 @@ describe("templated emails", () => {
       host: "gpu-1.uga.edu", port: 2222, lab: "bio", node: "gpu-1",
     });
     expect(sent[0].subject).toBe("Welcome Alice to bio");
-    expect(sent[0].text).toBe("User alice pw pw123 on node gpu-1 (gpu-1.uga.edu)");
+    expect(sent[0].text).toContain("User alice pw pw123 on node gpu-1 (gpu-1.uga.edu)");
     // Restore defaults so later tests see the built-in template.
     settings.setSetting("welcomeEmailSubject", "");
     settings.setSetting("welcomeEmailBody", "");
@@ -140,7 +142,7 @@ describe("templated emails", () => {
     settings.setSetting("gpuWarnEmailBody", "PID {pid} on {node} — {grace_minutes}m left");
     await mailer.sendGpuWarningEmail("a@uga.edu", { username: "alice", lab: "bio", pid: 42, node: "gpu-01", graceMinutes: 15 });
     expect(sent[0].subject).toBe("Heads up alice");
-    expect(sent[0].text).toBe("PID 42 on gpu-01 — 15m left");
+    expect(sent[0].text).toContain("PID 42 on gpu-01 — 15m left");
   });
 
   it("removal email distinguishes deleted vs retained data", async () => {
@@ -155,7 +157,7 @@ describe("templated emails", () => {
     settings.setSetting("removalEmailBody", "Lab {lab}: {data_status}");
     await mailer.sendRemovalEmail("a@uga.edu", "bio", true);
     expect(sent[0].subject).toBe("Bye from bio");
-    expect(sent[0].text).toBe("Lab bio: Your scratch and cold-storage data in this lab has been deleted.");
+    expect(sent[0].text).toContain("Lab bio: Your scratch and cold-storage data in this lab has been deleted.");
 
     settings.setSetting("quotaEmailSubject", "{lab} {pct}% full");
     settings.setSetting("quotaEmailBody", "{used}/{quota} on {pool}\n{breakdown}");
@@ -170,11 +172,27 @@ describe("templated emails", () => {
     settings.setSetting("testEmailSubject", "ping");
     settings.setSetting("testEmailBody", "pong");
     await mailer.sendTestEmail("a@uga.edu");
-    expect(sent[2]).toMatchObject({ subject: "ping", text: "pong" });
+    expect(sent[2].subject).toBe("ping");
+    expect(sent[2].text).toContain("pong\n\nNingxi Cheng");
 
     // Restore defaults so later tests / runs see the built-in templates.
     for (const k of ["removalEmailSubject", "removalEmailBody", "quotaEmailSubject", "quotaEmailBody", "testEmailSubject", "testEmailBody"] as const) {
       settings.setSetting(k, "");
     }
+  });
+
+  it("uses one editable signature for both HTML and plain-text email alternatives", async () => {
+    settings.setSetting(
+      "emailSignatureHtml",
+      '<div><strong>Research Team</strong><br><a href="mailto:team@uga.edu">team@uga.edu</a></div>',
+    );
+
+    await mailer.sendMail("a@uga.edu", "Signed", "Message body\nsecond line\n\n— Lab Manager");
+
+    expect(sent[0].text).toBe("Message body\nsecond line\n\nResearch Team\nteam@uga.edu");
+    expect(sent[0].html).toContain("Message body\nsecond line");
+    expect(sent[0].html).toContain("<strong>Research Team</strong>");
+    expect(sent[0].html).not.toContain("— Lab Manager");
+    settings.setSetting("emailSignatureHtml", settings.DEFAULT_EMAIL_SIGNATURE_HTML);
   });
 });


### PR DESCRIPTION
## Summary
- add an editable universal UGA email signature with HTML paste/copy and live preview
- append the signature to every outbound email as HTML with a plain-text fallback
- migrate saved templates away from the legacy fixed footer and cover the behavior with tests

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm test` (231 tests)
- `npm run build`
- desktop and mobile browser QA