### PR TITLE
Allow student Codex self-updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,12 @@ jobs:
         run: sudo apparmor_parser -Q -T agent/src/lab_agent/assets/lab-codex.apparmor
       - name: Build pinned lab image
         run: docker build --tag custom-ssh:ci image
+      - name: Verify student npm prefix
+        run: |
+          docker run --rm --entrypoint sh custom-ssh:ci -c '
+            useradd -m -s /bin/bash student
+            su - student -c '\''
+              test "$(npm config get prefix)" = "$HOME/.local"
+              case ":$PATH:" in *":$HOME/.local/bin:"*) ;; *) exit 1 ;; esac
+            '\''
+          '

--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ seccomp support, Git, ripgrep, curl, proc tools, and a version-pinned Codex CLI.
 contains no systemd, Docker packages, daemon configuration, socket, inner NVIDIA runtime, or NVIDIA
 service.
 
+The pinned root-owned Codex is the image baseline. Student npm global installs use
+`$HOME/.local`, so Codex's in-app updater works without sudo and persists with the student's home.
+`host-prepare` applies the same npm configuration to already-running managed labs.
+
 ## 3. Start and validate the node
 
 ```bash
@@ -159,6 +163,10 @@ unshare --user --map-root-user true
 codex --version
 codex sandbox -- true
 ```
+
+Run a raw bubblewrap diagnostic directly from the student's shell, not as a Codex tool command.
+Codex tool commands already run inside a bubblewrap sandbox that intentionally blocks creating a
+further nested user namespace.
 
 Also verify `nvidia-smi`, Codex workspace writes under the student's home, network namespace
 isolation, and that container root cannot modify a host sentinel outside `/home` and

--- a/agent/src/lab_agent/hostprep.py
+++ b/agent/src/lab_agent/hostprep.py
@@ -13,6 +13,7 @@ import grp
 import json
 import os
 import pwd
+import shlex
 import shutil
 from collections.abc import Sequence
 from importlib import resources
@@ -28,6 +29,10 @@ SUBUID = Path("/etc/subuid")
 SUBGID = Path("/etc/subgid")
 SYSCTL_FILE = Path("/etc/sysctl.d/90-lab-codex.conf")
 APPARMOR_DEST = Path("/etc/apparmor.d/lab-codex")
+
+LAB_NPM_PROFILE = """export NPM_CONFIG_PREFIX="$HOME/.local"
+export PATH="$HOME/.local/bin:$PATH"
+"""
 
 # Packages available from the default Ubuntu archive. ca-certificates/curl/gnupg are fetched first
 # because adding the Docker/NVIDIA apt repos below needs them.
@@ -282,6 +287,43 @@ def _install_security_assets(cfg: AgentConfig) -> None:
             raise RuntimeError(f"could not load bwrap-userns-restrict: {loaded.logs}")
 
 
