### PR TITLE
Allow SSH privilege-separation chroot

### DIFF
--- a/agent/src/lab_agent/assets/lab-codex-seccomp.json
+++ b/agent/src/lab_agent/assets/lab-codex-seccomp.json
@@ -9,7 +9,7 @@
     {
       "names": [
         "accept", "accept4", "access", "adjtimex", "alarm", "bind", "brk", "capget",
-        "capset", "chdir", "chmod", "chown", "clock_getres", "clock_gettime", "clock_nanosleep",
+        "capset", "chdir", "chmod", "chown", "chroot", "clock_getres", "clock_gettime", "clock_nanosleep",
         "close", "close_range", "connect", "copy_file_range", "creat", "dup", "dup2", "dup3",
         "epoll_create", "epoll_create1", "epoll_ctl", "epoll_pwait", "epoll_wait", "eventfd",
         "eventfd2", "execve", "execveat", "exit", "exit_group", "faccessat", "faccessat2",

--- a/agent/tests/test_hostprep.py
+++ b/agent/tests/test_hostprep.py
@@ -199,14 +199,14 @@ def test_rewrite_nvidia_apt_list_injects_signed_by():
     )
 
 
-def test_security_assets_include_required_bubblewrap_syscalls():
+def test_security_assets_include_required_runtime_syscalls():
     root = resources.files("lab_agent").joinpath("assets")
     profile = json.loads(root.joinpath("lab-codex-seccomp.json").read_text())
     allowed = {name for group in profile["syscalls"] if group["action"] == "SCMP_ACT_ALLOW"
                for name in group["names"]}
     assert {"clone", "clone3", "unshare", "setns", "mount", "umount2", "pivot_root",
             "fsopen", "fsconfig", "fsmount", "move_mount", "open_tree", "mount_setattr",
-            "seccomp", "prctl", "capset"} <= allowed
+            "seccomp", "prctl", "capset", "chroot"} <= allowed
     apparmor = root.joinpath("lab-codex.apparmor").read_text()
     assert "/usr/bin/bwrap cx -> lab-codex-bwrap" in apparmor
     assert "profile lab-codex-bwrap" in apparmor and "userns," in apparmor


### PR DESCRIPTION
## Summary
- allow the `chroot` syscall in the lab seccomp profile
- add a regression assertion for required runtime syscalls

## Context
OpenSSH accepts TCP connections but closes during key exchange when its pre-auth process cannot `chroot` into `/run/sshd`.

## Testing
- `uv run --extra dev pytest -q tests/test_hostprep.py tests/test_image_contract.py`
- `uv run --extra dev ruff check src tests`