### PR TITLE
Fix plain-text email formatting

### DIFF
--- a/controller/src/app/(app)/email-templates/_components/SignatureEditor.tsx
+++ b/controller/src/app/(app)/email-templates/_components/SignatureEditor.tsx
@@ -1,112 +1,39 @@
-"use client";
-
-import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 
 interface Props {
-  html: string;
+  text: string;
   action: (formData: FormData) => void | Promise<void>;
 }
 
-/** Copy/paste HTML editor and isolated preview for the signature shared by every outbound email. */
-export function SignatureEditor({ html: initialHtml, action }: Props) {
-  const [html, setHtml] = useState(initialHtml);
-  const [clipboardStatus, setClipboardStatus] = useState("");
-
-  async function pasteFromClipboard() {
-    try {
-      if (navigator.clipboard.read) {
-        const items = await navigator.clipboard.read();
-        for (const item of items) {
-          if (item.types.includes("text/html")) {
-            setHtml(await (await item.getType("text/html")).text());
-            setClipboardStatus("Pasted the formatted HTML from your clipboard.");
-            return;
-          }
-        }
-      }
-      setHtml(await navigator.clipboard.readText());
-      setClipboardStatus("Pasted the HTML source from your clipboard.");
-    } catch {
-      setClipboardStatus("Clipboard access was blocked. Paste directly into the HTML field instead.");
-    }
-  }
-
-  async function copySignature() {
-    try {
-      const wrapper = document.createElement("div");
-      wrapper.innerHTML = html;
-      const plain = wrapper.innerText.trim();
-      await navigator.clipboard.write([
-        new ClipboardItem({
-          "text/html": new Blob([html], { type: "text/html" }),
-          "text/plain": new Blob([plain], { type: "text/plain" }),
-        }),
-      ]);
-      setClipboardStatus("Copied the formatted signature. You can paste it into an email client.");
-    } catch {
-      try {
-        await navigator.clipboard.writeText(html);
-        setClipboardStatus("Copied the signature HTML source.");
-      } catch {
-        setClipboardStatus("Clipboard access was blocked. Select and copy the HTML field manually.");
-      }
-    }
-  }
-
+/** Plain-text signature shared by every outbound email. */
+export function SignatureEditor({ text, action }: Props) {
   return (
     <Card>
-      <CardContent className="flex flex-col gap-4">
-        <div className="flex flex-col gap-1">
-          <h2 className="text-base font-semibold">Universal email signature</h2>
-          <p className="text-sm text-muted-foreground">
-            Appended to every email sent by the controller. Paste HTML from the UGA signature builder,
-            review it below, then save.
-          </p>
-        </div>
-
+      <CardHeader>
+        <CardTitle>Universal email signature</CardTitle>
+        <CardDescription>
+          Appended to every email exactly as entered. Leave it blank to send emails without a signature.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
         <form action={action} className="flex flex-col gap-3">
           <div className="flex flex-col gap-1.5">
-            <Label htmlFor="signature-html">Signature HTML</Label>
+            <Label htmlFor="signature-text">Plain-text signature</Label>
             <Textarea
-              id="signature-html"
-              name="signatureHtml"
-              rows={14}
-              value={html}
-              onChange={(event) => setHtml(event.target.value)}
+              id="signature-text"
+              name="signatureText"
+              rows={6}
+              defaultValue={text}
               className="font-mono text-xs"
-              spellCheck={false}
             />
           </div>
-          <div className="flex flex-wrap gap-2">
+          <div>
             <Button type="submit">Save signature</Button>
-            <Button type="button" variant="outline" onClick={pasteFromClipboard}>
-              Paste from clipboard
-            </Button>
-            <Button type="button" variant="outline" onClick={copySignature}>
-              Copy signature
-            </Button>
           </div>
-          {clipboardStatus ? (
-            <p className="text-xs text-muted-foreground" role="status">
-              {clipboardStatus}
-            </p>
-          ) : null}
         </form>
-
-        <div className="flex flex-col gap-1.5">
-          <Label>Preview</Label>
-          <iframe
-            key={html}
-            title="Universal email signature preview"
-            sandbox=""
-            srcDoc={`<!doctype html><html><body>${html}</body></html>`}
-            className="h-44 w-full rounded-md border border-input bg-white p-3"
-          />
-        </div>
       </CardContent>
     </Card>
   );

--- a/controller/src/app/(app)/email-templates/actions.ts
+++ b/controller/src/app/(app)/email-templates/actions.ts
@@ -17,7 +17,7 @@ import { putFlash } from "@/lib/flash";
 
 export async function saveUniversalSignatureAction(formData: FormData) {
   await requireAdmin();
-  setSetting("emailSignatureHtml", String(formData.get("signatureHtml") ?? "").trim());
+  setSetting("emailSignatureText", String(formData.get("signatureText") ?? "").trim());
   revalidatePath("/email-templates");
 }
 

--- a/controller/src/app/(app)/email-templates/page.tsx
+++ b/controller/src/app/(app)/email-templates/page.tsx
@@ -164,7 +164,7 @@ export default async function EmailTemplatesPage({
         </p>
       </div>
 
-      <SignatureEditor html={s.emailSignatureHtml} action={saveUniversalSignatureAction} />
+      <SignatureEditor text={s.emailSignatureText} action={saveUniversalSignatureAction} />
 
       <EditableTemplate
         name="Welcome / credentials"
@@ -236,7 +236,7 @@ export default async function EmailTemplatesPage({
                 Announcements
               </Link>{" "}
               compose form. Picking one fills the subject/body, which the admin edits before sending. A
-              universal signature above is appended to every announcement on send.
+              plain-text signature above is appended to every announcement on send.
             </p>
             <div className="space-y-1.5 pt-1">
               <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">

--- a/controller/src/lib/db.ts
+++ b/controller/src/lib/db.ts
@@ -13,7 +13,7 @@ import Database from "better-sqlite3";
 const { existsSync, mkdirSync, renameSync, rmSync } = process.getBuiltinModule("node:fs");
 const { dirname } = process.getBuiltinModule("node:path");
 import { env } from "./env";
-import { stripLegacyEmailSignature } from "./template";
+import { legacySignatureHtmlToText, stripLegacyEmailSignature } from "./template";
 
 /** If a WebDAV restore was staged as <dbPath>.restore, swap it in before opening. */
 function applyStagedRestore(dbPath: string): void {
@@ -548,6 +548,32 @@ Thanks for helping keep the cluster healthy.`,
           // Invalid setting JSON already falls back safely in getSetting; leave it untouched here.
         }
       }
+    },
+  },
+  {
+    // Replace the HTML signature setting with plain text. Preserve a customized signature by
+    // converting it once, then remove the obsolete setting so it cannot be used accidentally.
+    id: "0019_plain_text_email_signature",
+    fn: (conn) => {
+      const row = conn
+        .prepare("SELECT value FROM settings WHERE key = 'emailSignatureHtml'")
+        .get() as { value: string } | undefined;
+      if (row) {
+        try {
+          const html = JSON.parse(row.value);
+          if (typeof html === "string") {
+            conn
+              .prepare(
+                `INSERT INTO settings (key, value) VALUES ('emailSignatureText', ?)
+                 ON CONFLICT(key) DO NOTHING`,
+              )
+              .run(JSON.stringify(legacySignatureHtmlToText(html)));
+          }
+        } catch {
+          // Invalid setting JSON was already ignored by getSetting; do not migrate it.
+        }
+      }
+      conn.prepare("DELETE FROM settings WHERE key = 'emailSignatureHtml'").run();
     },
   },
 ];

--- a/controller/src/lib/mailer.ts
+++ b/controller/src/lib/mailer.ts
@@ -45,65 +45,12 @@ function transport() {
   });
 }
 
-function escapeHtml(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
-}
-
-function decodeHtmlEntities(value: string): string {
-  const named: Record<string, string> = {
-    amp: "&",
-    apos: "'",
-    gt: ">",
-    lt: "<",
-    nbsp: " ",
-    quot: '"',
-  };
-  return value.replace(/&(#x[\da-f]+|#\d+|\w+);/gi, (whole, entity: string) => {
-    if (entity[0] === "#") {
-      const hex = entity[1]?.toLowerCase() === "x";
-      const codePoint = Number.parseInt(entity.slice(hex ? 2 : 1), hex ? 16 : 10);
-      return Number.isFinite(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff
-        ? String.fromCodePoint(codePoint)
-        : whole;
-    }
-    return named[entity.toLowerCase()] ?? whole;
-  });
-}
-
-/** Derive the multipart plain-text signature from the admin's HTML signature. */
-export function signatureHtmlToText(html: string): string {
-  return decodeHtmlEntities(
-    html
-      .replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi, "")
-      .replace(/<img\b[^>]*\balt\s*=\s*(["'])(.*?)\1[^>]*>/gi, "$2")
-      .replace(/<br\s*\/?\s*>/gi, "\n")
-      .replace(/<\/(div|p|li|tr|h[1-6])\s*>/gi, "\n")
-      .replace(/<[^>]+>/g, ""),
-  )
-    .replace(/[ \t]+\n/g, "\n")
-    .replace(/\n[ \t]+/g, "\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
-}
-
-/** Build text + HTML alternatives with the one universal signature appended to each. */
-export function emailContent(body: string): { text: string; html: string } {
+/** Build the text-only message with the universal signature appended. */
+export function emailContent(body: string): { text: string } {
   const cleanBody = stripLegacyEmailSignature(body).trimEnd();
-  const signatureHtml = getSetting("emailSignatureHtml").trim();
-  const signatureText = signatureHtmlToText(signatureHtml);
+  const signatureText = getSetting("emailSignatureText").trim();
   return {
     text: [cleanBody, signatureText].filter(Boolean).join("\n\n"),
-    html: [
-      `<div style="white-space: pre-wrap;">${escapeHtml(cleanBody)}</div>`,
-      signatureHtml,
-    ]
-      .filter(Boolean)
-      .join("<br><br>"),
   };
 }
 

--- a/controller/src/lib/settings.ts
+++ b/controller/src/lib/settings.ts
@@ -33,9 +33,8 @@ export interface Settings {
   smtpPass: string;
   smtpFrom: string;
   smtpSecure: boolean; // true = implicit TLS (465); false = STARTTLS/none
-  // HTML signature appended by the mailer to every outbound email. It is edited as copy/paste HTML
-  // on the Templates page; the mailer also derives a plain-text fallback for text-only clients.
-  emailSignatureHtml: string;
+  // Plain-text signature appended by the mailer to every outbound email.
+  emailSignatureText: string;
   // Optional public hostname students SSH to (falls back to the node name).
   sshHostOverride: string;
   // Welcome email sent to a student when added to a lab. Both fields support {placeholder}
@@ -205,18 +204,11 @@ export const DEFAULT_TEST_SUBJECT = "Lab Manager test email";
 export const DEFAULT_TEST_BODY =
   "This is a test email from the Lab Manager controller. SMTP is configured correctly.";
 
-/** UGA-branded signature used by every email unless an admin replaces it on the Templates page. */
-export const DEFAULT_EMAIL_SIGNATURE_HTML = `<div id="template2" class="signature">
-  <p style="margin-bottom: 1em; font: 12px 'Georgia', 'Times', 'sans-serif';">
-    <span style="font-weight: 900;">Ningxi Cheng</span><span style="font-weight: 900;">, Graduate Research Assistant</span>
-    <br>
-    <span>School of Computing | <span style="font-style: italic;">Ph.D. Student</span></span>
-  </p>
-  <p style="margin-bottom: 1em; font: 12px 'Georgia', 'Times', 'sans-serif';">
-    <span><a href="mailto:edwardcheng@uga.edu">edwardcheng@uga.edu</a></span>
-  </p>
-  <div class="logo"><img width="160" src="https://brand.uga.edu/email-signature-builder/assets/images/uga-logo@2x.png" alt="University of Georgia"></div>
-</div>`;
+/** Default plain-text signature used unless an admin replaces it on the Templates page. */
+export const DEFAULT_EMAIL_SIGNATURE_TEXT = `Ningxi Cheng, Graduate Research Assistant
+School of Computing | Ph.D. Student
+edwardcheng@uga.edu
+University of Georgia`;
 
 export const DEFAULT_SETTINGS: Settings = {
   fastQuotaDefaultBytes: 2 * TIB,
@@ -232,7 +224,7 @@ export const DEFAULT_SETTINGS: Settings = {
   smtpPass: "",
   smtpFrom: "",
   smtpSecure: false,
-  emailSignatureHtml: DEFAULT_EMAIL_SIGNATURE_HTML,
+  emailSignatureText: DEFAULT_EMAIL_SIGNATURE_TEXT,
   sshHostOverride: "",
   welcomeEmailSubject: DEFAULT_WELCOME_SUBJECT,
   welcomeEmailBody: DEFAULT_WELCOME_BODY,

--- a/controller/src/lib/template.ts
+++ b/controller/src/lib/template.ts
@@ -19,3 +19,35 @@ export function renderTemplate(template: string, vars: Record<string, string | n
 export function stripLegacyEmailSignature(text: string): string {
   return text.replace(/\n*\s*—\s*Lab Manager\s*$/i, "").trimEnd();
 }
+
+/** Convert a legacy HTML signature to plain text during the settings migration. */
+export function legacySignatureHtmlToText(html: string): string {
+  const namedEntities: Record<string, string> = {
+    amp: "&",
+    apos: "'",
+    gt: ">",
+    lt: "<",
+    nbsp: " ",
+    quot: '"',
+  };
+  const text = html
+    .replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi, "")
+    .replace(/<img\b[^>]*\balt\s*=\s*(["'])(.*?)\1[^>]*>/gi, "\n$2\n")
+    .replace(/<br\s*\/?\s*>/gi, "\n")
+    .replace(/<\/(div|p|li|tr|h[1-6])\s*>/gi, "\n")
+    .replace(/<[^>]+>/g, "");
+
+  return text
+    .replace(/&(#x[\da-f]+|#\d+|\w+);/gi, (whole, entity: string) => {
+      if (entity[0] !== "#") return namedEntities[entity.toLowerCase()] ?? whole;
+      const hex = entity[1]?.toLowerCase() === "x";
+      const codePoint = Number.parseInt(entity.slice(hex ? 2 : 1), hex ? 16 : 10);
+      return Number.isFinite(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff
+        ? String.fromCodePoint(codePoint)
+        : whole;
+    })
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n[ \t]+/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}

--- a/controller/tests/mailer.test.ts
+++ b/controller/tests/mailer.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { legacySignatureHtmlToText } from "../src/lib/template";
 
 const tmp = mkdtempSync(join(tmpdir(), "lab-ctl-mailer-"));
 process.env.DB_PATH = join(tmp, "controller.db");
@@ -64,7 +65,7 @@ describe("sendMail gating", () => {
     expect(res).toEqual({ sent: true });
     expect(sent[0]).toMatchObject({ from: "labs@uga.edu", to: "a@uga.edu", subject: "Subject" });
     expect(sent[0].text).toContain("Body\n\nNingxi Cheng, Graduate Research Assistant");
-    expect(sent[0].html).toContain("uga-logo@2x.png");
+    expect(sent[0]).not.toHaveProperty("html");
   });
 
   it("returns the error message when the transport throws", async () => {
@@ -73,6 +74,14 @@ describe("sendMail gating", () => {
     const res = await mailer.sendMail("a@uga.edu", "s", "b");
     expect(res.sent).toBe(false);
     expect(res.error).toBe("smtp down");
+  });
+});
+
+describe("legacy signature migration", () => {
+  it("converts saved HTML into readable plain text", () => {
+    const html =
+      '<div><strong>Research &amp; Compute</strong><br><a href="mailto:team@uga.edu">team@uga.edu</a><img src="logo.png" alt="UGA"></div>';
+    expect(legacySignatureHtmlToText(html)).toBe("Research & Compute\nteam@uga.edu\nUGA");
   });
 });
 
@@ -181,18 +190,13 @@ describe("templated emails", () => {
     }
   });
 
-  it("uses one editable signature for both HTML and plain-text email alternatives", async () => {
-    settings.setSetting(
-      "emailSignatureHtml",
-      '<div><strong>Research Team</strong><br><a href="mailto:team@uga.edu">team@uga.edu</a></div>',
-    );
+  it("preserves body formatting and appends the editable plain-text signature", async () => {
+    settings.setSetting("emailSignatureText", "Research Team\nteam@uga.edu");
 
     await mailer.sendMail("a@uga.edu", "Signed", "Message body\nsecond line\n\n— Lab Manager");
 
     expect(sent[0].text).toBe("Message body\nsecond line\n\nResearch Team\nteam@uga.edu");
-    expect(sent[0].html).toContain("Message body\nsecond line");
-    expect(sent[0].html).toContain("<strong>Research Team</strong>");
-    expect(sent[0].html).not.toContain("— Lab Manager");
-    settings.setSetting("emailSignatureHtml", settings.DEFAULT_EMAIL_SIGNATURE_HTML);
+    expect(sent[0]).not.toHaveProperty("html");
+    settings.setSetting("emailSignatureText", settings.DEFAULT_EMAIL_SIGNATURE_TEXT);
   });
 });


### PR DESCRIPTION
## Summary
- send outbound email as plain text only so clients preserve line breaks
- replace the HTML signature editor with a plain-text signature field
- migrate existing saved HTML signatures to readable plain text

## Validation
- npm test (232 tests)
- npm run typecheck
- npm run lint