### PR TITLE
Add ranked SMTP failover configs

### DIFF
--- a/controller/src/app/(app)/settings/actions.ts
+++ b/controller/src/app/(app)/settings/actions.ts
@@ -1,9 +1,10 @@
 "use server";
 
+import { randomUUID } from "node:crypto";
 import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
 import { sendTestEmail } from "@/lib/mailer";
-import { broadcastGpuPolicy, setSetting, TIB } from "@/lib/settings";
+import { broadcastGpuPolicy, getSmtpConfigs, setSetting, TIB } from "@/lib/settings";
 import { requireAdmin } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { pruneLogs } from "@/lib/maintenance";
@@ -79,14 +80,40 @@ export async function saveSmtpSettingsAction(formData: FormData) {
     String(formData.get("smtpHost") ?? ""),
     Number(formData.get("smtpPort")) || 587,
   );
-  setSetting("smtpHost", host);
-  setSetting("smtpPort", port);
-  setSetting("smtpSecure", secure);
-  setSetting("smtpUser", String(formData.get("smtpUser") ?? "").trim());
+  const configs = getSmtpConfigs();
+  const id = String(formData.get("smtpId") ?? "").trim() || randomUUID();
+  const existing = configs.find((config) => config.id === id);
   const pass = String(formData.get("smtpPass") ?? "");
-  // Only overwrite the stored password when a new one is entered (the field renders blank).
-  if (pass) setSetting("smtpPass", pass);
-  setSetting("smtpFrom", String(formData.get("smtpFrom") ?? "").trim());
+  const rankValue = Number(formData.get("smtpRank"));
+  const rank = Number.isFinite(rankValue) && rankValue > 0
+    ? Math.trunc(rankValue)
+    : existing?.rank ?? Math.max(0, ...configs.map((config) => config.rank)) + 1;
+  const updated = {
+    id,
+    name: String(formData.get("smtpName") ?? "").trim() || `SMTP ${rank}`,
+    rank,
+    host,
+    port,
+    secure,
+    user: String(formData.get("smtpUser") ?? "").trim(),
+    pass: pass || existing?.pass || "",
+    from: String(formData.get("smtpFrom") ?? "").trim(),
+  };
+  setSetting("smtpConfigs", existing
+    ? configs.map((config) => config.id === id ? updated : config)
+    : [...configs, updated]);
+  revalidatePath("/settings");
+}
+
+export async function deleteSmtpSettingsAction(formData: FormData) {
+  await requireAdmin();
+  const id = String(formData.get("smtpId") ?? "");
+  setSetting("smtpConfigs", getSmtpConfigs().filter((config) => config.id !== id));
+  revalidatePath("/settings");
+}
+
+export async function saveSshHostOverrideAction(formData: FormData) {
+  await requireAdmin();
   setSetting("sshHostOverride", String(formData.get("sshHostOverride") ?? "").trim());
   revalidatePath("/settings");
 }

--- a/controller/src/app/(app)/settings/page.tsx
+++ b/controller/src/app/(app)/settings/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { getSettings, TIB } from "@/lib/settings";
+import { getSettings, getSmtpConfigs, TIB } from "@/lib/settings";
 import { db } from "@/lib/db";
 import { fmtBytes } from "@/lib/format";
 import { logsContentBytes } from "@/lib/maintenance";
