### PR TITLE
Persist npm prefix per student

### DIFF
--- a/agent/src/lab_agent/executors/users.py
+++ b/agent/src/lab_agent/executors/users.py
@@ -74,6 +74,12 @@ fi
 ln -sfn /cold-storage/"$u" /home/"$u"/cold-storage
 chown -h {uid}:{gid} /home/"$u"/cold-storage
 grep -q '^umask ' /home/"$u"/.bashrc 2>/dev/null || echo 'umask 027' >> /home/"$u"/.bashrc
+install -d -m 0755 -o {uid} -g {gid} /home/"$u"/.local /home/"$u"/.local/bin
+touch /home/"$u"/.npmrc
+sed -i '/^[[:space:]]*prefix[[:space:]]*=/d' /home/"$u"/.npmrc
+printf 'prefix=/home/%s/.local\n' "$u" >> /home/"$u"/.npmrc
+chown {uid}:{gid} /home/"$u"/.npmrc
+chmod 0644 /home/"$u"/.npmrc
 printf '%s:%s' "$u" {_shell_quote(password)} | chpasswd
 """
     return _run_script(container, script)

--- a/agent/src/lab_agent/hostprep.py
+++ b/agent/src/lab_agent/hostprep.py
@@ -299,6 +299,16 @@ def _lab_npm_config_script() -> str:
         "grep -qxF '. /etc/profile.d/lab-npm-user-prefix.sh' /etc/bash.bashrc || "
         "printf '%s\\n' '. /etc/profile.d/lab-npm-user-prefix.sh' >> /etc/bash.bashrc\n"
         "chmod 0644 /etc/npmrc /etc/profile.d/lab-npm-user-prefix.sh\n"
+        "getent passwd | while IFS=: read -r user _ uid gid _ home _; do\n"
+        "  if [ \"$uid\" -ge 10000 ] 2>/dev/null && [ \"$uid\" -le 59999 ]; then\n"
+        "    install -d -m 0755 -o \"$uid\" -g \"$gid\" \"$home/.local\" \"$home/.local/bin\"\n"
+        "    touch \"$home/.npmrc\"\n"
+        "    sed -i '/^[[:space:]]*prefix[[:space:]]*=/d' \"$home/.npmrc\"\n"
+        "    printf 'prefix=%s/.local\\n' \"$home\" >> \"$home/.npmrc\"\n"
+        "    chown \"$uid:$gid\" \"$home/.npmrc\"\n"
+        "    chmod 0644 \"$home/.npmrc\"\n"
+        "  fi\n"
+        "done\n"
     )
 
 

--- a/agent/tests/test_hostprep.py
+++ b/agent/tests/test_hostprep.py
@@ -223,6 +223,8 @@ def test_running_labs_get_home_owned_npm_prefix(monkeypatch):
     assert len(exec_calls) == 2
     assert all("prefix=${HOME}/.local" in call for call in exec_calls)
     assert all("/etc/profile.d/lab-npm-user-prefix.sh" in call for call in exec_calls)
+    assert all('"$home/.npmrc"' in call for call in exec_calls)
+    assert all("10000" in call and "59999" in call for call in exec_calls)
 
 
 def test_lab_npm_configuration_script_has_valid_shell_syntax():

--- a/agent/tests/test_users.py
+++ b/agent/tests/test_users.py
@@ -26,6 +26,9 @@ def test_add_user_exact_ids_sudo_and_flat_links(monkeypatch):
     assert '/cold-storage/"$u"' in script
     assert '/fast/"$u"' not in script and '/cold/"$u"' not in script
     assert "docker" not in script
+    assert '/home/"$u"/.npmrc' in script
+    assert "prefix=/home/%s/.local" in script
+    assert '/home/"$u"/.local/bin' in script
 
 
 def test_uid_and_username_validation(monkeypatch):


### PR DESCRIPTION
## Summary
- write an explicit home-owned npm prefix into every provisioned student `.npmrc`
- have `host-prepare` converge existing persistent student homes in running managed labs
- create the persistent `.local/bin` destination with correct student ownership

This avoids dependence on npm global-config precedence and makes Codex self-updates deterministic.

## Verification
- `cd agent && uv run --extra dev ruff check src tests`
- `cd agent && uv run --extra dev pytest -q` (219 passed, 4 skipped)