### PR TITLE
Fix GPU user tracing with userns remap

### DIFF
--- a/agent/src/lab_agent/gpu/monitor.py
+++ b/agent/src/lab_agent/gpu/monitor.py
@@ -117,18 +117,32 @@ def _container_info(pid: int) -> tuple[str | None, bool, str | None]:
 
 
 def _proc_uid(pid: int) -> int | None:
+    """Return the process's effective UID as seen inside its own user namespace.
+
+    Docker's daemon-wide ``userns-remap`` means /proc/<pid>/status exposes the remapped host UID
+    to the root agent (for example, container UID 10000 appears as host UID 241072).  ``getent``
+    runs inside the container and therefore needs the namespace UID, not that host UID.
+    """
     try:
         with open(f"/proc/{pid}/status", encoding="utf-8") as fh:
             for line in fh:
                 if line.startswith("Uid:"):
-                    return int(line.split()[1])
+                    host_uid = int(line.split()[2])
+                    break
+            else:
+                return None
+        with open(f"/proc/{pid}/uid_map", encoding="utf-8") as fh:
+            for line in fh:
+                inside_start, outside_start, length = (int(value) for value in line.split())
+                if outside_start <= host_uid < outside_start + length:
+                    return inside_start + (host_uid - outside_start)
     except (OSError, ValueError, IndexError):
         return None
     return None
 
 
 def _student_user(container: str | None, pid: int) -> str | None:
-    """Resolve the in-container username for a host PID's uid."""
+    """Resolve the in-container username for a host PID's namespace UID."""
     if not container:
         return None
     uid = _proc_uid(pid)

--- a/agent/tests/test_gpu_monitor.py
+++ b/agent/tests/test_gpu_monitor.py
@@ -2,6 +2,16 @@ from lab_agent.executors.base import CommandResult
 from lab_agent.gpu import monitor
 
 
+class _FakeProcFile:
+    def __init__(self, files):
+        self.files = files
+
+    def __call__(self, path, **kwargs):
+        from io import StringIO
+
+        return StringIO(self.files[path])
+
+
 def test_list_gpu_processes_merges_vram_and_util(monkeypatch):
     def fake_run(args, **kwargs):
         argv = [str(a) for a in args]
@@ -41,6 +51,24 @@ def test_parse_inspect_distinguishes_managed_from_unmanaged():
     # An unmanaged container: docker emits "<no value>" for missing labels -> managed False, lab None.
     assert monitor._parse_inspect("/rando|<no value>|<no value>") == ("rando", False, None)
     assert monitor._parse_inspect("/x||") == ("x", False, None)
+
+
+def test_proc_uid_translates_userns_remapped_host_uid(monkeypatch):
+    files = {
+        "/proc/123/status": "Name:\tpython3\nUid:\t241072\t241072\t241072\t241072\n",
+        "/proc/123/uid_map": "         0     231072      65536\n",
+    }
+    monkeypatch.setattr("builtins.open", _FakeProcFile(files))
+    assert monitor._proc_uid(123) == 10000
+
+
+def test_proc_uid_is_unchanged_without_userns_remap(monkeypatch):
+    files = {
+        "/proc/456/status": "Uid:\t10000\t10000\t10000\t10000\n",
+        "/proc/456/uid_map": "         0          0 4294967295\n",
+    }
+    monkeypatch.setattr("builtins.open", _FakeProcFile(files))
+    assert monitor._proc_uid(456) == 10000
 
 
 def test_list_gpu_processes_carries_managed_label(monkeypatch):


### PR DESCRIPTION
## Summary
- translate GPU process host UIDs through `/proc/<pid>/uid_map`
- resolve the translated UID inside the managed lab container
- cover remapped and non-remapped UID namespaces

## Verification
- `uv run --frozen --extra dev pytest` (217 passed, 4 skipped)
- `uv run --frozen --extra dev ruff check src/lab_agent/gpu/monitor.py tests/test_gpu_monitor.py`