@@ -11,10 +11,12 @@ import { Select } from "@/components/ui/select";
 import { ConfirmButton } from "../_components/ConfirmButton";
 import {
   clearLogsAction,
+  deleteSmtpSettingsAction,
   saveAlertSettingsAction,
   saveGpuPolicyAction,
   saveScrubSettingsAction,
   saveSmtpSettingsAction,
+  saveSshHostOverrideAction,
   saveStorageSettingsAction,
   saveUsageScanSettingsAction,
   scrubNowAction,
@@ -45,6 +47,8 @@ export default async function SettingsPage({
 }) {
   const { smtp, scrub, logs: logsMsg } = await searchParams;
   const s = getSettings();
+  const smtpConfigs = getSmtpConfigs();
+  const nextSmtpRank = Math.max(0, ...smtpConfigs.map((config) => config.rank)) + 1;
   const logCount = (db().prepare("SELECT COUNT(*) AS n FROM logs").get() as { n: number }).n;
   const logBytes = logsContentBytes();
   return (
@@ -116,37 +120,94 @@ export default async function SettingsPage({
         <CardContent className="space-y-3">
           <h3 className="text-base font-semibold">Email (external SMTP)</h3>
           {smtp && <p className="text-sm text-primary">{smtp}</p>}
-          <form action={saveSmtpSettingsAction} className="grid max-w-xl grid-cols-1 gap-3 sm:grid-cols-2">
+          <p className="text-xs text-muted-foreground">
+            Servers are attempted from the lowest rank to the highest. A failed delivery automatically
+            falls through to the next configured server.
+          </p>
+          {smtpConfigs.map((config) => (
+            <div key={config.id} className="flex max-w-xl flex-col gap-3 rounded-md border p-3">
+              <form action={saveSmtpSettingsAction} className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <input type="hidden" name="smtpId" value={config.id} />
+                <div>
+                  <Label>Config name</Label>
+                  <Input name="smtpName" defaultValue={config.name} placeholder="Primary SMTP" />
+                </div>
+                <div>
+                  <Label>Rank</Label>
+                  <Input name="smtpRank" type="number" min={1} defaultValue={config.rank} />
+                </div>
+                <div>
+                  <Label>SMTP host</Label>
+                  <Input name="smtpHost" defaultValue={config.host} placeholder="https://smtp.uga.edu:465" />
+                  <small className="text-xs text-muted-foreground">
+                    Use https:// (or port 465) for implicit TLS; http:// for STARTTLS.
+                  </small>
+                </div>
+                <div>
+                  <Label>Port</Label>
+                  <Input name="smtpPort" type="number" min={1} defaultValue={config.port} />
+                </div>
+                <div>
+                  <Label>Username</Label>
+                  <Input name="smtpUser" defaultValue={config.user} />
+                </div>
+                <div>
+                  <Label>Password</Label>
+                  <Input name="smtpPass" type="password" placeholder={config.pass ? "•••••• (unchanged)" : ""} />
+                </div>
+                <div>
+                  <Label>From address</Label>
+                  <Input name="smtpFrom" defaultValue={config.from} placeholder="labs@uga.edu" />
+                </div>
+                <div className="flex items-end">
+                  <Button type="submit">Save config</Button>
+                </div>
+              </form>
+              <form action={deleteSmtpSettingsAction}>
+                <input type="hidden" name="smtpId" value={config.id} />
+                <Button type="submit" variant="destructive">Delete config</Button>
+              </form>
+            </div>
+          ))}
+          <form action={saveSmtpSettingsAction} className="grid max-w-xl grid-cols-1 gap-3 rounded-md border p-3 sm:grid-cols-2">
+            <div>
+              <Label>Config name</Label>
+              <Input name="smtpName" placeholder="Backup SMTP" />
+            </div>
+            <div>
+              <Label>Rank</Label>
+              <Input name="smtpRank" type="number" min={1} defaultValue={nextSmtpRank} />
+            </div>
             <div>
               <Label>SMTP host</Label>
-              <Input name="smtpHost" defaultValue={s.smtpHost} placeholder="https://smtp.uga.edu:465" />
-              <small className="text-xs text-muted-foreground">
-                Use https:// (or port 465) for implicit TLS; http:// for STARTTLS.
-              </small>
+              <Input name="smtpHost" placeholder="https://smtp.example.com:465" />
             </div>
             <div>
               <Label>Port</Label>
-              <Input name="smtpPort" type="number" defaultValue={s.smtpPort} />
+              <Input name="smtpPort" type="number" min={1} defaultValue={587} />
             </div>
             <div>
               <Label>Username</Label>
-              <Input name="smtpUser" defaultValue={s.smtpUser} />
+              <Input name="smtpUser" />
             </div>
             <div>
               <Label>Password</Label>
-              <Input name="smtpPass" type="password" placeholder={s.smtpPass ? "•••••• (unchanged)" : ""} />
+              <Input name="smtpPass" type="password" />
             </div>
             <div>
               <Label>From address</Label>
-              <Input name="smtpFrom" defaultValue={s.smtpFrom} placeholder="labs@uga.edu" />
+              <Input name="smtpFrom" placeholder="labs@example.com" />
             </div>
+            <div className="flex items-end">
+              <Button type="submit" variant="secondary">Add SMTP config</Button>
+            </div>
+          </form>
+          <form action={saveSshHostOverrideAction} className="flex max-w-xl flex-wrap items-end gap-3">
             <div>
               <Label>SSH host override (optional)</Label>
               <Input name="sshHostOverride" defaultValue={s.sshHostOverride} placeholder="gpu.uga.edu" />
             </div>
-            <div className="sm:col-span-2">
-              <Button type="submit">Save SMTP</Button>
-            </div>
+            <Button type="submit" variant="secondary">Save SSH host</Button>
           </form>
           <form action={testEmailAction} className="flex flex-wrap items-end gap-3">
             <div>

--- a/controller/src/lib/mailer.ts
+++ b/controller/src/lib/mailer.ts
@@ -21,8 +21,9 @@ import {
   DEFAULT_WELCOME_SUBJECT,
   REMOVAL_DATA_DELETED,
   REMOVAL_DATA_RETAINED,
+  type SmtpConfig,
+  getSmtpConfigs,
   getSetting,
-  isSmtpConfigured,
 } from "./settings";
 
 // Re-exported for back-compat: callers (and tests) still import renderTemplate from the mailer.
@@ -34,13 +35,13 @@ export interface SendResult {
   error?: string;
 }
 
-function transport() {
+function transport(config: SmtpConfig) {
   return nodemailer.createTransport({
-    host: getSetting("smtpHost"),
-    port: getSetting("smtpPort"),
-    secure: getSetting("smtpSecure"),
-    auth: getSetting("smtpUser")
-      ? { user: getSetting("smtpUser"), pass: getSetting("smtpPass") }
+    host: config.host,
+    port: config.port,
+    secure: config.secure,
+    auth: config.user
+      ? { user: config.user, pass: config.pass }
       : undefined,
   });
 }
@@ -55,15 +56,21 @@ export function emailContent(body: string): { text: string } {
 }
 
 export async function sendMail(to: string, subject: string, text: string): Promise<SendResult> {
-  if (!isSmtpConfigured()) return { sent: false, skipped: true };
+  const configs = getSmtpConfigs().filter((config) => config.host && config.from);
+  if (configs.length === 0) return { sent: false, skipped: true };
   if (!to) return { sent: false, skipped: true };
-  try {
-    const content = emailContent(text);
-    await transport().sendMail({ from: getSetting("smtpFrom"), to, subject, ...content });
-    return { sent: true };
-  } catch (err) {
-    return { sent: false, error: err instanceof Error ? err.message : String(err) };
+  const content = emailContent(text);
+  const errors: string[] = [];
+  for (const config of configs) {
+    try {
+      await transport(config).sendMail({ from: config.from, to, subject, ...content });
+      return { sent: true };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      errors.push(configs.length === 1 ? message : `${config.name}: ${message}`);
+    }
   }
+  return { sent: false, error: errors.join("; ") };
 }
 
 export async function sendTestEmail(to: string): Promise<SendResult> {

--- a/controller/src/lib/settings.ts
+++ b/controller/src/lib/settings.ts
@@ -14,6 +14,18 @@ export const TIB = 1024 ** 4;
 // Credential settings encrypted at rest (M-05). Stored AES-GCM-encrypted; decrypted on read.
 const ENCRYPTED_KEYS = new Set<keyof Settings>(["smtpPass", "webdavPass"]);
 
+export interface SmtpConfig {
+  id: string;
+  name: string;
+  rank: number;
+  host: string;
+  port: number;
+  user: string;
+  pass: string;
+  from: string;
+  secure: boolean;
+}
+
 export interface Settings {
   fastQuotaDefaultBytes: number;
   slowQuotaDefaultBytes: number;
@@ -33,6 +45,9 @@ export interface Settings {
   smtpPass: string;
   smtpFrom: string;
   smtpSecure: boolean; // true = implicit TLS (465); false = STARTTLS/none
+  // Ranked SMTP servers. An explicitly stored empty array disables SMTP. When this key has never
+  // been stored, getSmtpConfigs() exposes the legacy single-server fields above for compatibility.
+  smtpConfigs: SmtpConfig[];
   // Plain-text signature appended by the mailer to every outbound email.
   emailSignatureText: string;
   // Optional public hostname students SSH to (falls back to the node name).
@@ -224,6 +239,7 @@ export const DEFAULT_SETTINGS: Settings = {
   smtpPass: "",
   smtpFrom: "",
   smtpSecure: false,
+  smtpConfigs: [],
   emailSignatureText: DEFAULT_EMAIL_SIGNATURE_TEXT,
   sshHostOverride: "",
   welcomeEmailSubject: DEFAULT_WELCOME_SUBJECT,
@@ -322,7 +338,43 @@ export function broadcastGpuPolicy(actor?: string): void {
 }
 
 export function isSmtpConfigured(): boolean {
-  return getSetting("smtpHost").trim() !== "" && getSetting("smtpFrom").trim() !== "";
+  return getSmtpConfigs().some((config) => config.host !== "" && config.from !== "");
+}
+
+/** Return every SMTP config in failover order (lowest rank is attempted first). */
+export function getSmtpConfigs(): SmtpConfig[] {
+  const hasRankedConfigs = !!db().prepare("SELECT 1 FROM settings WHERE key = 'smtpConfigs'").get();
+  if (hasRankedConfigs) {
+    return getSetting("smtpConfigs")
+      .filter((config) => config && typeof config === "object")
+      .map((config, index) => ({
+        id: String(config.id || `smtp-${index + 1}`),
+        name: String(config.name || `SMTP ${index + 1}`),
+        rank: Number.isFinite(Number(config.rank)) ? Math.max(1, Math.trunc(Number(config.rank))) : index + 1,
+        host: String(config.host || "").trim(),
+        port: Number(config.port) > 0 ? Math.trunc(Number(config.port)) : 587,
+        user: String(config.user || "").trim(),
+        pass: String(config.pass || ""),
+        from: String(config.from || "").trim(),
+        secure: !!config.secure,
+      }))
+      .sort((a, b) => a.rank - b.rank || a.name.localeCompare(b.name));
+  }
+
+  const host = getSetting("smtpHost").trim();
+  const from = getSetting("smtpFrom").trim();
+  if (!host && !from) return [];
+  return [{
+    id: "legacy",
+    name: "Primary SMTP",
+    rank: 1,
+    host,
+    port: getSetting("smtpPort"),
+    user: getSetting("smtpUser").trim(),
+    pass: getSetting("smtpPass"),
+    from,
+    secure: getSetting("smtpSecure"),
+  }];
 }
 
 export function getSetting<K extends keyof Settings>(key: K): Settings[K] {
@@ -332,6 +384,12 @@ export function getSetting<K extends keyof Settings>(key: K): Settings[K] {
   if (!row) return DEFAULT_SETTINGS[key];
   try {
     const parsed = JSON.parse(row.value) as Settings[K];
+    if (key === "smtpConfigs" && Array.isArray(parsed)) {
+      return parsed.map((config) => ({
+        ...config,
+        pass: typeof config?.pass === "string" ? decryptSecret(config.pass) : "",
+      })) as Settings[K];
+    }
     if (ENCRYPTED_KEYS.has(key) && typeof parsed === "string") {
       return decryptSecret(parsed) as Settings[K];
     }
@@ -350,8 +408,9 @@ export function getSettings(): Settings {
 }
 
 export function setSetting<K extends keyof Settings>(key: K, value: Settings[K]): void {
-  const toStore =
-    ENCRYPTED_KEYS.has(key) && typeof value === "string"
+  const toStore = key === "smtpConfigs" && Array.isArray(value)
+    ? value.map((config) => ({ ...config, pass: encryptSecret(config.pass) }))
+    : ENCRYPTED_KEYS.has(key) && typeof value === "string"
       ? (encryptSecret(value) as Settings[K])
       : value;
   db()

--- a/controller/tests/mailer.test.ts
+++ b/controller/tests/mailer.test.ts
@@ -13,13 +13,23 @@ process.env.SESSION_SECRET = "test-session-secret-test-session";
 // Capture the messages handed to nodemailer instead of opening an SMTP socket.
 const sent: any[] = [];
 let failNext = false;
+const failedHosts = new Set<string>();
 const sendMailImpl = vi.fn(async (msg: any) => {
   if (failNext) throw new Error("smtp down");
   sent.push(msg);
   return { messageId: "1" };
 });
+const transports: any[] = [];
 vi.mock("nodemailer", () => ({
-  default: { createTransport: () => ({ sendMail: sendMailImpl }) },
+  default: { createTransport: (options: any) => {
+    transports.push(options);
+    return {
+      sendMail: async (msg: any) => {
+        if (failedHosts.has(options.host)) throw new Error(`${options.host} down`);
+        return sendMailImpl(msg);
+      },
+    };
+  } },
 }));
 
 let dbmod: typeof import("../src/lib/db");
@@ -35,19 +45,22 @@ beforeAll(async () => {
 
 beforeEach(() => {
   sent.length = 0;
+  transports.length = 0;
+  failedHosts.clear();
   failNext = false;
   sendMailImpl.mockClear();
 });
 
 function configureSmtp() {
-  settings.setSetting("smtpHost", "smtp.uga.edu");
-  settings.setSetting("smtpFrom", "labs@uga.edu");
+  settings.setSetting("smtpConfigs", [{
+    id: "primary", name: "Primary", rank: 1, host: "smtp.uga.edu", port: 587,
+    user: "", pass: "", from: "labs@uga.edu", secure: false,
+  }]);
 }
 
 describe("sendMail gating", () => {
   it("skips when SMTP is not configured", async () => {
-    settings.setSetting("smtpHost", "");
-    settings.setSetting("smtpFrom", "");
+    settings.setSetting("smtpConfigs", []);
     const res = await mailer.sendMail("a@uga.edu", "s", "b");
     expect(res).toEqual({ sent: false, skipped: true });
     expect(sendMailImpl).not.toHaveBeenCalled();
@@ -74,6 +87,33 @@ describe("sendMail gating", () => {
     const res = await mailer.sendMail("a@uga.edu", "s", "b");
     expect(res.sent).toBe(false);
     expect(res.error).toBe("smtp down");
+  });
+
+  it("fails over through SMTP configs in rank order", async () => {
+    settings.setSetting("smtpConfigs", [
+      { id: "backup", name: "Backup", rank: 20, host: "smtp.backup", port: 465, user: "b", pass: "bp", from: "backup@example.com", secure: true },
+      { id: "primary", name: "Primary", rank: 10, host: "smtp.primary", port: 587, user: "p", pass: "pp", from: "primary@example.com", secure: false },
+    ]);
+    failedHosts.add("smtp.primary");
+
+    const res = await mailer.sendMail("a@uga.edu", "Subject", "Body");
+
+    expect(res).toEqual({ sent: true });
+    expect(transports.map((options) => options.host)).toEqual(["smtp.primary", "smtp.backup"]);
+    expect(sent[0].from).toBe("backup@example.com");
+  });
+
+  it("returns every ranked failure when all SMTP configs fail", async () => {
+    settings.setSetting("smtpConfigs", [
+      { id: "one", name: "First", rank: 1, host: "smtp.one", port: 587, user: "", pass: "", from: "one@example.com", secure: false },
+      { id: "two", name: "Second", rank: 2, host: "smtp.two", port: 587, user: "", pass: "", from: "two@example.com", secure: false },
+    ]);
+    failedHosts.add("smtp.one");
+    failedHosts.add("smtp.two");
+
+    const res = await mailer.sendMail("a@uga.edu", "Subject", "Body");
+
+    expect(res).toEqual({ sent: false, error: "First: smtp.one down; Second: smtp.two down" });
   });
 });
 

--- a/controller/tests/settings.test.ts
+++ b/controller/tests/settings.test.ts
@@ -54,6 +54,18 @@ describe("getSetting / setSetting", () => {
     expect(raw.value).toContain("enc:v1:");
   });
 
+  it("encrypts passwords inside ranked SMTP configs", () => {
+    settings.setSetting("smtpConfigs", [{
+      id: "primary", name: "Primary", rank: 1, host: "smtp.example.com", port: 587,
+      user: "mailer", pass: "ranked-secret", from: "labs@example.com", secure: false,
+    }]);
+
+    expect(settings.getSmtpConfigs()[0].pass).toBe("ranked-secret");
+    const raw = dbmod.db().prepare("SELECT value FROM settings WHERE key = 'smtpConfigs'").get() as { value: string };
+    expect(raw.value).not.toContain("ranked-secret");
+    expect(raw.value).toContain("enc:v1:");
+  });
+
   it("falls back to default when the stored value is corrupt JSON", () => {
     dbmod
       .db()
@@ -77,6 +89,7 @@ describe("getSettings", () => {
 
 describe("configuration helpers", () => {
   it("isSmtpConfigured needs both host and from", () => {
+    dbmod.db().prepare("DELETE FROM settings WHERE key = 'smtpConfigs'").run();
     settings.setSetting("smtpHost", "");
     settings.setSetting("smtpFrom", "");
     expect(settings.isSmtpConfigured()).toBe(false);


### PR DESCRIPTION
## Summary
- support multiple SMTP configurations with per-server credentials and sender addresses
- attempt SMTP servers in ascending rank order with automatic failover
- preserve legacy single-server settings until the first ranked-config edit
- add settings UI and encrypted-at-rest coverage for ranked configurations

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm test` (240 tests)
- `npm run build`
- desktop and mobile browser QA of the settings workflow