### PR TITLE
Use Codex sandbox as runtime health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,7 @@ the real bubblewrap and Codex smoke tests as that ordinary user. A lab is not he
 commands pass inside its outer container:
 
 ```bash
-bwrap --ro-bind / / --proc /proc --dev /dev \
-  --unshare-user --unshare-pid --unshare-net --new-session true
+bwrap --version
 unshare --user --map-root-user true
 codex --version
 codex sandbox -- true

--- a/agent/src/lab_agent/assets/lab-codex.apparmor
+++ b/agent/src/lab_agent/assets/lab-codex.apparmor
@@ -39,10 +39,6 @@ profile lab-codex flags=(attach_disconnected,mediate_deleted) {
     deny /proc/tty/driver/** rwklx,
     deny /sys/firmware/** rwklx,
     deny /sys/kernel/security/** rwklx,
-    # Mount propagation is mediated separately from ordinary mounts on Ubuntu kernels. bwrap's
-    # first mount operation is mount(NULL, "/", MS_REC|MS_SLAVE), reported by AppArmor as
-    # make-rslave; without this explicit rule it fails before constructing the sandbox root.
-    mount options=(rw, make-rslave) -> /,
     mount,
     umount,
     pivot_root,

--- a/agent/src/lab_agent/system.py
+++ b/agent/src/lab_agent/system.py
@@ -342,10 +342,10 @@ def detect_capabilities(cfg: AgentConfig, *, deep: bool = True) -> Capabilities:
             mode = run(["docker", "exec", target[0], "stat", "-c", "%a", "/usr/bin/bwrap"],
                        timeout=20)
             mode_ok = mode.ok and mode.stdout.strip() == "755"
-            bwrap_ok = mode_ok and _student_command(target, [
-                "bwrap", "--ro-bind", "/", "/", "--proc", "/proc", "--dev", "/dev",
-                "--unshare-user", "--unshare-pid", "--unshare-net", "--new-session", "true",
-            ])
+            # Codex owns its bwrap invocation and changes it as the Linux sandbox evolves. Keep
+            # this distribution-binary check to the contract we control; codex_ok below is the
+            # authoritative end-to-end sandbox smoke test.
+            bwrap_ok = mode_ok and _student_command(target, ["bwrap", "--version"])
             nested_userns_ok = nested_userns_ok and _student_command(
                 target, ["unshare", "--user", "--map-root-user", "true"]
             )
@@ -361,7 +361,7 @@ def detect_capabilities(cfg: AgentConfig, *, deep: bool = True) -> Capabilities:
             )
     if not bwrap_ok:
         _issue(issues, "bubblewrap_failed", "critical",
-               "Distribution /usr/bin/bwrap is missing, setuid, or cannot create its sandbox", True)
+               "Distribution /usr/bin/bwrap is missing, setuid, or not executable", True)
     if not nested_userns_ok and not any(i.code == "bubblewrap_namespace" for i in issues):
         _issue(issues, "bubblewrap_namespace", "critical",
                "Nested unprivileged user namespace test failed", True)

--- a/agent/tests/integration/test_real_lab.py
+++ b/agent/tests/integration/test_real_lab.py
@@ -48,10 +48,7 @@ def test_outer_boundary_and_mounts():
 
 
 def test_unprivileged_bubblewrap_and_codex():
-    student_exec(
-        "bwrap", "--ro-bind", "/", "/", "--proc", "/proc", "--dev", "/dev",
-        "--unshare-user", "--unshare-pid", "--unshare-net", "--new-session", "true",
-    )
+    student_exec("bwrap", "--version")
     student_exec("unshare", "--user", "--map-root-user", "true")
     student_exec("codex", "--version")
     student_exec("codex", "sandbox", "--", "true")

--- a/agent/tests/test_hostprep.py
+++ b/agent/tests/test_hostprep.py
@@ -210,4 +210,3 @@ def test_security_assets_include_required_runtime_syscalls():
     apparmor = root.joinpath("lab-codex.apparmor").read_text()
     assert "/usr/bin/bwrap cx -> lab-codex-bwrap" in apparmor
     assert "profile lab-codex-bwrap" in apparmor and "userns," in apparmor
-    assert "mount options=(rw, make-rslave) -> /," in apparmor


### PR DESCRIPTION
## Summary
- treat `codex sandbox -- true` as the authoritative end-to-end sandbox smoke test
- limit the standalone distribution bubblewrap check to presence, non-setuid mode, and student executability
- remove the ineffective AppArmor propagation exception and stale standalone bwrap sandbox recipe

## Verification
- `cd agent && uv run --extra dev ruff check src tests`
- `cd agent && uv run --extra dev pytest -q` (217 passed, 4 skipped)