### PR TITLE
Back Docker's data-root with a native ZFS dataset, drop overlay2

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,11 @@ No additional shared or per-user dataset layers are created.
 
 ## 1. Prepare every host
 
-Use a dedicated Ubuntu 22.04/24.04 node with Docker Engine, ZFS, AppArmor, NVIDIA drivers and
-NVIDIA Container Toolkit where GPUs are present. Every node must reserve the same IDs:
+Use a dedicated Ubuntu 22.04/24.04 node. `host-prepare` installs Docker Engine, ZFS tools, and
+AppArmor tooling itself (see below); the only prerequisites it does NOT automate are the zpool
+layout (disk topology is hardware-specific) and, on GPU nodes, the NVIDIA driver itself (needs a
+reboot and a hardware-matched version — install it before running `host-prepare`, which then adds
+the NVIDIA Container Toolkit once it sees GPU hardware). Every node must reserve the same IDs:
 
 ```text
 user:  labdockremap
@@ -33,27 +36,35 @@ student container IDs: 10000-59999
 mapped host ID: 231072 + container ID
 ```
 
-Create the storage roots. The agent creates the per-lab datasets, but the pools and Docker backing
-filesystem must already exist:
+Create the storage roots. The agent creates the per-lab datasets, but the pools must already exist:
 
 ```bash
 sudo zfs create -o mountpoint=/fast fast/labs
 sudo zfs create slow/labs                    # local cold-storage nodes only
 ```
 
-Choose one rootfs-quota-capable Docker backing store before `host-prepare`:
+`host-prepare` provisions the Docker backing store itself as a native ZFS dataset on the fast pool
+(`<fast_pool>/<docker_dataset_name>`, default `fast/docker`) mounted directly at the `data-root`,
+with `storage-driver: zfs` in `daemon.json`, **but only once the fast pool (and, on a local ZFS
+cold tier, the slow pool too) actually exist**. If the zpool(s) aren't there yet — e.g. this is a
+brand-new node and disks/zpools haven't been provisioned — `host-prepare` just installs Docker on
+its plain default backing store instead of failing outright; `lab-agent doctor` accepts that as
+expected until the pools show up (it already reports them missing separately). Docker's zfs driver
+clones the dataset per image layer and per container, so a configured `rootfs_quota`
+(`--storage-opt size=`) is enforced via ZFS's own `quota` property on each container's clone — no
+XFS, no zvol, no `/etc/fstab` entry to maintain. The dataset itself is capped by `docker_quota_gb`
+(default 1024 GiB; `0` = unlimited, sharing the rest of the fast pool). Unlike a zvol this is a
+**live** property: change `docker_quota_gb` and re-run `host-prepare` to resize immediately, with
+no unmount or reboot.
 
-```bash
-# ZFS option: put Docker's data-root on a dedicated dataset and set "storage-driver": "zfs"
-sudo systemctl stop docker
-sudo zfs create -o mountpoint=/var/lib/docker fast/docker
+Whenever the dataset doesn't exist yet and the data-root already has content — a fresh docker-ce
+install's just-created default state, or a data-root Docker has genuinely been running against
+under the plain backing store because the zpool(s) only just appeared — that content is moved
+aside, the dataset is created at the same mountpoint, and the content is copied back into it before
+the backup is removed. Nothing is discarded and nothing is left duplicated on the old filesystem.
 
-# OR overlay2 option: mount an XFS filesystem at /var/lib/docker with prjquota/pquota.
-findmnt -no FSTYPE,OPTIONS /var/lib/docker
-```
-
-The doctor rejects other storage drivers and rejects `overlay2` unless its backing filesystem is
-XFS with project quotas. This prevents a configured `rootfs_quota` from silently doing nothing.
+Once the fast (and, if applicable, slow) pool(s) exist, the doctor rejects any storage driver other
+than `zfs`; before that it accepts whatever Docker's plain install picked.
 
 If cold storage is SMB, mount it at the configured `slow_path` before starting the agent. The share
 must preserve numeric POSIX ownership and permit `chown`; an absent mount is a hard failure and the
@@ -71,8 +82,21 @@ sudo lab-agent host-prepare
 
 `host-prepare` is idempotent and does all of the following:
 
