### PR TITLE
Add clear action for GPU events

### DIFF
--- a/controller/src/app/(app)/gpu/actions.ts
+++ b/controller/src/app/(app)/gpu/actions.ts
@@ -1,0 +1,11 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { requireAdmin } from "@/lib/auth";
+import { clearGpuEvents } from "@/lib/gpu";
+
+export async function clearGpuEventsAction() {
+  const actor = (await requireAdmin()).email;
+  clearGpuEvents(actor);
+  revalidatePath("/gpu");
+}

--- a/controller/src/app/(app)/gpu/page.tsx
+++ b/controller/src/app/(app)/gpu/page.tsx
@@ -1,5 +1,7 @@
 import { db } from "@/lib/db";
 import { ago, fmtBytes } from "@/lib/format";
+import { ConfirmButton } from "../_components/ConfirmButton";
+import { clearGpuEventsAction } from "./actions";
 import { Card, CardContent } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 
@@ -16,6 +18,7 @@ interface SnapRow {
 }
 
 interface EventRow {
+  id: number;
   node: string;
   pid: number | null;
   user: string | null;
@@ -74,7 +77,21 @@ export default function GpuPage() {
 
       <Card>
         <CardContent className="space-y-3">
-          <h3 className="text-base font-semibold">Recent idle-kill events</h3>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h3 className="text-base font-semibold">Recent idle-kill events</h3>
+            {events.length > 0 ? (
+              <form action={clearGpuEventsAction}>
+                <ConfirmButton
+                  size="sm"
+                  title="Clear GPU events?"
+                  confirmLabel="Clear events"
+                  confirm="Clear all recorded GPU idle-kill events? This cannot be undone and does not affect live GPU processes."
+                >
+                  Clear events
+                </ConfirmButton>
+              </form>
+            ) : null}
+          </div>
           {events.length === 0 ? (
             <p className="text-sm text-muted-foreground">No events yet.</p>
           ) : (
@@ -90,8 +107,8 @@ export default function GpuPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {events.map((e, i) => (
-                  <TableRow key={i}>
+                {events.map((e) => (
+                  <TableRow key={e.id}>
                     <TableCell className="text-muted-foreground">{ago(e.ts)}</TableCell>
                     <TableCell>{e.node}</TableCell>
                     <TableCell>{e.pid ?? "—"}</TableCell>

--- a/controller/src/lib/gpu.ts
+++ b/controller/src/lib/gpu.ts
@@ -1,0 +1,11 @@
+import { audit } from "./audit";
+import { db } from "./db";
+
+/** Delete historical idle-kill events without disturbing the live GPU process snapshot. */
+export function clearGpuEvents(actor: string): number {
+  return db().transaction(() => {
+    const cleared = db().prepare("DELETE FROM gpu_events").run().changes;
+    audit(actor, "gpu.events.clear", undefined, `${cleared} event(s)`);
+    return cleared;
+  })();
+}

--- a/controller/tests/actions-auth.test.ts
+++ b/controller/tests/actions-auth.test.ts
@@ -28,6 +28,7 @@ describe("Server Actions reject unauthenticated callers", () => {
   let templates: typeof import("../src/app/(app)/email-templates/actions.js");
   let backups: typeof import("../src/app/(app)/backups/actions.js");
   let stats: typeof import("../src/app/(app)/stats/actions.js");
+  let gpu: typeof import("../src/app/(app)/gpu/actions.js");
 
   beforeAll(async () => {
     labs = await import("../src/app/(app)/labs/actions.js");
@@ -36,6 +37,7 @@ describe("Server Actions reject unauthenticated callers", () => {
     templates = await import("../src/app/(app)/email-templates/actions.js");
     backups = await import("../src/app/(app)/backups/actions.js");
     stats = await import("../src/app/(app)/stats/actions.js");
+    gpu = await import("../src/app/(app)/gpu/actions.js");
   });
 
   const fd = () => new FormData();
@@ -54,6 +56,7 @@ describe("Server Actions reject unauthenticated callers", () => {
       labs.addMemberAction(fd()),
       labs.removeMemberAction(fd()),
       stats.usageScanAction(fd()),
+      gpu.clearGpuEventsAction(),
       students.importStudentsAction({ labId: 1, rows: [] }),
       settings.saveStorageSettingsAction(fd()),
       settings.saveUsageScanSettingsAction(fd()),

--- a/controller/tests/gpu.test.ts
+++ b/controller/tests/gpu.test.ts
@@ -1,0 +1,44 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const tmp = mkdtempSync(join(tmpdir(), "lab-ctl-gpu-"));
+process.env.DB_PATH = join(tmp, "controller.db");
+process.env.SIGNUP_TOKEN = "t";
+process.env.AGENT_TOKEN = "t";
+process.env.SESSION_SECRET = "test-session-secret-test-session";
+
+let dbmod: typeof import("../src/lib/db");
+let gpu: typeof import("../src/lib/gpu");
+
+beforeAll(async () => {
+  dbmod = await import("../src/lib/db");
+  gpu = await import("../src/lib/gpu");
+});
+
+describe("GPU event history", () => {
+  it("clears events, preserves the live snapshot, and records an audit entry", () => {
+    const d = dbmod.db();
+    d.prepare(
+      "INSERT INTO gpu_snapshot (node, pid, ts) VALUES ('gpu-1', 42, 1)",
+    ).run();
+    d.prepare(
+      "INSERT INTO gpu_events (node, pid, state, ts) VALUES ('gpu-1', 42, 'warned', 1)",
+    ).run();
+    d.prepare(
+      "INSERT INTO gpu_events (node, pid, state, ts) VALUES ('gpu-1', 42, 'killed', 2)",
+    ).run();
+
+    expect(gpu.clearGpuEvents("admin@example.com")).toBe(2);
+    expect(d.prepare("SELECT COUNT(*) AS n FROM gpu_events").get()).toMatchObject({ n: 0 });
+    expect(d.prepare("SELECT COUNT(*) AS n FROM gpu_snapshot").get()).toMatchObject({ n: 1 });
+    expect(
+      d.prepare("SELECT actor, action, detail FROM audit_log ORDER BY id DESC LIMIT 1").get(),
+    ).toMatchObject({
+      actor: "admin@example.com",
+      action: "gpu.events.clear",
+      detail: "2 event(s)",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a confirmed Clear events action to the GPU event history
- authenticate and audit event-history deletion without touching the live snapshot
- cover clearing behavior and unauthenticated server-action access

## Validation
- npm run lint
- npm run typecheck
- npm test (237 tests)
- npm run build
- rendered production QA in the in-app browser