+def _lab_npm_config_script() -> str:
+    return (
+        "set -eu\n"
+        "touch /etc/npmrc\n"
+        "sed -i '/^[[:space:]]*prefix[[:space:]]*=/d' /etc/npmrc\n"
+        "printf '%s\\n' 'prefix=${HOME}/.local' >> /etc/npmrc\n"
+        "install -d -m 0755 /etc/profile.d\n"
+        "printf '%s' " + shlex.quote(LAB_NPM_PROFILE)
+        + " > /etc/profile.d/lab-npm-user-prefix.sh\n"
+        "grep -qxF '. /etc/profile.d/lab-npm-user-prefix.sh' /etc/bash.bashrc || "
+        "printf '%s\\n' '. /etc/profile.d/lab-npm-user-prefix.sh' >> /etc/bash.bashrc\n"
+        "chmod 0644 /etc/npmrc /etc/profile.d/lab-npm-user-prefix.sh\n"
+    )
+
+
+def _configure_running_lab_npm() -> list[str]:
+    """Give students a persistent, home-owned npm prefix in every running managed lab.
+
+    The image keeps a pinned root-owned Codex as its baseline.  Codex's in-app updater runs as the
+    student, so its global npm install must land in the persistent home instead of /usr/lib.
+    """
+    listed = run([
+        "docker", "ps", "--filter", "label=lab-agent.managed=true", "--format", "{{.Names}}"
+    ], timeout=20)
+    if not listed.ok:
+        raise RuntimeError(f"could not list managed labs for npm configuration: {listed.logs}")
+
+    configured: list[str] = []
+    script = _lab_npm_config_script()
+    for name in listed.stdout.splitlines():
+        result = run(["docker", "exec", name, "sh", "-c", script], timeout=30)
+        if not result.ok:
+            raise RuntimeError(f"could not configure student npm prefix in {name}: {result.logs}")
+        configured.append(name)
+    return configured
+
+
 def _zfs_pools_ready(cfg: AgentConfig) -> bool:
     """Whether the zpool(s) the Docker ZFS dataset depends on already exist. Disk topology is an
     operator decision made outside host-prepare (see module docstring); until the pool(s) show up,
@@ -424,6 +466,7 @@ def prepare_host(cfg: AgentConfig) -> dict[str, Any]:
     restarted = run(["systemctl", "restart", "docker"], timeout=120)
     if not restarted.ok:
         raise RuntimeError(restarted.logs)
+    npm_configured_labs = _configure_running_lab_npm()
     return {
         "userns_user": cfg.userns_user,
         "subordinate_range": [cfg.userns_start, cfg.userns_size],
@@ -434,4 +477,5 @@ def prepare_host(cfg: AgentConfig) -> dict[str, Any]:
         "gpu_cgroupfs_workaround": gpu_present,
         "seccomp_profile": cfg.seccomp_profile,
         "apparmor_profile": cfg.apparmor_profile,
+        "npm_user_prefix_labs": npm_configured_labs,
     }

--- a/agent/src/lab_agent/system.py
+++ b/agent/src/lab_agent/system.py
@@ -352,6 +352,17 @@ def detect_capabilities(cfg: AgentConfig, *, deep: bool = True) -> Capabilities:
             codex_ok = _student_command(target, ["codex", "--version"]) and _student_command(
                 target, ["codex", "sandbox", "--", "true"]
             )
+            npm_prefix_ok = _student_command(
+                target, ["sh", "-c", 'test "$(npm config get prefix)" = "$HOME/.local"']
+            )
+            if not npm_prefix_ok:
+                _issue(
+                    issues,
+                    "codex_update_prefix",
+                    "critical",
+                    "Student npm prefix is not home-owned; run lab-agent host-prepare",
+                    True,
+                )
         else:
             _issue(
                 issues,

--- a/agent/tests/test_hostprep.py
+++ b/agent/tests/test_hostprep.py
@@ -210,3 +210,21 @@ def test_security_assets_include_required_runtime_syscalls():
     apparmor = root.joinpath("lab-codex.apparmor").read_text()
     assert "/usr/bin/bwrap cx -> lab-codex-bwrap" in apparmor
     assert "profile lab-codex-bwrap" in apparmor and "userns," in apparmor
+
+
+def test_running_labs_get_home_owned_npm_prefix(monkeypatch):
+    runner = Runner({
+        "docker ps": (True, "lab-one\nlab-two\n"),
+        "docker exec": (True, ""),
+    })
+    monkeypatch.setattr(hostprep, "run", runner)
+    assert hostprep._configure_running_lab_npm() == ["lab-one", "lab-two"]
+    exec_calls = [call for call in runner.calls if call.startswith("docker exec")]
+    assert len(exec_calls) == 2
+    assert all("prefix=${HOME}/.local" in call for call in exec_calls)
+    assert all("/etc/profile.d/lab-npm-user-prefix.sh" in call for call in exec_calls)
+
+
+def test_lab_npm_configuration_script_has_valid_shell_syntax():
+    result = real_run(["sh", "-n", "-c", hostprep._lab_npm_config_script()])
+    assert result.ok, result.logs

--- a/agent/tests/test_image_contract.py
+++ b/agent/tests/test_image_contract.py
@@ -9,6 +9,9 @@ def test_lab_image_has_codex_bubblewrap_and_no_nested_engine():
     assert "bubblewrap uidmap libseccomp2" in dockerfile
     assert "chmod 0755 /usr/bin/bwrap" in dockerfile
     assert "test ! -u /usr/bin/bwrap" in dockerfile
+    assert "prefix=${HOME}/.local" in dockerfile
+    assert 'export PATH="$HOME/.local/bin:$PATH"' in dockerfile
+    assert ". /etc/profile.d/lab-npm-user-prefix.sh" in dockerfile
     assert "systemd" not in dockerfile
     assert "/sbin/init" not in dockerfile
     assert 'STOPSIGNAL SIGTERM' in dockerfile

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -21,6 +21,16 @@ RUN apt-get update \
     && test ! -u /usr/bin/bwrap \
     && rm -rf /var/lib/apt/lists/* /root/.npm
 
+# Keep the pinned system Codex as a baseline while allowing its student-run in-app updater to
+# install a newer global package into the persistent home without sudo.
+RUN printf '%s\n' 'prefix=${HOME}/.local' > /etc/npmrc \
+    && printf '%s\n' \
+        'export NPM_CONFIG_PREFIX="$HOME/.local"' \
+        'export PATH="$HOME/.local/bin:$PATH"' \
+        > /etc/profile.d/lab-npm-user-prefix.sh \
+    && printf '%s\n' '. /etc/profile.d/lab-npm-user-prefix.sh' >> /etc/bash.bashrc \
+    && chmod 0644 /etc/npmrc /etc/profile.d/lab-npm-user-prefix.sh
+
 # Password SSH remains the initial access mechanism; root login is disabled. Every container creates
 # unique host keys on first boot.
 RUN sed -i 's/^#\?PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config \


### PR DESCRIPTION
## Summary
- configure npm global installs under each student persistent home so the Codex in-app updater does not need root
- have `host-prepare` converge the npm prefix in existing running managed labs
- add doctor coverage for updater readiness and document why raw bwrap cannot be tested from inside a Codex tool sandbox
- verify the student npm prefix in the built image CI job

## Verification
- `cd agent && uv run --extra dev ruff check src tests`
- `cd agent && uv run --extra dev pytest -q` (219 passed, 4 skipped)