### PR TITLE
Fix host-prepared Codex sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ bwrap --ro-bind / / --proc /proc --dev /dev \
   --unshare-user --unshare-pid --unshare-net --new-session true
 unshare --user --map-root-user true
 codex --version
-codex sandbox linux -- true
+codex sandbox -- true
 ```
 
 Also verify `nvidia-smi`, Codex workspace writes under the student's home, network namespace

--- a/agent/README.md
+++ b/agent/README.md
@@ -19,7 +19,7 @@ sudo lab-agent start
 ```
 
 After a lab and student have been provisioned, run `sudo lab-agent doctor`. Health is critical if
-Docker userns remapping, bubblewrap namespaces, the real `codex sandbox linux -- true` smoke test,
+Docker userns remapping, bubblewrap namespaces, the real `codex sandbox -- true` smoke test,
 NVML/CDI, ZFS, or the configured SMB mount fails.
 
 Development checks:

--- a/agent/src/lab_agent/assets/lab-codex.apparmor
+++ b/agent/src/lab_agent/assets/lab-codex.apparmor
@@ -39,6 +39,10 @@ profile lab-codex flags=(attach_disconnected,mediate_deleted) {
     deny /proc/tty/driver/** rwklx,
     deny /sys/firmware/** rwklx,
     deny /sys/kernel/security/** rwklx,
+    # Mount propagation is mediated separately from ordinary mounts on Ubuntu kernels. bwrap's
+    # first mount operation is mount(NULL, "/", MS_REC|MS_SLAVE), reported by AppArmor as
+    # make-rslave; without this explicit rule it fails before constructing the sandbox root.
+    mount options=(rw, make-rslave) -> /,
     mount,
     umount,
     pivot_root,

--- a/agent/src/lab_agent/system.py
+++ b/agent/src/lab_agent/system.py
@@ -350,7 +350,7 @@ def detect_capabilities(cfg: AgentConfig, *, deep: bool = True) -> Capabilities:
                 target, ["unshare", "--user", "--map-root-user", "true"]
             )
             codex_ok = _student_command(target, ["codex", "--version"]) and _student_command(
-                target, ["codex", "sandbox", "linux", "--", "true"]
+                target, ["codex", "sandbox", "--", "true"]
             )
         else:
             _issue(
@@ -367,7 +367,7 @@ def detect_capabilities(cfg: AgentConfig, *, deep: bool = True) -> Capabilities:
                "Nested unprivileged user namespace test failed", True)
     if deep and target is not None and not codex_ok:
         _issue(issues, "codex_sandbox_failed", "critical",
-               "codex sandbox linux -- true failed as a provisioned student")
+               "codex sandbox -- true failed as a provisioned student")
 
     gpu_list = run(["nvidia-smi", "-L"], timeout=20)
     smi_count = sum(1 for line in gpu_list.stdout.splitlines()

--- a/agent/tests/integration/test_real_lab.py
+++ b/agent/tests/integration/test_real_lab.py
@@ -54,13 +54,13 @@ def test_unprivileged_bubblewrap_and_codex():
     )
     student_exec("unshare", "--user", "--map-root-user", "true")
     student_exec("codex", "--version")
-    student_exec("codex", "sandbox", "linux", "--", "true")
+    student_exec("codex", "sandbox", "--", "true")
 
 
 def test_gpu_storage_and_quota_commands():
     student_exec("sh", "-c", "test -w /home/$USER && test -w /cold-storage/$USER")
     student_exec("nvidia-smi")
-    student_exec("codex", "sandbox", "linux", "--", "nvidia-smi")
+    student_exec("codex", "sandbox", "--", "nvidia-smi")
     student_exec("labquota", "--me")
 
 

--- a/agent/tests/test_hostprep.py
+++ b/agent/tests/test_hostprep.py
@@ -210,3 +210,4 @@ def test_security_assets_include_required_runtime_syscalls():
     apparmor = root.joinpath("lab-codex.apparmor").read_text()
     assert "/usr/bin/bwrap cx -> lab-codex-bwrap" in apparmor
     assert "profile lab-codex-bwrap" in apparmor and "userns," in apparmor
+    assert "mount options=(rw, make-rslave) -> /," in apparmor


### PR DESCRIPTION
## Summary
- allow bubblewrap root mount propagation in the AppArmor profile installed by `host-prepare`
- use the current `codex sandbox -- COMMAND` CLI syntax in doctor and integration checks
- update operator documentation and assert the required AppArmor rule in tests

## Verification
- `cd agent && uv run --extra dev ruff check src tests`
- `cd agent && uv run --extra dev pytest -q` (217 passed, 4 skipped)
- `cd controller && npm run typecheck`
- `cd controller && npm run lint`
- `cd controller && npm test` (240 passed)
- `cd controller && npm run build`