### PR TITLE
Add MB/GB/TB quota units, cap to pool capacity, fix account loss on recreate

### DIFF
--- a/controller/src/app/(app)/labs/[id]/placements/[placementId]/page.tsx
+++ b/controller/src/app/(app)/labs/[id]/placements/[placementId]/page.tsx
@@ -6,18 +6,20 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Select } from "@/components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { db } from "@/lib/db";
 import { takeFlash } from "@/lib/flash";
-import { fmtBytes, pct } from "@/lib/format";
+import { bytesToQuotaInput, fmtBytes, pct } from "@/lib/format";
 import {
   containerOptionsOf,
   getPlacement,
   listPlacementMembers,
   listPlacements,
+  nodePoolCapacityBytes,
   type Placement,
 } from "@/lib/placements";
-import { getSetting, TIB } from "@/lib/settings";
+import { getSetting } from "@/lib/settings";
 import {
   removePlacementAction,
   revealPlacementCredentialAction,
@@ -76,12 +78,13 @@ function taskLabel(task: TaskStatus | null): { text: string; variant: "ok" | "wa
   return { text: "queued", variant: "warn" };
 }
 
-function QuotaStatus({ desired, usage }: { desired: number; usage: Usage | null }) {
+function QuotaStatus({ desired, usage, capBytes }: { desired: number; usage: Usage | null; capBytes: number | null }) {
   const percent = usage ? pct(usage.used, desired) : null;
   return (
     <p className="mt-1 text-xs text-muted-foreground">
       Desired {fmtBytes(desired)} · agent reported {usage?.quota ? fmtBytes(usage.quota) : "—"} · used{" "}
       {usage ? fmtBytes(usage.used) : "—"}{percent !== null ? ` (${percent}%)` : ""}
+      {capBytes !== null ? ` · node pool capacity ${fmtBytes(capBytes)}` : ""}
     </p>
   );
 }
@@ -117,6 +120,9 @@ export default async function PlacementPage({
   const opts = containerOptionsOf(placement);
   const host = getSetting("sshHostOverride").trim() || placement.node_name;
   const canEdit = placement.state !== "deleting";
+  const capacity = nodePoolCapacityBytes(placement.node_id);
+  const fastDefault = bytesToQuotaInput(placement.fast_quota_bytes);
+  const coldDefault = placement.cold_quota_bytes !== null ? bytesToQuotaInput(placement.cold_quota_bytes) : null;
 
   return (
     <div className="space-y-4">
@@ -186,20 +192,50 @@ export default async function PlacementPage({
           <form action={setPlacementQuotaAction} className="grid grid-cols-1 gap-3 sm:grid-cols-3">
             <input type="hidden" name="placementId" value={placement.id} />
             <div>
-              <Label>Fast quota (TB)</Label>
-              <Input name="fastTb" type="number" min="0.001" max="100000" step="0.5" defaultValue={placement.fast_quota_bytes / TIB} disabled={!canEdit} />
-              <QuotaStatus desired={placement.fast_quota_bytes} usage={fastUsage} />
+              <Label>Fast quota</Label>
+              <div className="flex gap-2">
+                <Input
+                  name="fastAmount"
+                  type="number"
+                  min="0"
+                  step="any"
+                  defaultValue={fastDefault.amount}
+                  disabled={!canEdit}
+                  className="flex-1"
+                />
+                <Select name="fastUnit" defaultValue={fastDefault.unit} disabled={!canEdit} className="w-20">
+                  <option value="MB">MB</option>
+                  <option value="GB">GB</option>
+                  <option value="TB">TB</option>
+                </Select>
+              </div>
+              <QuotaStatus desired={placement.fast_quota_bytes} usage={fastUsage} capBytes={capacity.fastBytes} />
             </div>
             <div>
-              <Label>Cold quota (TB)</Label>
-              {placement.cold_quota_bytes === null ? (
+              <Label>Cold quota</Label>
+              {placement.cold_quota_bytes === null || coldDefault === null ? (
                 <p className="pt-2 text-sm text-muted-foreground">
                   Managed by {ownerPlacement?.node_name ?? placement.cold_owner_name ?? "owner node"}; change it on the owner placement.
                 </p>
               ) : (
                 <>
-                  <Input name="coldTb" type="number" min="0.001" max="100000" step="0.5" defaultValue={placement.cold_quota_bytes / TIB} disabled={!canEdit} />
-                  <QuotaStatus desired={placement.cold_quota_bytes} usage={coldUsage} />
+                  <div className="flex gap-2">
+                    <Input
+                      name="coldAmount"
+                      type="number"
+                      min="0"
+                      step="any"
+                      defaultValue={coldDefault.amount}
+                      disabled={!canEdit}
+                      className="flex-1"
+                    />
+                    <Select name="coldUnit" defaultValue={coldDefault.unit} disabled={!canEdit} className="w-20">
+                      <option value="MB">MB</option>
+                      <option value="GB">GB</option>
+                      <option value="TB">TB</option>
+                    </Select>
+                  </div>
+                  <QuotaStatus desired={placement.cold_quota_bytes} usage={coldUsage} capBytes={capacity.coldBytes} />
                 </>
               )}
             </div>

--- a/controller/src/app/(app)/labs/actions.ts
+++ b/controller/src/app/(app)/labs/actions.ts
@@ -17,6 +17,7 @@ import {
   retryPlacement,
   updatePlacementQuota,
 } from "@/lib/placements";
+import { QUOTA_UNIT_BYTES, type QuotaUnit } from "@/lib/format";
 import { TIB } from "@/lib/settings";
 import { addStudentToLab, copyMembers, removeStudentFromLab } from "@/lib/students";
 
@@ -32,6 +33,24 @@ function tbToBytes(value: FormDataEntryValue | null, label: string): number {
     throw new Error(`${label} quota must be a positive number no greater than 100,000 TB`);
   }
   return Math.round(tb * TIB);
+}
+
+const MAX_QUOTA_BYTES = 100_000 * TIB;
+
+/** Amount+unit quota input (used by the live-quota form, which lets admins pick MB/GB/TB and any
+ * decimal amount instead of being pinned to whole-TB steps). */
+function amountToBytes(amount: FormDataEntryValue | null, unit: FormDataEntryValue | null, label: string): number {
+  const n = Number(amount);
+  const perUnit = QUOTA_UNIT_BYTES[String(unit) as QuotaUnit];
+  if (!perUnit) throw new Error(`${label} quota unit must be MB, GB, or TB`);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new Error(`${label} quota must be a positive number`);
+  }
+  const bytes = Math.round(n * perUnit);
+  if (bytes > MAX_QUOTA_BYTES) {
+    throw new Error(`${label} quota must be no greater than 100,000 TB`);
+  }
+  return bytes;
 }
 
 function containerOptionsFromForm(formData: FormData): ContainerOptions {
@@ -130,17 +149,20 @@ export async function setPlacementQuotaAction(formData: FormData) {
   const placementId = Number(formData.get("placementId"));
   const placement = getPlacement(placementId);
   if (!placement) return;
-  const fastTb = formData.get("fastTb");
-  const coldTb = formData.get("coldTb");
+  const fastAmount = formData.get("fastAmount");
+  const coldAmount = formData.get("coldAmount");
   try {
     updatePlacementQuota(
       placementId,
       {
-        fastQuotaBytes: fastTb !== null && fastTb !== "" ? tbToBytes(fastTb, "Fast") : undefined,
+        fastQuotaBytes:
+          fastAmount !== null && fastAmount !== ""
+            ? amountToBytes(fastAmount, formData.get("fastUnit"), "Fast")
+            : undefined,
         // SMB clients have no local cold quota; their owner placement is linked from the page.
         coldQuotaBytes:
-          placement.cold_quota_bytes !== null && coldTb !== null && coldTb !== ""
-            ? tbToBytes(coldTb, "Cold")
+          placement.cold_quota_bytes !== null && coldAmount !== null && coldAmount !== ""
+            ? amountToBytes(coldAmount, formData.get("coldUnit"), "Cold")
             : undefined,
       },
       who,

--- a/controller/src/lib/format.ts
+++ b/controller/src/lib/format.ts
@@ -1,3 +1,15 @@
+/** Byte size of each quota-input unit, shared with the amount+unit quota forms and their server
+ * actions so the two always agree on what "1 GB" means (binary, matching fmtBytes above). */
+export const QUOTA_UNIT_BYTES = { MB: 1024 ** 2, GB: 1024 ** 3, TB: 1024 ** 4 } as const;
+export type QuotaUnit = keyof typeof QUOTA_UNIT_BYTES;
+
+/** Pick the largest whole unit (MB/GB/TB) for a byte quota, to pre-fill an editable amount+unit
+ * input pair. Rounded to 3 decimals so re-editing an already-set quota doesn't show float noise. */
+export function bytesToQuotaInput(bytes: number): { amount: number; unit: QuotaUnit } {
+  const unit: QuotaUnit = bytes >= QUOTA_UNIT_BYTES.TB ? "TB" : bytes >= QUOTA_UNIT_BYTES.GB ? "GB" : "MB";
+  return { amount: Math.round((bytes / QUOTA_UNIT_BYTES[unit]) * 1000) / 1000, unit };
+}
+
 export function fmtBytes(n: number | null | undefined): string {
   if (n === null || n === undefined) return "—";
   const units = ["B", "KB", "MB", "GB", "TB", "PB"];

--- a/controller/src/lib/placements.ts
+++ b/controller/src/lib/placements.ts
@@ -10,6 +10,7 @@
 
 import { audit } from "./audit";
 import { db } from "./db";
+import { fmtBytes } from "./format";
 import { sendCredentialEmail } from "./mailer";
 import { generatePassword } from "./passwords";
 import { enqueueTask } from "./queue";
@@ -521,6 +522,28 @@ export function completeStudentRemoval(taskUuid: string): void {
   }
 }
 
+export interface NodePoolCapacity {
+  fastBytes: number | null;
+  coldBytes: number | null;
+}
+
+/** The node's actual ZFS pool sizes from the latest heartbeat telemetry (see stats.ts's parsePools
+ * for the sibling reader). Null when the node hasn't reported yet — callers skip the cap in that case
+ * rather than blocking quota changes on missing telemetry. */
+export function nodePoolCapacityBytes(nodeId: number): NodePoolCapacity {
+  const row = db().prepare("SELECT pools FROM nodes WHERE id = ?").get(nodeId) as { pools: string | null } | undefined;
+  const sizeOf = (p: unknown): number | null =>
+    p && typeof p === "object" && typeof (p as { size?: unknown }).size === "number" ? (p as { size: number }).size : null;
+  if (!row?.pools) return { fastBytes: null, coldBytes: null };
+  try {
+    const arr = JSON.parse(row.pools) as unknown;
+    if (!Array.isArray(arr)) return { fastBytes: null, coldBytes: null };
+    return { fastBytes: sizeOf(arr[0]), coldBytes: sizeOf(arr[1]) };
+  } catch {
+    return { fastBytes: null, coldBytes: null };
+  }
+}
+
 /** Live quota change (no recreate). Routes to lab.set_quota on the placement's node. */
 export function updatePlacementQuota(
   placementId: number,
@@ -529,6 +552,21 @@ export function updatePlacementQuota(
 ): void {
   const p = getPlacement(placementId);
   if (!p) throw new Error("Unknown placement");
+  const capacity = nodePoolCapacityBytes(p.node_id);
+  if (input.fastQuotaBytes !== undefined && capacity.fastBytes !== null && input.fastQuotaBytes > capacity.fastBytes) {
+    throw new Error(
+      `Fast quota ${fmtBytes(input.fastQuotaBytes)} exceeds node '${p.node_name}'s fast pool capacity of ${fmtBytes(capacity.fastBytes)}`,
+    );
+  }
+  if (
+    input.coldQuotaBytes != null &&
+    capacity.coldBytes !== null &&
+    input.coldQuotaBytes > capacity.coldBytes
+  ) {
+    throw new Error(
+      `Cold quota ${fmtBytes(input.coldQuotaBytes)} exceeds node '${p.node_name}'s cold pool capacity of ${fmtBytes(capacity.coldBytes)}`,
+    );
+  }
   const params: Record<string, unknown> = { lab: p.lab_name };
   if (input.fastQuotaBytes !== undefined) {
     db().prepare("UPDATE lab_placements SET fast_quota_bytes = ? WHERE id = ?").run(input.fastQuotaBytes, placementId);
@@ -541,6 +579,46 @@ export function updatePlacementQuota(
   touch(placementId);
   enqueueTask(p.node_name, "lab.set_quota", params, actor);
   audit(actor, "placement.set_quota", `${p.lab_name}@${p.node_name}`, JSON.stringify(params));
+}
+
+/**
+ * Re-add every current member of a placement. Student accounts (useradd/chpasswd) live in the
+ * container's writable layer, not the bind-mounted ZFS datasets, so container.recreate wipes them
+ * even though their data survives — each member needs a fresh student.add after the container comes
+ * back. The agent's task queue is a single-consumer FIFO per node, so tasks enqueued here after
+ * container.recreate are guaranteed to run against the new container, not the old one.
+ */
+function reprovisionPlacementMembers(placement: Placement, actor?: string): void {
+  const members = db()
+    .prepare(
+      `SELECT pm.id AS member_id, students.username AS username, students.linux_uid AS linux_uid
+       FROM placement_members pm JOIN students ON students.id = pm.student_id
+       WHERE pm.placement_id = ? ORDER BY students.username`,
+    )
+    .all(placement.id) as { member_id: number; username: string; linux_uid: number }[];
+  const now = Date.now();
+  for (const m of members) {
+    const password = generatePassword();
+    db()
+      .prepare(
+        `UPDATE placement_members
+         SET state = 'provisioning', last_error = NULL, credential_secret = ?, updated_at = ?
+         WHERE id = ?`,
+      )
+      .run(encryptSecret(password), now, m.member_id);
+    enqueueTask(
+      placement.node_name,
+      "student.add",
+      {
+        lab: placement.lab_name,
+        username: m.username,
+        password,
+        uid: m.linux_uid,
+        gid: m.linux_uid,
+      },
+      actor,
+    );
+  }
 }
 
 /** Recreate the container with a (possibly changed) image / container options. Preserves data. */
@@ -577,6 +655,8 @@ export function recreatePlacement(
     },
     actor,
   );
+  // Re-add every current member — see reprovisionPlacementMembers for why this is necessary.
+  reprovisionPlacementMembers(fresh, actor);
   audit(actor, "placement.recreate", `${fresh.lab_name}@${fresh.node_name}`);
 }
 

--- a/controller/tests/placements.test.ts
+++ b/controller/tests/placements.test.ts
@@ -140,6 +140,28 @@ describe("updatePlacementQuota (live, no recreate)", () => {
     );
     expect(enqueueTask.mock.calls.some((c) => c[1] === "container.recreate")).toBe(false);
   });
+
+  it("rejects a quota larger than the node's reported pool capacity, and allows it once telemetry clears", async () => {
+    const lab = newLab("quota-capped");
+    const p = await grant(lab.id, nodeA);
+    dbmod
+      .db()
+      .prepare("UPDATE nodes SET pools = ? WHERE id = ?")
+      .run(JSON.stringify([{ name: "fast", size: 4000, alloc: 0, free: 4000 }, { name: "cold", size: 8000, alloc: 0, free: 8000 }]), nodeA);
+    enqueueTask.mockClear();
+
+    expect(() => placements.updatePlacementQuota(p.id, { fastQuotaBytes: 5000 }, "admin")).toThrow(/exceeds node/);
+    expect(enqueueTask).not.toHaveBeenCalled();
+
+    // At the reported cap it's allowed.
+    placements.updatePlacementQuota(p.id, { fastQuotaBytes: 4000 }, "admin");
+    expect(placements.getPlacement(p.id)!.fast_quota_bytes).toBe(4000);
+
+    // No telemetry at all (e.g. node never reported) skips the cap rather than blocking the change.
+    dbmod.db().prepare("UPDATE nodes SET pools = NULL WHERE id = ?").run(nodeA);
+    placements.updatePlacementQuota(p.id, { fastQuotaBytes: 999_999 }, "admin");
+    expect(placements.getPlacement(p.id)!.fast_quota_bytes).toBe(999_999);
+  });
 });
 
 describe("retryPlacement", () => {
@@ -183,6 +205,28 @@ describe("recreatePlacement", () => {
       expect.objectContaining({ lab: "recreate", image: "custom-ssh-v2" }),
       "admin",
     );
+  });
+
+  it("re-adds every existing member after recreate, since accounts live in the container's writable layer", async () => {
+    const lab = newLab("recreate-members");
+    await students.addStudentToLab(lab.id, { username: "alice", email: "a@uga.edu" }, "admin");
+    await students.addStudentToLab(lab.id, { username: "bob" }, "admin");
+    const p = await grant(lab.id, nodeA);
+    enqueueTask.mockClear();
+
+    placements.recreatePlacement(p.id, { image: "custom-ssh-v2" }, "admin");
+
+    const calls = enqueueTask.mock.calls;
+    const recreateIdx = calls.findIndex((c) => c[1] === "container.recreate");
+    const addIdxs = calls.map((c, i) => (c[1] === "student.add" ? i : -1)).filter((i) => i >= 0);
+    expect(recreateIdx).toBeGreaterThanOrEqual(0);
+    // Every re-add must be queued after container.recreate — the agent's per-node queue is a single
+    // FIFO consumer, so ordering here is what guarantees the add lands on the new container.
+    expect(addIdxs.every((i) => i > recreateIdx)).toBe(true);
+    expect(addIdxs.map((i) => (calls[i][2] as any).username).sort()).toEqual(["alice", "bob"]);
+
+    const n = (dbmod.db().prepare("SELECT COUNT(*) AS n FROM placement_members WHERE placement_id=?").get(p.id) as any).n;
+    expect(n).toBe(2);
   });
 });
 


### PR DESCRIPTION
## Summary
- Quota form now accepts an amount + unit (MB/GB/TB) instead of whole-TB steps, and shows the node's reported pool capacity next to each quota.
- `updatePlacementQuota` rejects a quota above the node's last-reported ZFS pool size (skipped when telemetry hasn't arrived yet).
- `recreatePlacement` re-enqueues `student.add` for every existing member, since `container.recreate` wipes accounts living in the writable layer even though their bind-mounted data survives.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` (236 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)