### PR TITLE
Verify SSH runtime during provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ sudo lab-agent host-prepare
   `bwrap-userns-restrict` profile when available;
 - regenerates NVIDIA CDI at `/etc/cdi/nvidia.yaml` when `nvidia-ctk` is installed.
 
+Seccomp policy is fixed when Docker creates a container. If an agent upgrade changes
+`lab-codex-seccomp.json`, run `host-prepare` and recreate each existing placement; restarting its
+container does not apply the new policy. `lab-agent doctor` reports containers whose stamped
+profile digest differs from the installed profile.
+
 Inspect the resulting Docker settings before accepting work:
 
 ```bash

--- a/agent/src/lab_agent/containerops.py
+++ b/agent/src/lab_agent/containerops.py
@@ -24,6 +24,9 @@ def _labels(cfg: AgentConfig, lab: str) -> dict[str, str]:
         "lab-agent.managed": "true",
         "lab-agent.lab": lab,
         "lab-agent.node": cfg.node_name,
+        # Docker compiles seccomp policy at container creation. A profile file updated later does
+        # not change an existing container, so stamp the exact policy for doctor to compare.
+        "lab-agent.seccomp-sha256": docker.security_profile_digest(cfg.seccomp_profile),
     }
 
 
@@ -73,7 +76,7 @@ def ensure_container(cfg: AgentConfig, lab: str, params: dict[str, Any]) -> str:
         logs = docker.container_logs(name)
         docker.remove_container(name)
         detail = f": {logs}" if logs else ""
-        raise docker.DockerError(f"container did not become ready (sshd not active){detail}")
+        raise docker.DockerError(f"container did not become ready (SSH handshake failed){detail}")
     return container_id
 
 
@@ -115,7 +118,7 @@ def recreate_container(cfg: AgentConfig, params: dict[str, Any]) -> tuple[Any, s
             logs = docker.container_logs(name)
             detail = f": {logs}" if logs else ""
             raise docker.DockerError(
-                f"candidate container did not become ready (sshd not active){detail}"
+                f"candidate container did not become ready (SSH handshake failed){detail}"
             )
     except Exception as exc:
         # 4a. Roll back: drop the broken candidate and restore the preserved container.

--- a/agent/src/lab_agent/executors/docker.py
+++ b/agent/src/lab_agent/executors/docker.py
@@ -12,9 +12,11 @@ host Docker socket.
 
 from __future__ import annotations
 
+import hashlib
 import re
 import time
 from dataclasses import dataclass, field
+from pathlib import Path
 
 from .base import CommandResult, run
 
@@ -29,6 +31,14 @@ ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 class DockerError(RuntimeError):
     pass
+
+
+def security_profile_digest(path: str) -> str:
+    """Fingerprint a seccomp profile so running containers can be checked for stale policy."""
+    try:
+        return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+    except OSError:
+        return ""
 
 
 def validate_image(image: str) -> str:
@@ -187,12 +197,23 @@ def start_container(name: str) -> None:
 
 
 def wait_ssh_ready(name: str, *, timeout: float = 90.0, interval: float = 2.0) -> bool:
-    """Poll until sshd is PID 1 with a valid configuration, or the timeout elapses."""
+    """Poll until sshd completes a real key exchange, or the timeout elapses.
+
+    ``sshd -t`` alone is insufficient: it does not exercise the pre-auth child, privilege
+    separation, host-key access, or the container security profiles.  ``ssh-keyscan`` completes
+    enough of the SSH handshake to catch those failures without needing a student account.
+    """
     deadline = time.monotonic() + timeout
     while True:
         res = exec_in(
             name,
-            ["sh", "-c", 'test "$(cat /proc/1/comm)" = sshd && /usr/sbin/sshd -t'],
+            [
+                "sh",
+                "-c",
+                'test "$(cat /proc/1/comm)" = sshd '
+                "&& /usr/sbin/sshd -t "
+                '&& test -n "$(ssh-keyscan -T 5 -t ed25519 127.0.0.1 2>/dev/null)"',
+            ],
             timeout=15,
         )
         if res.ok:

--- a/agent/src/lab_agent/system.py
+++ b/agent/src/lab_agent/system.py
@@ -9,6 +9,7 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
 from .config import AgentConfig
+from .executors import docker
 from .executors.base import run
 
 
@@ -194,6 +195,25 @@ def _security_profiles_ok(cfg: AgentConfig) -> bool:
     return status.ok and cfg.apparmor_profile in status.stdout
 
 
+def _stale_seccomp_containers(cfg: AgentConfig) -> list[str]:
+    """Return managed containers not created with the currently installed seccomp policy."""
+    expected = docker.security_profile_digest(cfg.seccomp_profile)
+    if not expected:
+        return []
+    listed = run([
+        "docker", "ps", "--filter", "label=lab-agent.managed=true",
+        "--format", '{{.Names}}\t{{.Label "lab-agent.seccomp-sha256"}}',
+    ], timeout=20)
+    if not listed.ok:
+        return []
+    stale: list[str] = []
+    for line in listed.stdout.splitlines():
+        parts = line.split("\t", 1)
+        if parts and (len(parts) == 1 or parts[1] != expected):
+            stale.append(parts[0])
+    return stale
+
+
 def _first_student_container() -> tuple[str, str] | None:
     listed = run([
         "docker", "ps", "--filter", "label=lab-agent.managed=true", "--format", "{{.Names}}"
@@ -301,8 +321,24 @@ def detect_capabilities(cfg: AgentConfig, *, deep: bool = True) -> Capabilities:
     codex_ok = False
     target: tuple[str, str] | None = None
     if deep and docker_ok:
+        stale_seccomp = _stale_seccomp_containers(cfg)
+        if stale_seccomp:
+            _issue(
+                issues,
+                "container_seccomp_stale",
+                "critical",
+                "Managed containers require recreation after a seccomp profile update: "
+                + ", ".join(stale_seccomp),
+            )
         target = _first_student_container()
         if target:
+            if not docker.wait_ssh_ready(target[0], timeout=10, interval=1):
+                _issue(
+                    issues,
+                    "ssh_handshake_failed",
+                    "critical",
+                    f"SSH key exchange failed in '{target[0]}'; inspect its Docker logs",
+                )
             mode = run(["docker", "exec", target[0], "stat", "-c", "%a", "/usr/bin/bwrap"],
                        timeout=20)
             mode_ok = mode.ok and mode.stdout.strip() == "755"

--- a/agent/tests/integration/test_real_lab.py
+++ b/agent/tests/integration/test_real_lab.py
@@ -41,6 +41,10 @@ def test_outer_boundary_and_mounts():
     assert destinations == {"/home", "/cold-storage", "/run/labquota"}
     assert docker("exec", CONTAINER, "cat", "/proc/1/comm").stdout.strip() == "sshd"
     docker("exec", CONTAINER, "/usr/sbin/sshd", "-t")
+    keys = docker(
+        "exec", CONTAINER, "ssh-keyscan", "-T", "5", "-t", "ed25519", "127.0.0.1"
+    )
+    assert "ssh-ed25519" in keys.stdout
 
 
 def test_unprivileged_bubblewrap_and_codex():

--- a/agent/tests/test_containerops.py
+++ b/agent/tests/test_containerops.py
@@ -38,6 +38,11 @@ def test_mount_contract(monkeypatch):
     assert mounts.apparmor_profile == "lab-codex"
 
 
+def test_labels_stamp_seccomp_digest(monkeypatch):
+    monkeypatch.setattr(containerops.docker, "security_profile_digest", lambda path: "abc123")
+    assert containerops._labels(cfg(), "bio")["lab-agent.seccomp-sha256"] == "abc123"
+
+
 def test_creation_requires_userns_and_passes_cdi(monkeypatch):
     common(monkeypatch)
     events = []

--- a/agent/tests/test_docker.py
+++ b/agent/tests/test_docker.py
@@ -81,7 +81,7 @@ def test_usage_helpers(monkeypatch):
     assert docker.du_home("lab-bio", "alice") == 123
 
 
-def test_wait_ssh_ready_checks_sshd_as_pid_one(monkeypatch):
+def test_wait_ssh_ready_completes_key_exchange(monkeypatch):
     calls = []
 
     def ready(name, argv, **kwargs):
@@ -91,7 +91,10 @@ def test_wait_ssh_ready_checks_sshd_as_pid_one(monkeypatch):
     monkeypatch.setattr(docker, "exec_in", ready)
     assert docker.wait_ssh_ready("lab-bio", timeout=0, interval=0)
     assert calls == [("lab-bio", [
-        "sh", "-c", 'test "$(cat /proc/1/comm)" = sshd && /usr/sbin/sshd -t'
+        "sh",
+        "-c",
+        'test "$(cat /proc/1/comm)" = sshd && /usr/sbin/sshd -t '
+        '&& test -n "$(ssh-keyscan -T 5 -t ed25519 127.0.0.1 2>/dev/null)"',
     ])]
 
 

--- a/agent/tests/test_system.py
+++ b/agent/tests/test_system.py
@@ -129,3 +129,11 @@ def test_docker_root_ok_rejects_wrong_remap_suffix(monkeypatch):
     runner.responses["docker info --format {{.DockerRootDir}}"] = (True, "/var/lib/docker/0.0")
     monkeypatch.setattr(system, "run", runner)
     assert not system._docker_root_ok(cfg())
+
+
+def test_stale_seccomp_containers_detects_missing_and_changed_labels(monkeypatch):
+    monkeypatch.setattr(system.docker, "security_profile_digest", lambda path: "current")
+    monkeypatch.setattr(system, "run", Runner({
+        "docker ps": (True, "lab-old\nlab-stale\tprevious\nlab-current\tcurrent\n"),
+    }))
+    assert system._stale_seccomp_containers(cfg()) == ["lab-old", "lab-stale"]


### PR DESCRIPTION
## Summary
- require a real SSH key exchange before declaring a lab container ready
- make `lab-agent doctor` report SSH handshake failures
- stamp containers with the installed seccomp profile digest and report stale policy
- extend real-node acceptance coverage and document recreation requirements

## Why
`sshd -t` validates configuration only. It previously allowed a container whose pre-auth process was blocked by seccomp to be marked active.

## Testing
- `uv run --extra dev ruff check src tests`
- `uv run --extra dev pytest -q` (215 passed, 4 skipped)