### PR TITLE
Fix student.add: cp has no --chown flag

### DIFF
--- a/agent/src/lab_agent/executors/users.py
+++ b/agent/src/lab_agent/executors/users.py
@@ -60,7 +60,8 @@ existing_group=$(getent group {gid} | cut -d: -f1 || true)
 if [ -z "$existing_group" ]; then groupadd -g {gid} "$u"; else test "$existing_group" = "$u"; fi
 if ! id "$u" >/dev/null 2>&1; then
   useradd -M -d /home/"$u" -u {uid} -g {gid} -s /bin/bash "$u"
-  cp -a -n --chown={uid}:{gid} /etc/skel/. /home/"$u"/
+  cp -a -n /etc/skel/. /home/"$u"/
+  chown -R {uid}:{gid} /home/"$u"/
 fi
 test "$(id -u "$u")" = "{uid}"
 test "$(id -g "$u")" = "{gid}"


### PR DESCRIPTION
## Summary
- `student.add` was failing on every fresh account: `cp -a -n --chown=UID:GID /etc/skel/. ...` inside the lab container errored with `cp: unrecognized option '--chown=...'`.
- GNU coreutils `cp` has never had a `--chown` flag — that syntax belongs to `install(1)`, `docker cp`, and Dockerfile `COPY --chown`, not `cp`. This would fail on any image/coreutils version.
- Split into `cp -a -n /etc/skel/. ...` followed by `chown -R UID:GID ...`. Safe here since this block only runs once, on first-time account creation.

## Test plan
- [ ] After merge, run `sudo lab-agent upgrade` on affected nodes (e.g. `ubuntu-epyc`) to pull the fix and restart the service.
- [ ] Retry a `student.add` task and confirm the container gets a populated, correctly-owned home directory (`ls -la /home/<user>`, `id <user>`).