+- installs Docker Engine (from Docker's official apt repo), `zfsutils-linux`, and AppArmor tooling
+  if missing — a fully unprovisioned node needs nothing pre-installed but the OS itself; on an
+  already-provisioned node this step is a handful of fast `dpkg` checks and touches the network
+  only when something is actually missing;
+- installs `nvidia-container-toolkit` (from NVIDIA's official apt repo) when it detects NVIDIA GPU
+  hardware and the package isn't already present — it never installs the NVIDIA driver itself;
 - creates `labdockremap` and exact `/etc/subuid` and `/etc/subgid` entries;
-- writes Docker `userns-remap` and `data-root`, then restarts Docker;
+- once the fast (and, if applicable, slow) zpool(s) exist, provisions the
+  `<fast_pool>/<docker_dataset_name>` ZFS dataset, mounts it at the `data-root` (migrating in any
+  existing content first), and applies `docker_quota_gb` as a live ZFS quota — otherwise leaves
+  Docker on its plain default backing store;
+- writes Docker `userns-remap` and `data-root`, adds `storage-driver=zfs` once the dataset above is
+  in use, and on GPU nodes pins `exec-opts: ["native.cgroupdriver=cgroupfs"]` to work around a
+  [known runc/systemd-cgroup-driver bug](https://github.com/opencontainers/runc/discussions/1133)
+  that drops a container's GPU device access on `systemctl daemon-reload`, then restarts Docker;
 - enforces `kernel.unprivileged_userns_clone=1`, `user.max_user_namespaces=16384`, and
   `kernel.apparmor_restrict_unprivileged_userns=1`;
 - installs and loads `lab-codex-seccomp.json`, `lab-codex`, and the distribution

--- a/agent/src/lab_agent/config.py
+++ b/agent/src/lab_agent/config.py
@@ -26,6 +26,14 @@ DEFAULT_USERNS_START = 231_072
 DEFAULT_USERNS_SIZE = 65_536
 DEFAULT_FAST_MOUNT_ROOT = "/fast"
 DEFAULT_DOCKER_DATA_ROOT = "/var/lib/docker"
+# Docker's data-root is a native ZFS dataset on the fast pool (storage-driver "zfs"): every image
+# layer and container is its own ZFS clone, and its rootfs_quota storage-opt maps straight onto the
+# clone's "quota" property. The dataset lives at <fast_pool>/<dataset-name>.
+DEFAULT_DOCKER_DATASET_NAME = "docker"
+# ZFS "quota" (GiB) applied to the dataset on every host-prepare run; 0 means unlimited (shares the
+# rest of the fast pool). Unlike a zvol this is a live property: change it and re-run host-prepare
+# to resize immediately, with no unmount/reformat/reboot.
+DEFAULT_DOCKER_QUOTA_GB = 1024
 DEFAULT_SECCOMP_PROFILE = "/etc/lab-agent/security/lab-codex-seccomp.json"
 DEFAULT_APPARMOR_PROFILE = "lab-codex"
 
@@ -58,6 +66,9 @@ class AgentConfig:
     userns_start: int = DEFAULT_USERNS_START
     userns_size: int = DEFAULT_USERNS_SIZE
     docker_data_root: str = DEFAULT_DOCKER_DATA_ROOT
+    # Name of the fast-pool dataset backing the Docker data-root (full name: <fast_pool>/<name>).
+    docker_dataset_name: str = DEFAULT_DOCKER_DATASET_NAME
+    docker_quota_gb: int = DEFAULT_DOCKER_QUOTA_GB
     seccomp_profile: str = DEFAULT_SECCOMP_PROFILE
     apparmor_profile: str = DEFAULT_APPARMOR_PROFILE
     # Local cache DB for the durable task buffer + offline event/log buffer.
@@ -87,6 +98,11 @@ class AgentConfig:
     @property
     def slow_is_zfs(self) -> bool:
         return self.slow_backend != SLOW_BACKEND_SMB
+
+    @property
+    def docker_dataset(self) -> str:
+        """Full ZFS dataset name backing Docker's data-root."""
+        return f"{self.fast_pool}/{self.docker_dataset_name}"
 
     @property
     def labs_fast_root(self) -> str:
@@ -145,6 +161,8 @@ def load_config(path: Path | None = None) -> AgentConfig:
         "userns_start",
         "userns_size",
         "docker_data_root",
+        "docker_dataset_name",
+        "docker_quota_gb",
         "seccomp_profile",
         "apparmor_profile",
         "state_db",
@@ -192,6 +210,8 @@ def render_config(cfg: AgentConfig) -> str:
         "userns_start",
         "userns_size",
         "docker_data_root",
+        "docker_dataset_name",
+        "docker_quota_gb",
         "seccomp_profile",
         "apparmor_profile",
         "state_db",

--- a/agent/src/lab_agent/hostprep.py
+++ b/agent/src/lab_agent/hostprep.py
@@ -1,4 +1,11 @@
-"""Idempotent host preparation for Docker userns-remap and the Codex/bubblewrap profiles."""
+"""Idempotent host preparation for Docker userns-remap and the Codex/bubblewrap profiles.
+
+Besides converging config, this installs everything host-prepare itself depends on: Docker Engine
+(from Docker's official apt repo), ZFS userspace tools, AppArmor tooling, and — only when NVIDIA
+GPU hardware is present — the NVIDIA Container Toolkit. It never installs the NVIDIA kernel driver
+itself (needs a reboot and hardware-specific version choice) or creates zpools (disk topology is
+the operator's call); both remain documented manual prerequisites.
+"""
 
 from __future__ import annotations
 
@@ -7,18 +14,38 @@ import json
 import os
 import pwd
 import shutil
+from collections.abc import Sequence
 from importlib import resources
 from pathlib import Path
 from typing import Any
 
 from .config import AgentConfig
 from .executors.base import run
+from .system import _nvidia_hardware_count, _pool_exists
 
 DAEMON_JSON = Path("/etc/docker/daemon.json")
 SUBUID = Path("/etc/subuid")
 SUBGID = Path("/etc/subgid")
 SYSCTL_FILE = Path("/etc/sysctl.d/90-lab-codex.conf")
 APPARMOR_DEST = Path("/etc/apparmor.d/lab-codex")
+
+# Packages available from the default Ubuntu archive. ca-certificates/curl/gnupg are fetched first
+# because adding the Docker/NVIDIA apt repos below needs them.
+PREREQ_APT_PACKAGES = ("ca-certificates", "curl", "gnupg")
+CORE_APT_PACKAGES = ("zfsutils-linux", "apparmor", "apparmor-utils")
+DOCKER_APT_PACKAGES = (
+    "docker-ce", "docker-ce-cli", "containerd.io", "docker-buildx-plugin", "docker-compose-plugin",
+)
+NVIDIA_APT_PACKAGES = ("nvidia-container-toolkit",)
+
+DOCKER_GPG_KEY = Path("/etc/apt/keyrings/docker.asc")
+DOCKER_APT_LIST = Path("/etc/apt/sources.list.d/docker.list")
+NVIDIA_GPG_KEY = Path("/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg")
+NVIDIA_APT_LIST = Path("/etc/apt/sources.list.d/nvidia-container-toolkit.list")
+NVIDIA_GPG_KEY_URL = "https://nvidia.github.io/libnvidia-container/gpgkey"
+NVIDIA_APT_LIST_URL = (
+    "https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list"
+)
 
 
 def mapped_host_id(cfg: AgentConfig, container_id: int) -> int:
@@ -27,11 +54,50 @@ def mapped_host_id(cfg: AgentConfig, container_id: int) -> int:
     return cfg.userns_start + container_id
 
 
-def merge_daemon_config(current: dict[str, Any], cfg: AgentConfig) -> dict[str, Any]:
+# Certain runc versions drop a container's access to its GPU device nodes on `systemctl
+# daemon-reload` when using the systemd cgroup driver and the NVIDIA driver hasn't created the
+# /dev/char symlinks those runc versions need to re-apply the device cgroup rule (see
+# https://github.com/opencontainers/runc/discussions/1133). Docker's own cgroupfs driver isn't
+# affected, so GPU nodes get pinned to it.
+NVIDIA_CGROUPFS_EXEC_OPT = "native.cgroupdriver=cgroupfs"
+
+
+def merge_daemon_config(current: dict[str, Any], cfg: AgentConfig, *, use_zfs: bool,
+                         gpu_present: bool) -> dict[str, Any]:
     merged = dict(current)
     merged["userns-remap"] = cfg.userns_user
     merged["data-root"] = cfg.docker_data_root
+    if use_zfs:
+        # The data-root is a native ZFS dataset; the zfs graphdriver clones it per layer/container
+        # and honours --storage-opt size via ZFS's own "quota" property.
+        merged["storage-driver"] = "zfs"
+    if gpu_present:
+        # Replace rather than append: Docker rejects daemon.json if "native.cgroupdriver" appears
+        # in exec-opts more than once, so any prior value (ours from an earlier run, or an
+        # operator's) is dropped in favour of the workaround.
+        exec_opts = [o for o in merged.get("exec-opts", [])
+                     if not o.startswith("native.cgroupdriver=")]
+        exec_opts.append(NVIDIA_CGROUPFS_EXEC_OPT)
+        merged["exec-opts"] = exec_opts
     return merged
+
+
+def docker_quota_zfs_value(quota_gb: int) -> str:
+    """ZFS "quota" property value for a GiB cap, or "none" for unlimited (mirrors the "0" = no
+    quota convention Docker's own zfs storage driver uses for --storage-opt size)."""
+    return f"{int(quota_gb)}G" if quota_gb else "none"
+
+
+def docker_apt_source_line(arch: str, codename: str) -> str:
+    return (
+        f"deb [arch={arch} signed-by={DOCKER_GPG_KEY}] "
+        f"https://download.docker.com/linux/ubuntu {codename} stable\n"
+    )
+
+
+def rewrite_nvidia_apt_list(raw: str) -> str:
+    """Inject signed-by=<our keyring> into NVIDIA's published sources.list content."""
+    return raw.replace("deb https://", f"deb [signed-by={NVIDIA_GPG_KEY}] https://")
 
 
 def replace_subid_entry(text: str, user: str, start: int, size: int) -> str:
@@ -66,6 +132,113 @@ def _write(path: Path, text: str, mode: int = 0o644) -> None:
 def _require_root() -> None:
     if os.geteuid() != 0:
         raise PermissionError("host-prepare must run as root")
+
+
+def _dpkg_installed(pkg: str) -> bool:
+    result = run(["dpkg-query", "-W", "-f=${Status}", pkg], timeout=15)
+    return result.ok and "install ok installed" in result.stdout
+
+
+def _missing_packages(names: Sequence[str]) -> list[str]:
+    return [name for name in names if not _dpkg_installed(name)]
+
+
+def _apt_update() -> None:
+    result = run(["apt-get", "update"], timeout=180)
+    if not result.ok:
+        raise RuntimeError(f"apt-get update failed: {result.logs}")
+
+
+def _apt_install(packages: Sequence[str]) -> None:
+    missing = _missing_packages(packages)
+    if not missing:
+        return
+    result = run(
+        ["apt-get", "install", "-y",
+         "-o", "Dpkg::Options::=--force-confdef", "-o", "Dpkg::Options::=--force-confold",
+         *missing],
+        timeout=600,
+    )
+    if not result.ok:
+        raise RuntimeError(f"apt-get install failed for {', '.join(missing)}: {result.logs}")
+
+
+def _os_codename() -> str:
+    try:
+        text = Path("/etc/os-release").read_text(encoding="utf-8")
+    except OSError as exc:
+        raise RuntimeError(f"cannot read /etc/os-release: {exc}") from exc
+    for line in text.splitlines():
+        if line.startswith("VERSION_CODENAME="):
+            return line.split("=", 1)[1].strip().strip('"')
+    raise RuntimeError("VERSION_CODENAME not found in /etc/os-release")
+
+
+def _dpkg_arch() -> str:
+    result = run(["dpkg", "--print-architecture"], timeout=10)
+    if not result.ok:
+        raise RuntimeError(f"could not determine dpkg architecture: {result.logs}")
+    return result.stdout.strip()
+
+
+def _ensure_docker_apt_repo() -> bool:
+    """Add Docker's official apt repo + signing key if missing. Returns True if newly added."""
+    if DOCKER_GPG_KEY.exists() and DOCKER_APT_LIST.exists():
+        return False
+    key = run(["curl", "-fsSL", "https://download.docker.com/linux/ubuntu/gpg"], timeout=30)
+    if not key.ok or not key.stdout.strip():
+        raise RuntimeError(f"could not fetch the Docker apt signing key: {key.logs}")
+    _write(DOCKER_GPG_KEY, key.stdout, mode=0o644)
+    _write(DOCKER_APT_LIST, docker_apt_source_line(_dpkg_arch(), _os_codename()))
+    return True
+
+
+def _ensure_nvidia_apt_repo() -> bool:
+    """Add the NVIDIA Container Toolkit apt repo + signing key if missing. Returns True if newly
+    added."""
+    if NVIDIA_GPG_KEY.exists() and NVIDIA_APT_LIST.exists():
+        return False
+    key = run(["curl", "-fsSL", NVIDIA_GPG_KEY_URL], timeout=30)
+    if not key.ok or not key.stdout.strip():
+        raise RuntimeError(f"could not fetch the NVIDIA apt signing key: {key.logs}")
+    NVIDIA_GPG_KEY.parent.mkdir(parents=True, exist_ok=True)
+    dearmored = run(["gpg", "--yes", "--dearmor", "-o", str(NVIDIA_GPG_KEY)],
+                     timeout=15, input_text=key.stdout)
+    if not dearmored.ok:
+        raise RuntimeError(f"could not dearmor the NVIDIA apt signing key: {dearmored.logs}")
+    listing = run(["curl", "-fsSL", NVIDIA_APT_LIST_URL], timeout=30)
+    if not listing.ok or not listing.stdout.strip():
+        raise RuntimeError(f"could not fetch the NVIDIA apt repo list: {listing.logs}")
+    _write(NVIDIA_APT_LIST, rewrite_nvidia_apt_list(listing.stdout))
+    return True
+
+
+def _ensure_base_packages() -> bool:
+    """Install Docker Engine, ZFS tools, and AppArmor tooling. Returns True if Docker Engine was
+    newly installed by this call (as opposed to already present from an earlier run or a prior,
+    unmanaged install)."""
+    os.environ.setdefault("DEBIAN_FRONTEND", "noninteractive")
+    if _missing_packages(PREREQ_APT_PACKAGES):
+        _apt_update()
+        _apt_install(PREREQ_APT_PACKAGES)
+
+    repo_added = _ensure_docker_apt_repo()
+    docker_missing = _missing_packages(DOCKER_APT_PACKAGES)
+    if repo_added or docker_missing or _missing_packages(CORE_APT_PACKAGES):
+        _apt_update()
+    _apt_install(CORE_APT_PACKAGES)
+    _apt_install(DOCKER_APT_PACKAGES)
+    return bool(docker_missing)
+
+
+def _ensure_nvidia_toolkit_if_present(gpu_present: bool) -> None:
+    """Install nvidia-container-toolkit when NVIDIA GPU hardware is present. Never touches the
+    proprietary driver itself; that stays a manual, reboot-requiring operator step."""
+    if not gpu_present or not _missing_packages(NVIDIA_APT_PACKAGES):
+        return
+    if _ensure_nvidia_apt_repo():
+        _apt_update()
+    _apt_install(NVIDIA_APT_PACKAGES)
 
 
 def _ensure_account(user: str) -> None:
@@ -109,9 +282,89 @@ def _install_security_assets(cfg: AgentConfig) -> None:
             raise RuntimeError(f"could not load bwrap-userns-restrict: {loaded.logs}")
 
 
+def _zfs_pools_ready(cfg: AgentConfig) -> bool:
+    """Whether the zpool(s) the Docker ZFS dataset depends on already exist. Disk topology is an
+    operator decision made outside host-prepare (see module docstring); until the pool(s) show up,
+    Docker gets a plain install on its own default backing store instead of a hard failure."""
+    if not _pool_exists(cfg.fast_pool):
+        return False
+    return not cfg.slow_is_zfs or _pool_exists(cfg.slow_pool)
+
+
+def _create_docker_dataset(cfg: AgentConfig) -> None:
+    created = run([
+        "zfs", "create", "-o", "atime=off", "-o", "compression=lz4",
+        "-o", f"mountpoint={cfg.docker_data_root}", cfg.docker_dataset,
+    ], timeout=60)
+    if not created.ok:
+        raise RuntimeError(f"could not create Docker dataset {cfg.docker_dataset}: {created.logs}")
+
+
+def _migrate_data_root_into_dataset(cfg: AgentConfig, root: Path) -> None:
+    """Move aside whatever currently occupies the data-root, create the ZFS dataset at that same
+    mountpoint, and copy the content back in. Covers both a fresh docker-ce install's just-created
+    default state and a data-root Docker has actually been running against under a different
+    backing store (e.g. the zpool(s) only just appeared on a node that already had Docker plainly
+    installed) — either way nothing here is discarded until it is safely copied into the dataset."""
+    backup = root.with_name(f"{root.name}.pre-zfs.bak")
+    if backup.exists():
+        shutil.rmtree(backup)
+    root.rename(backup)
+    root.mkdir(parents=True, exist_ok=True)
+    _create_docker_dataset(cfg)
+    copied = run(["cp", "-a", f"{backup}/.", str(root)], timeout=3600)
+    if not copied.ok:
+        raise RuntimeError(f"could not migrate {backup} into {cfg.docker_dataset}: {copied.logs}")
+    shutil.rmtree(backup)
+
+
+def _prepare_docker_storage(cfg: AgentConfig) -> bool:
+    """Back Docker's data-root with a native ZFS dataset (storage-driver "zfs") once the fast (and,
+    for a local ZFS cold tier, slow) pool(s) exist. Returns whether ZFS is now in use, so the
+    daemon.json write can agree with what actually happened here. Until the pool(s) show up, this
+    is a no-op and Docker is left on its plain default backing store.
+
+    Converges to: a fast-pool dataset mounted at the data-root with the configured quota applied.
+    Docker manages per-layer/per-container clones inside it directly; there is no filesystem to
+    format and no /etc/fstab entry to maintain. If the data-root already has content when the pools
+    first appear — Docker having run a while on its plain default store — that content is migrated
+    into the new dataset rather than left behind.
+    """
+    if not _zfs_pools_ready(cfg):
+        return False
+
+    run(["systemctl", "stop", "docker.socket"], timeout=60)
+    run(["systemctl", "stop", "docker"], timeout=120)
+
+    exists = run(["zfs", "list", "-H", "-o", "name", cfg.docker_dataset], timeout=20).ok
+    if not exists:
+        root = Path(cfg.docker_data_root)
+        root.mkdir(parents=True, exist_ok=True)
+        if any(root.iterdir()):
+            _migrate_data_root_into_dataset(cfg, root)
+        else:
+            _create_docker_dataset(cfg)
+    else:
+        mounted = run(["zfs", "mount", cfg.docker_dataset], timeout=30)
+        if not mounted.ok and "already mounted" not in mounted.logs.lower():
+            raise RuntimeError(f"could not mount {cfg.docker_dataset}: {mounted.logs}")
+
+    quota = run(
+        ["zfs", "set", f"quota={docker_quota_zfs_value(cfg.docker_quota_gb)}", cfg.docker_dataset],
+        timeout=20,
+    )
+    if not quota.ok:
+        raise RuntimeError(f"could not set quota on {cfg.docker_dataset}: {quota.logs}")
+    return True
+
+
 def prepare_host(cfg: AgentConfig) -> dict[str, Any]:
     """Configure one node. Re-running converges to the same files and daemon settings."""
     _require_root()
+    gpu_present = _nvidia_hardware_count() > 0
+    _ensure_base_packages()
+    _ensure_nvidia_toolkit_if_present(gpu_present)
+
     if not Path("/proc/self/ns/user").exists():
         raise RuntimeError("kernel lacks user namespace support")
     try:
@@ -143,14 +396,17 @@ def prepare_host(cfg: AgentConfig) -> dict[str, Any]:
         raise RuntimeError(applied.logs)
 
     _install_security_assets(cfg)
+
+    docker_on_zfs = _prepare_docker_storage(cfg)
+
     current: dict[str, Any] = {}
     if DAEMON_JSON.exists():
         try:
             current = json.loads(DAEMON_JSON.read_text(encoding="utf-8"))
         except json.JSONDecodeError as exc:
             raise RuntimeError(f"invalid {DAEMON_JSON}: {exc}") from exc
-    Path(cfg.docker_data_root).mkdir(parents=True, exist_ok=True)
-    _write(DAEMON_JSON, json.dumps(merge_daemon_config(current, cfg), indent=2) + "\n")
+    merged = merge_daemon_config(current, cfg, use_zfs=docker_on_zfs, gpu_present=gpu_present)
+    _write(DAEMON_JSON, json.dumps(merged, indent=2) + "\n")
 
     if shutil.which("nvidia-ctk"):
         Path("/etc/cdi").mkdir(parents=True, exist_ok=True)
@@ -172,6 +428,10 @@ def prepare_host(cfg: AgentConfig) -> dict[str, Any]:
         "userns_user": cfg.userns_user,
         "subordinate_range": [cfg.userns_start, cfg.userns_size],
         "docker_data_root": cfg.docker_data_root,
+        "docker_storage_driver": "zfs" if docker_on_zfs else "default",
+        "docker_dataset": cfg.docker_dataset if docker_on_zfs else None,
+        "docker_quota_gb": cfg.docker_quota_gb if docker_on_zfs else None,
+        "gpu_cgroupfs_workaround": gpu_present,
         "seccomp_profile": cfg.seccomp_profile,
         "apparmor_profile": cfg.apparmor_profile,
     }

--- a/agent/src/lab_agent/system.py
+++ b/agent/src/lab_agent/system.py
@@ -78,7 +78,7 @@ class Capabilities:
         return asdict(self)
 
 
-DOCKER_DRIVERS_OK = ("zfs", "overlay2")
+DOCKER_DRIVERS_OK = ("zfs",)
 
 
 def _issue(items: list[HealthIssue], code: str, severity: str, message: str,
@@ -124,20 +124,6 @@ def _docker_root_ok(cfg: AgentConfig) -> bool:
     result = run(["docker", "info", "--format", "{{.DockerRootDir}}"], timeout=20)
     return result.ok and os.path.realpath(result.stdout.strip()) == os.path.realpath(
         cfg.docker_data_root
-    )
-
-
-def _overlay_quota_ok(cfg: AgentConfig) -> bool:
-    backing_fmt = (
-        '{{range .DriverStatus}}{{if eq (index . 0) "Backing Filesystem"}}'
-        "{{index . 1}}{{end}}{{end}}"
-    )
-    backing = run(["docker", "info", "--format", backing_fmt], timeout=20)
-    if not backing.ok or backing.stdout.strip().lower() != "xfs":
-        return False
-    options = run(["findmnt", "-no", "OPTIONS", cfg.docker_data_root], timeout=20)
-    return options.ok and any(
-        option in options.stdout.split(",") for option in ("pquota", "prjquota")
     )
 
 
@@ -264,6 +250,13 @@ def detect_capabilities(cfg: AgentConfig, *, deep: bool = True) -> Capabilities:
     if not zfs_ok:
         _issue(issues, "zfs_missing", "critical", "ZFS is unavailable")
 
+    # host-prepare only puts Docker's data-root on a ZFS dataset once the pool(s) it needs exist
+    # (see hostprep._zfs_pools_ready); before that, a plain install on the default backing store is
+    # expected and the missing pool(s) are already flagged below via fast/cold_storage_missing.
+    zfs_pools_ready = zfs_ok and _pool_exists(cfg.fast_pool) and (
+        not cfg.slow_is_zfs or _pool_exists(cfg.slow_pool)
+    )
+
     docker_ok = run(["docker", "version", "--format", "{{.Server.Version}}"], timeout=20).ok
     driver = ""
     if docker_ok:
@@ -271,15 +264,12 @@ def detect_capabilities(cfg: AgentConfig, *, deep: bool = True) -> Capabilities:
         driver = result.stdout.strip() if result.ok else ""
     else:
         _issue(issues, "docker_unavailable", "critical", "Docker daemon is unreachable")
-    if docker_ok and driver not in DOCKER_DRIVERS_OK:
+    if docker_ok and zfs_pools_ready and driver not in DOCKER_DRIVERS_OK:
         _issue(issues, "docker_storage_driver", "critical",
                f"Docker storage driver '{driver or 'unknown'}' is unsupported")
     if docker_ok and not _docker_root_ok(cfg):
         _issue(issues, "docker_data_root", "critical",
                f"Docker data-root does not match '{cfg.docker_data_root}'", True)
-    if docker_ok and driver == "overlay2" and not _overlay_quota_ok(cfg):
-        _issue(issues, "docker_rootfs_quota", "critical",
-               "overlay2 rootfs quotas require XFS mounted with pquota/prjquota")
 
     userns_ok = docker_ok and _docker_userns(cfg)
     if docker_ok and not userns_ok:

--- a/agent/tests/test_hostprep.py
+++ b/agent/tests/test_hostprep.py
@@ -3,17 +3,41 @@ from importlib import resources
 
 import pytest
 
+from lab_agent import hostprep
 from lab_agent.config import AgentConfig
+from lab_agent.executors.base import CommandResult
+from lab_agent.executors.base import run as real_run
 from lab_agent.hostprep import (
+    docker_apt_source_line,
+    docker_quota_zfs_value,
     mapped_host_id,
     merge_daemon_config,
     replace_subid_entry,
+    rewrite_nvidia_apt_list,
     subid_conflicts,
 )
 
 
 def cfg():
     return AgentConfig(controller_url="ws://x", token="t")
+
+
+class Runner:
+    """Fakes the zfs/systemctl calls host-prepare issues; anything unlisted (e.g. `cp -a`) falls
+    through to a real subprocess so filesystem side effects can be checked for real."""
+
+    def __init__(self, responses):
+        self.responses = responses
+        self.calls = []
+
+    def __call__(self, args, **kwargs):
+        command = " ".join(str(x) for x in args)
+        self.calls.append(command)
+        for prefix, value in self.responses.items():
+            if command.startswith(prefix):
+                ok, stdout = value
+                return CommandResult(ok, list(args), 0 if ok else 1, stdout, "" if ok else "err")
+        return real_run(args, **kwargs)
 
 
 def test_host_id_translation_and_bounds():
@@ -36,10 +60,143 @@ def test_subid_entry_is_exact_and_idempotent():
 
 
 def test_daemon_config_preserves_unrelated_settings():
-    merged = merge_daemon_config({"log-driver": "journald"}, cfg())
+    merged = merge_daemon_config({"log-driver": "journald"}, cfg(), use_zfs=True, gpu_present=False)
     assert merged == {
-        "log-driver": "journald", "userns-remap": "labdockremap", "data-root": "/var/lib/docker"
+        "log-driver": "journald",
+        "userns-remap": "labdockremap",
+        "data-root": "/var/lib/docker",
+        "storage-driver": "zfs",
     }
+
+
+def test_daemon_config_without_zfs_pools_omits_storage_driver():
+    merged = merge_daemon_config({}, cfg(), use_zfs=False, gpu_present=False)
+    assert merged == {"userns-remap": "labdockremap", "data-root": "/var/lib/docker"}
+
+
+def test_daemon_config_gpu_present_pins_cgroupfs():
+    merged = merge_daemon_config({}, cfg(), use_zfs=True, gpu_present=True)
+    assert merged["exec-opts"] == ["native.cgroupdriver=cgroupfs"]
+
+
+def test_daemon_config_gpu_cgroupfs_opt_is_idempotent():
+    once = merge_daemon_config({}, cfg(), use_zfs=True, gpu_present=True)
+    twice = merge_daemon_config(once, cfg(), use_zfs=True, gpu_present=True)
+    assert twice["exec-opts"] == ["native.cgroupdriver=cgroupfs"]
+
+
+def test_daemon_config_gpu_present_replaces_conflicting_cgroupdriver_opt():
+    merged = merge_daemon_config({"exec-opts": ["native.cgroupdriver=systemd"]}, cfg(),
+                                  use_zfs=True, gpu_present=True)
+    assert merged["exec-opts"] == ["native.cgroupdriver=cgroupfs"]
+
+
+def test_daemon_config_gpu_present_preserves_unrelated_exec_opts():
+    merged = merge_daemon_config({"exec-opts": ["native.cgroupdriver=systemd", "other=1"]}, cfg(),
+                                  use_zfs=True, gpu_present=True)
+    assert merged["exec-opts"] == ["other=1", "native.cgroupdriver=cgroupfs"]
+
+
+def test_docker_dataset_follows_fast_pool():
+    c = AgentConfig(controller_url="ws://x", token="t", fast_pool="nvme")
+    assert c.docker_dataset == "nvme/docker"
+
+
+def test_zfs_pools_ready_requires_the_slow_pool_on_the_zfs_backend(monkeypatch):
+    monkeypatch.setattr(hostprep, "_pool_exists", lambda pool: pool == "fast")
+    assert not hostprep._zfs_pools_ready(cfg())
+    monkeypatch.setattr(hostprep, "_pool_exists", lambda pool: pool in {"fast", "slow"})
+    assert hostprep._zfs_pools_ready(cfg())
+
+
+def test_zfs_pools_ready_ignores_slow_pool_on_smb_backend(monkeypatch):
+    monkeypatch.setattr(hostprep, "_pool_exists", lambda pool: pool == "fast")
+    smb_cfg = AgentConfig(controller_url="ws://x", token="t", slow_backend="smb")
+    assert hostprep._zfs_pools_ready(smb_cfg)
+
+
+def test_prepare_docker_storage_is_a_noop_without_pools(monkeypatch):
+    monkeypatch.setattr(hostprep, "_pool_exists", lambda pool: False)
+    runner = Runner({})
+    monkeypatch.setattr(hostprep, "run", runner)
+    assert hostprep._prepare_docker_storage(cfg()) is False
+    assert runner.calls == []
+
+
+def test_prepare_docker_storage_creates_dataset_on_empty_root(monkeypatch, tmp_path):
+    monkeypatch.setattr(hostprep, "_pool_exists", lambda pool: True)
+    root = tmp_path / "docker"
+    root.mkdir()
+    runner = Runner({
+        "systemctl stop": (True, ""),
+        "zfs list -H -o name fast/docker": (False, ""),
+        "zfs create": (True, ""),
+        "zfs set quota=": (True, ""),
+    })
+    monkeypatch.setattr(hostprep, "run", runner)
+    c = AgentConfig(controller_url="ws://x", token="t", docker_data_root=str(root))
+    assert hostprep._prepare_docker_storage(c) is True
+    assert any(call.startswith("zfs create") for call in runner.calls)
+    assert any(call.startswith("zfs set quota=1024G fast/docker") for call in runner.calls)
+
+
+def test_prepare_docker_storage_migrates_existing_content_into_the_dataset(monkeypatch, tmp_path):
+    """Simulates the "ZFS pools appear after Docker was already installed plainly" case: the
+    data-root already has real content when the dataset is first created, and it must end up
+    inside the dataset rather than discarded or left duplicated on the old filesystem."""
+    monkeypatch.setattr(hostprep, "_pool_exists", lambda pool: True)
+    root = tmp_path / "docker"
+    root.mkdir()
+    (root / "image-layer.txt").write_text("data")
+    runner = Runner({
+        "systemctl stop": (True, ""),
+        "zfs list -H -o name fast/docker": (False, ""),
+        "zfs create": (True, ""),
+        "zfs set quota=": (True, ""),
+    })
+    monkeypatch.setattr(hostprep, "run", runner)
+    c = AgentConfig(controller_url="ws://x", token="t", docker_data_root=str(root))
+    assert hostprep._prepare_docker_storage(c) is True
+    assert (root / "image-layer.txt").read_text() == "data"
+    assert not root.with_name("docker.pre-zfs.bak").exists()
+
+
+def test_prepare_docker_storage_mounts_existing_dataset(monkeypatch, tmp_path):
+    monkeypatch.setattr(hostprep, "_pool_exists", lambda pool: True)
+    root = tmp_path / "docker"
+    runner = Runner({
+        "systemctl stop": (True, ""),
+        "zfs list -H -o name fast/docker": (True, "fast/docker"),
+        "zfs mount fast/docker": (True, ""),
+        "zfs set quota=": (True, ""),
+    })
+    monkeypatch.setattr(hostprep, "run", runner)
+    c = AgentConfig(controller_url="ws://x", token="t", docker_data_root=str(root))
+    assert hostprep._prepare_docker_storage(c) is True
+    assert any(call.startswith("zfs mount fast/docker") for call in runner.calls)
+    assert not any(call.startswith("zfs create") for call in runner.calls)
+
+
+def test_docker_quota_zfs_value():
+    assert docker_quota_zfs_value(1024) == "1024G"
+    assert docker_quota_zfs_value(0) == "none"
+
+
+def test_docker_apt_source_line():
+    line = docker_apt_source_line("amd64", "noble")
+    assert line == (
+        "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] "
+        "https://download.docker.com/linux/ubuntu noble stable\n"
+    )
+
+
+def test_rewrite_nvidia_apt_list_injects_signed_by():
+    raw = "deb https://nvidia.github.io/libnvidia-container/stable/deb/$(ARCH) /\n"
+    rewritten = rewrite_nvidia_apt_list(raw)
+    assert rewritten == (
+        "deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] "
+        "https://nvidia.github.io/libnvidia-container/stable/deb/$(ARCH) /\n"
+    )
 
 
 def test_security_assets_include_required_bubblewrap_syscalls():


### PR DESCRIPTION
## Summary
- `host-prepare` now bootstraps a bare node itself: installs Docker Engine, ZFS tools, and AppArmor tooling from apt, and adds the NVIDIA Container Toolkit when GPU hardware is detected (never touches the NVIDIA driver itself).
- Once the fast (and, on a local ZFS cold tier, slow) zpool(s) exist, Docker's data-root is provisioned as a native ZFS dataset (`<fast_pool>/<docker_dataset_name>`, `storage-driver: zfs`), with existing data-root content migrated in and `docker_quota_gb` applied as a live, resizable ZFS quota. Before the pool(s) exist, Docker is left on its plain default backing store instead of failing.
- Drops the overlay2 + XFS project-quota path entirely (`DOCKER_DRIVERS_OK` is now just `("zfs",)`); the doctor only enforces the driver check once the ZFS pool(s) are actually present.
- GPU nodes get `native.cgroupdriver=cgroupfs` pinned in `daemon.json` to work around a [runc bug](https://github.com/opencontainers/runc/discussions/1133) that drops GPU device access on `systemctl daemon-reload`.

## Test plan
- [x] `agent` test suite passes locally (200 passed, 4 skipped; 1 pre-existing unrelated failure — `test_structured_healthy_capabilities` depends on real GPU hardware detection on the dev box and fails identically on `main`)
- [ ] CI green