### PR TITLE
Fix docker_data_root check to account for userns-remap nesting

### DIFF
--- a/agent/src/lab_agent/system.py
+++ b/agent/src/lab_agent/system.py
@@ -123,10 +123,17 @@ def _docker_userns(cfg: AgentConfig) -> bool:
 
 
 def _docker_root_ok(cfg: AgentConfig) -> bool:
+    # With userns-remap active, Docker nests its real root a level deeper at
+    # <data-root>/<remapped-uid>.<remapped-gid> and reports that nested path here rather than the
+    # configured data-root itself.
     result = run(["docker", "info", "--format", "{{.DockerRootDir}}"], timeout=20)
-    return result.ok and os.path.realpath(result.stdout.strip()) == os.path.realpath(
-        cfg.docker_data_root
+    if not result.ok:
+        return False
+    actual = os.path.realpath(result.stdout.strip())
+    remapped = os.path.realpath(
+        os.path.join(cfg.docker_data_root, f"{cfg.userns_start}.{cfg.userns_start}")
     )
+    return actual in (os.path.realpath(cfg.docker_data_root), remapped)
 
 
 def _subid_ok(cfg: AgentConfig) -> bool:

--- a/agent/tests/test_system.py
+++ b/agent/tests/test_system.py
@@ -25,7 +25,7 @@ def healthy_runner():
         "zfs version": (True, "zfs-2.2"),
         "docker version": (True, "27"),
         "docker info --format {{.Driver}}": (True, "zfs"),
-        "docker info --format {{.DockerRootDir}}": (True, "/var/lib/docker"),
+        "docker info --format {{.DockerRootDir}}": (True, "/var/lib/docker/231072.231072"),
         "docker info --format {{json .SecurityOptions}}":
             (True, '["name=seccomp,profile=default","name=userns:user=labdockremap"]'),
         "sysctl -n kernel.unprivileged_userns_clone": (True, "1"),
@@ -116,3 +116,16 @@ def test_driver_or_secure_boot_failure_is_operator_only(monkeypatch):
     caps = system.detect_capabilities(cfg(), deep=False)
     issue = next(i for i in caps.issues if i.code == "nvidia_kernel_failure")
     assert issue.repairable is False
+
+
+def test_docker_root_ok_accepts_userns_remap_nested_path(monkeypatch):
+    runner = healthy_runner()
+    monkeypatch.setattr(system, "run", runner)
+    assert system._docker_root_ok(cfg())
+
+
+def test_docker_root_ok_rejects_wrong_remap_suffix(monkeypatch):
+    runner = healthy_runner()
+    runner.responses["docker info --format {{.DockerRootDir}}"] = (True, "/var/lib/docker/0.0")
+    monkeypatch.setattr(system, "run", runner)
+    assert not system._docker_root_ok(cfg())


### PR DESCRIPTION
## Summary
- `_docker_root_ok` compared Docker's `DockerRootDir` against the plain configured `docker_data_root`, but with `userns-remap` active (required on every node in this repo) Docker always nests its real root a level deeper at `<data-root>/<remapped-uid>.<remapped-gid>` — so the check could never pass on a correctly-configured node.
- Fixed the check to accept either the plain data-root or the userns-remapped nested path.
- Updated the `healthy_runner` test fixture to stub a realistic remapped `DockerRootDir` (it previously stubbed the plain path while claiming userns-remap was active, masking the bug), and added two regression tests.

## Test plan
- [x] `uv run pytest` in `agent/` — full suite passes except one pre-existing, unrelated failure (a sandbox artifact: real GPU sysfs entries inflate a mocked GPU count in a test that doesn't mock `_nvidia_hardware_count`)
- [x] New tests `test_docker_root_ok_accepts_userns_remap_nested_path` and `test_docker_root_ok_rejects_wrong_remap_suffix` cover the fix directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)