### PR TITLE
Fix grant-node-access crash, placement-removal redirect, publish custom-ssh to GHCR

### DIFF
--- a/.github/workflows/build-lab-image.yml
+++ b/.github/workflows/build-lab-image.yml
@@ -1,0 +1,85 @@
+name: Build lab image
+
+# Gated on CI: a push to main runs the "CI" workflow (which also validates this image builds via the
+# lab-image job); only once it succeeds does this publish fire. Version tags (v*) and manual runs
+# build directly without waiting on CI. Lab nodes are NVIDIA GPU hosts (amd64-only), so this is a
+# single-arch publish — no multi-arch merge needed like the controller image.
+#
+# NOTE: workflow_run always uses the copy of this file on the default branch — these changes only
+# take effect once merged to main.
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ${{ github.repository_owner }}/custom-ssh
+
+jobs:
+  build:
+    # Build on: CI success on main, or a version tag / manual dispatch. PR and rewrite/** CI runs
+    # (different head_branch/event) are filtered out so we only publish from main.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'main' &&
+       github.event.workflow_run.event == 'push')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Lowercase image
+        env:
+          image: ${{ env.IMAGE }}
+        run: echo "IMAGE_LC=${image,,}" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          # For workflow_run, check out the exact commit CI validated. Empty for push/dispatch, which
+          # falls back to the triggering ref (the tag or branch).
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - name: Docker metadata (tags + labels)
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_LC }}
+          tags: |
+            # main (workflow_run) and manual runs move :latest; a v* tag push is a release and only
+            # gets its semver tag. ('push' here is exclusively the tags: ["v*"] trigger.)
+            type=raw,value=latest,enable=${{ github.event_name != 'push' }}
+            type=sha
+            type=semver,pattern={{version}}
+
+      - name: Build and push
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        with:
+          context: ./image
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # No provenance/SBOM attestation manifest — that is the spurious "unknown/unknown" entry on
+          # the GHCR package page.
+          provenance: false
+          sbom: false
+
+      - name: Inspect manifest
+        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_LC }}:${{ steps.meta.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -119,10 +119,17 @@ sysctl kernel.unprivileged_userns_clone user.max_user_namespaces \
 
 Nodes are dedicated to managed labs because Docker user-namespace remapping is daemon-wide.
 
-## 2. Build the lab image
+## 2. Get the lab image
+
+The default image is `ghcr.io/ec061/custom-ssh:latest`, built and pushed by the `Build lab image`
+GitHub Actions workflow (`image/Dockerfile`) on every merge to main. The agent pulls it automatically
+on first use, so nodes with GHCR access need no manual step here.
+
+To customize the image or build offline instead, build it locally under that same tag and point
+placements at it (or override the image per-placement in the controller UI):
 
 ```bash
-docker build -t custom-ssh image
+docker build -t ghcr.io/ec061/custom-ssh:latest image
 ```
 
 The image contains systemd, SSH, sudo, Python, Node.js LTS, bubblewrap, uidmap, seccomp support,

--- a/agent/src/lab_agent/executors/docker.py
+++ b/agent/src/lab_agent/executors/docker.py
@@ -54,7 +54,7 @@ def container_name(lab: str) -> str:
 
 @dataclass
 class ContainerOptions:
-    image: str = "custom-ssh"
+    image: str = "ghcr.io/ec061/custom-ssh:latest"
     cpus: str = "4"
     memory: str = "8g"
     shm_size: str = "1g"

--- a/controller/src/app/(app)/labs/_components/PlacementForm.tsx
+++ b/controller/src/app/(app)/labs/_components/PlacementForm.tsx
@@ -27,6 +27,7 @@ interface Props {
 /** "Grant node access": create a placement of the lab on a node with its initial container config. */
 export function PlacementForm({ labId, nodes, defaultFastTb, defaultColdTb, action }: Props) {
   const [nodeId, setNodeId] = useState<number>(0);
+  const noNodeSelected = nodeId === 0;
   if (nodes.length === 0) {
     return (
       <p className="text-sm text-muted-foreground">
@@ -43,8 +44,13 @@ export function PlacementForm({ labId, nodes, defaultFastTb, defaultColdTb, acti
       <input type="hidden" name="labId" value={labId} />
       <div>
         <Label>Node</Label>
-        <Select name="nodeId" required value={nodeId} onChange={(e) => setNodeId(Number(e.target.value))}>
-          <option value={0} disabled>
+        <Select
+          name="nodeId"
+          required
+          value={noNodeSelected ? "" : nodeId}
+          onChange={(e) => setNodeId(Number(e.target.value))}
+        >
+          <option value="" disabled>
             Select node…
           </option>
           {nodes.map((n) => (
@@ -70,7 +76,7 @@ export function PlacementForm({ labId, nodes, defaultFastTb, defaultColdTb, acti
       </div>
       <div>
         <Label>Base image</Label>
-        <Input name="image" defaultValue="custom-ssh" />
+        <Input name="image" defaultValue="ghcr.io/ec061/custom-ssh:latest" />
       </div>
       <div>
         <Label>CPUs</Label>
@@ -100,7 +106,7 @@ export function PlacementForm({ labId, nodes, defaultFastTb, defaultColdTb, acti
           The SSH port is allocated automatically on the node. Container options are frozen after
           creation (change them via the placement&apos;s recreate action). All GPUs are always attached.
         </p>
-        <Button type="submit" disabled={blocked}>
+        <Button type="submit" disabled={blocked || noNodeSelected}>
           Grant node access
         </Button>
       </div>

--- a/controller/src/app/(app)/labs/actions.ts
+++ b/controller/src/app/(app)/labs/actions.ts
@@ -102,10 +102,10 @@ export async function grantNodeAccessAction(formData: FormData) {
   const who = await actor();
   const labId = Number(formData.get("labId"));
   const nodeId = Number(formData.get("nodeId"));
-  if (!labId || !nodeId) throw new Error("Lab and node are required");
-  const image = String(formData.get("image") ?? "").trim() || "custom-ssh";
+  const image = String(formData.get("image") ?? "").trim() || "ghcr.io/ec061/custom-ssh:latest";
   const coldTb = formData.get("coldTb");
   try {
+    if (!labId || !nodeId) throw new Error("Lab and node are required");
     await createPlacement({
       labId,
       nodeId,
@@ -175,7 +175,7 @@ export async function recreatePlacementSettingsAction(formData: FormData) {
   const placementId = Number(formData.get("placementId"));
   const placement = getPlacement(placementId);
   if (!placement) redirect("/labs");
-  const image = String(formData.get("image") ?? "").trim() || "custom-ssh";
+  const image = String(formData.get("image") ?? "").trim() || "ghcr.io/ec061/custom-ssh:latest";
   const containerOptions = containerOptionsFromForm(formData);
   try {
     recreatePlacement(placementId, { image, containerOptions }, who);
@@ -238,8 +238,10 @@ export async function removePlacementAction(formData: FormData) {
   }
   revalidatePath(`/labs/${placement.lab_id}`);
   revalidatePath(`/labs/${placement.lab_id}/placements/${placement.id}`);
-  const fid = putFlash("Removal queued. The placement remains visible until the node confirms destruction.");
-  redirect(`/labs/${placement.lab_id}/placements/${placement.id}?saved=${fid}`);
+  // Don't send the user back to the placement's own page: the row (and that page) disappears
+  // as soon as the node confirms teardown, which can race the redirect.
+  const fid = putFlash("Removal queued. The placement remains visible on the lab page until the node confirms destruction.");
+  redirect(`/labs/${placement.lab_id}?saved=${fid}`);
 }
 
 export async function addMemberAction(formData: FormData) {


### PR DESCRIPTION
## Summary
- Fix `grantNodeAccessAction` crashing with an unhandled server error (the white "server error occurred" page) when the placement form is submitted without selecting a node. Root cause: the required-field check threw outside the try/catch, and the `<select>`'s placeholder used `value={0}` instead of `""`, silently defeating native `required` validation.
- Fix `removePlacementAction` redirecting to the placement's own detail page after queuing teardown — that page 404s once the node confirms destruction and the row is deleted, which can race the redirect. Now redirects to the lab page instead.
- Publish the `custom-ssh` lab image (`image/Dockerfile`) to `ghcr.io/ec061/custom-ssh` via a new GitHub Actions workflow (mirrors the existing controller image publish workflow), and point every default image reference (agent, controller server actions, form default, README) at it instead of the bare local-only tag.

## Test plan
- [x] `npm run typecheck` (controller) — passes
- [x] `npm run lint` (controller) — passes
- [x] `npm test` (controller) — 234/234 passing
- [x] agent `pytest` — 207 passing, 1 pre-existing unrelated failure (GPU-count assertion fails on this 4-GPU host; reproduces identically on main before this change)
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)