### PR TITLE
Fix nested Bubblewrap under Docker userns remap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Lab Manager: runc, Docker user namespaces, and Codex
 
 This repository runs one standard `runc` container per lab. There is no container engine inside a
-lab, no host engine socket, and no privileged mode. Students retain full `sudo` inside the lab;
-daemon-wide `userns-remap` maps that root account to an unprivileged host ID.
+lab, no host engine socket, and no privileged mode. Students retain full password-authenticated
+`sudo` inside the lab. Managed labs use Docker's per-container host user namespace because a
+daemon-remapped parent namespace locks the inherited mounts that nested bubblewrap must modify.
 
 Codex is a required workload. The lab image includes a pinned Codex CLI and distribution
 `/usr/bin/bwrap`; the outer container uses dedicated seccomp and AppArmor profiles that allow
@@ -33,8 +34,7 @@ the NVIDIA Container Toolkit once it sees GPU hardware). Every node must reserve
 user:  labdockremap
 subuid/subgid start: 231072
 range: 65536
-student container IDs: 10000-59999
-mapped host ID: 231072 + container ID
+student container and host IDs: 10000-59999
 ```
 
 Create the storage roots. The agent creates the per-lab datasets, but the pools must already exist:
@@ -117,6 +117,13 @@ and read-only submounts below `/proc` make Linux reject the fresh procfs mount r
 unprivileged bubblewrap PID namespace. The `lab-codex` AppArmor profile preserves those sensitive
 path restrictions without the conflicting submounts. Existing containers must be recreated after
 this contract changes; doctor reports them as `container_systempaths_stale`.
+
+Managed labs override the daemon default with `--userns=host`. Without that override, Linux locks
+the root mount inherited from Docker's remapped namespace and bubblewrap fails at `make / slave`
+before it can construct its sandbox. Students start unprivileged; each student has a real sudo rule
+that requires their assigned password. AppArmor, seccomp, the absence of Docker's socket, and the
+restricted bind mounts remain the outer boundary. This contract requires a clean lab reinstall
+because persistent ownership changes from remapped IDs to the stable student IDs.
 
 Inspect the resulting Docker settings before accepting work:
 

--- a/agent/src/lab_agent/containerops.py
+++ b/agent/src/lab_agent/containerops.py
@@ -30,6 +30,7 @@ def _labels(cfg: AgentConfig, lab: str) -> dict[str, str]:
         # This creation-time Docker option removes /proc overmounts that prevent bubblewrap from
         # mounting the procfs for its PID namespace. Doctor uses the label to reject old labs.
         "lab-agent.systempaths-unconfined": "true",
+        "lab-agent.userns": "host",
     }
 
 

--- a/agent/src/lab_agent/executors/docker.py
+++ b/agent/src/lab_agent/executors/docker.py
@@ -112,9 +112,12 @@ def build_run_args(
     if opts.ssh_port:
         args += ["-p", f"{opts.ssh_port}:22"]
     args += ["--cpus", opts.cpus, "--memory", opts.memory, "--shm-size", opts.shm_size]
-    # Standard runc + daemon-wide userns-remap provide the outer boundary. The custom profiles keep
-    # outer boundary while allowing unprivileged bubblewrap to create nested namespaces.
-    args += ["--runtime=runc", "--cgroupns=private", "--stop-signal", "SIGTERM"]
+    # A daemon-remapped parent user namespace locks inherited mounts against a student's nested
+    # namespace, so bubblewrap cannot change root mount propagation. Labs use the initial user
+    # namespace; students are non-root by default and sudo requires their password.
+    args += [
+        "--runtime=runc", "--userns=host", "--cgroupns=private", "--stop-signal", "SIGTERM"
+    ]
     args += ["--tmpfs", "/run:rw,nosuid,nodev", "--tmpfs", "/run/lock:rw,nosuid,nodev"]
     args += ["--security-opt", f"seccomp={mounts.seccomp_profile}"]
     args += ["--security-opt", f"apparmor={mounts.apparmor_profile}"]

--- a/agent/src/lab_agent/executors/users.py
+++ b/agent/src/lab_agent/executors/users.py
@@ -4,9 +4,9 @@ A student is a Linux user inside the lab container with:
   /home/<u>               is the persistent fast directory
   /home/<u>/cold-storage  -> /cold-storage/<u>
 
-There are no per-student datasets. The agent creates the storage directories on the host with
-daemon user-namespace-remapped numeric ownership before creating this account. The script is piped
-via stdin so the password never appears in the host process list.
+There are no per-student datasets. The agent creates storage directories with the student's stable
+numeric ownership before creating this account. The script is piped via stdin so the password never
+appears in the host process list.
 """
 
 from __future__ import annotations
@@ -52,8 +52,8 @@ def add_user(container: str, username: str, password: str, uid: int, gid: int) -
     validate_uid(uid, gid)
     # Password is embedded in the stdin-piped script body, never in argv.
     #
-    # Full sudo is intentionally retained. Docker's daemon-wide userns-remap maps container root to
-    # an unprivileged host uid; students remain mutually trusted within their shared lab container.
+    # Full sudo is retained, but it must require the student's password. A late-sorted per-user rule
+    # overrides NOPASSWD defaults that may be supplied by the base image.
     script = f"""set -e
 u={username}
 existing_group=$(getent group {gid} | cut -d: -f1 || true)
@@ -66,6 +66,8 @@ fi
 test "$(id -u "$u")" = "{uid}"
 test "$(id -g "$u")" = "{gid}"
 usermod -aG sudo "$u"
+printf '%s ALL=(ALL:ALL) PASSWD: ALL\n' "$u" > /etc/sudoers.d/zz-lab-agent-"$u"
+chmod 0440 /etc/sudoers.d/zz-lab-agent-"$u"
 chmod 0700 /home/"$u"
 if [ -e /home/"$u"/cold-storage ] && [ ! -L /home/"$u"/cold-storage ]; then
   echo "refusing to replace non-symlink cold-storage path" >&2

--- a/agent/src/lab_agent/labops.py
+++ b/agent/src/lab_agent/labops.py
@@ -41,14 +41,11 @@ def create_lab(cfg: AgentConfig, params: dict[str, Any]) -> tuple[Any, str]:
     )
     coldstore.create_lab(cfg, lab, slow_quota)
 
-    # With Docker userns-remap, container root is a high host uid. It owns each lab mount root so it
-    # can administer users inside the container without gaining host-root ownership.
+    # Managed labs use --userns=host, so container root owns the lab mount roots as host uid 0.
     from .executors import coldfs
 
-    coldfs.ensure_owned_dir(zfs.get_mountpoint(lab_fast(cfg, lab)), cfg.userns_start,
-                            cfg.userns_start, mode=0o711)
-    coldfs.ensure_owned_dir(coldstore.lab_mount(cfg, lab), cfg.userns_start,
-                            cfg.userns_start, mode=0o711)
+    coldfs.ensure_owned_dir(zfs.get_mountpoint(lab_fast(cfg, lab)), 0, 0, mode=0o711)
+    coldfs.ensure_owned_dir(coldstore.lab_mount(cfg, lab), 0, 0, mode=0o711)
 
     # Provision the shared container (no-op if Docker absent -> reported as failure upstream).
     container = containerops.ensure_container(cfg, lab, params)

--- a/agent/src/lab_agent/studentops.py
+++ b/agent/src/lab_agent/studentops.py
@@ -19,15 +19,16 @@ def add_student(cfg: AgentConfig, params: dict[str, Any]) -> tuple[Any, str]:
     users.validate_username(username)
     users.validate_uid(uid, gid)
 
-    host_uid = cfg.userns_start + uid
-    host_gid = cfg.userns_start + gid
+    # Managed labs use --userns=host, so persistent storage has identical host/container IDs.
+    host_uid = uid
+    host_gid = gid
     fast_root = zfs.get_mountpoint(lab_fast(cfg, lab))
     cold_root = coldstore.lab_mount(cfg, lab)
     coldfs.ensure_owned_dir(f"{fast_root}/{username}", host_uid, host_gid)
     coldfs.ensure_owned_dir(f"{cold_root}/{username}", host_uid, host_gid)
 
-    # The directories already have the daemon-remapped host IDs; the in-container account receives
-    # the matching stable IDs and only creates home-directory symlinks.
+    # The directories already have the student's stable IDs; account creation populates the home
+    # and creates its cold-storage symlink.
     users.add_user(docker.container_name(lab), username, password, uid, gid)
     return {"lab": lab, "username": username, "uid": uid}, (
         f"added student '{username}' (uid={uid}) to lab '{lab}'"

--- a/agent/src/lab_agent/system.py
+++ b/agent/src/lab_agent/system.py
@@ -229,6 +229,24 @@ def _stale_systempaths_containers() -> list[str]:
     ]
 
 
+def _stale_lab_userns_containers() -> list[str]:
+    """Return managed containers that still inherit Docker's remapped user namespace."""
+    listed = run([
+        "docker", "ps", "--filter", "label=lab-agent.managed=true",
+        "--format", "{{.Names}}",
+    ], timeout=20)
+    if not listed.ok:
+        return []
+    stale: list[str] = []
+    for container in listed.stdout.splitlines():
+        mode = run([
+            "docker", "inspect", "--format", "{{.HostConfig.UsernsMode}}", container,
+        ], timeout=20)
+        if not mode.ok or mode.stdout.strip() != "host":
+            stale.append(container)
+    return stale
+
+
 def _first_student_container() -> tuple[str, str] | None:
     listed = run([
         "docker", "ps", "--filter", "label=lab-agent.managed=true", "--format", "{{.Names}}"
@@ -264,7 +282,7 @@ def _smb_posix_ok(cfg: AgentConfig) -> bool:
     if not os.path.ismount(cfg.slow_path):
         return False
     probe = os.path.join(cfg.slow_path, f".lab-agent-posix-probe-{os.getpid()}")
-    mapped = cfg.userns_start + 10_000
+    mapped = 10_000
     child = os.path.join(probe, "write-test")
     try:
         os.mkdir(probe, 0o700)
@@ -353,6 +371,15 @@ def detect_capabilities(cfg: AgentConfig, *, deep: bool = True) -> Capabilities:
                 "critical",
                 "Managed containers require recreation for nested bubblewrap procfs: "
                 + ", ".join(stale_systempaths),
+            )
+        stale_lab_userns = _stale_lab_userns_containers()
+        if stale_lab_userns:
+            _issue(
+                issues,
+                "container_userns_stale",
+                "critical",
+                "Managed containers require reinstall for bubblewrap-compatible user namespaces: "
+                + ", ".join(stale_lab_userns),
             )
         target = _first_student_container()
         if target:

--- a/agent/tests/integration/test_real_lab.py
+++ b/agent/tests/integration/test_real_lab.py
@@ -38,6 +38,7 @@ def test_outer_boundary_and_mounts():
     assert "SYS_ADMIN" not in (host.get("CapAdd") or [])
     security = host.get("SecurityOpt") or []
     assert "systempaths=unconfined" in security
+    assert host["UsernsMode"] == "host"
     assert "seccomp=unconfined" not in security and "apparmor=unconfined" not in security
     destinations = {mount["Destination"] for mount in config["Mounts"]}
     assert destinations == {"/home", "/cold-storage", "/run/labquota"}
@@ -70,6 +71,11 @@ def test_gpu_storage_and_quota_commands():
 def test_sudo_reaches_container_root_but_not_host_files():
     if not PASSWORD:
         pytest.skip("set LAB_INTEGRATION_PASSWORD to verify student sudo")
+    passwordless = subprocess.run(
+        ["docker", "exec", "-u", STUDENT, CONTAINER, "sudo", "-n", "true"],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert passwordless.returncode != 0
     with tempfile.NamedTemporaryFile(prefix="lab-host-sentinel-", delete=False) as sentinel:
         sentinel.write(b"host-safe")
         path = sentinel.name

--- a/agent/tests/test_containerops.py
+++ b/agent/tests/test_containerops.py
@@ -42,6 +42,7 @@ def test_labels_stamp_seccomp_digest(monkeypatch):
     monkeypatch.setattr(containerops.docker, "security_profile_digest", lambda path: "abc123")
     assert containerops._labels(cfg(), "bio")["lab-agent.seccomp-sha256"] == "abc123"
     assert containerops._labels(cfg(), "bio")["lab-agent.systempaths-unconfined"] == "true"
+    assert containerops._labels(cfg(), "bio")["lab-agent.userns"] == "host"
 
 
 def test_creation_requires_userns_and_passes_cdi(monkeypatch):

--- a/agent/tests/test_docker.py
+++ b/agent/tests/test_docker.py
@@ -10,12 +10,13 @@ def mounts():
                   "/etc/lab-agent/security/lab-codex-seccomp.json", "lab-codex")
 
 
-def test_runc_userns_outer_container_contract():
+def test_runc_host_userns_outer_container_contract():
     opts = ContainerOptions(image="custom-ssh", cpus="8", memory="16g", shm_size="2g",
                             rootfs_quota="100g", ssh_port=50012)
     args = build_run_args("lab-bio", opts, mounts(), gpus=True)
     joined = " ".join(args)
     assert "--runtime=runc" in args
+    assert "--userns=host" in args
     assert "--device nvidia.com/gpu=all" in joined
     assert "seccomp=/etc/lab-agent/security/lab-codex-seccomp.json" in joined
     assert "apparmor=lab-codex" in joined

--- a/agent/tests/test_studentops.py
+++ b/agent/tests/test_studentops.py
@@ -27,14 +27,14 @@ def patch_storage(monkeypatch):
     return dirs, removed, users
 
 
-def test_add_student_uses_mapped_host_ownership(monkeypatch):
+def test_add_student_uses_native_host_ownership(monkeypatch):
     dirs, _, calls = patch_storage(monkeypatch)
     result, _ = studentops.add_student(cfg(), {
         "lab": "bio", "username": "alice", "password": "pw", "uid": 10042, "gid": 10042,
     })
     assert result["uid"] == 10042
-    assert dirs == [("/fast/bio/alice", 241114, 241114),
-                    ("/cold/bio/alice", 241114, 241114)]
+    assert dirs == [("/fast/bio/alice", 10042, 10042),
+                    ("/cold/bio/alice", 10042, 10042)]
     assert calls == [("add", "lab-bio", "alice", 10042, 10042)]
 
 

--- a/agent/tests/test_system.py
+++ b/agent/tests/test_system.py
@@ -144,3 +144,13 @@ def test_stale_systempaths_containers_detects_old_contract(monkeypatch):
         "docker ps": (True, "lab-old\nlab-stale\tfalse\nlab-current\ttrue\n"),
     }))
     assert system._stale_systempaths_containers() == ["lab-old", "lab-stale"]
+
+
+def test_stale_lab_userns_containers_detects_remapped_contract(monkeypatch):
+    monkeypatch.setattr(system, "run", Runner({
+        "docker ps": (True, "lab-old\nlab-remapped\nlab-current\n"),
+        "docker inspect --format {{.HostConfig.UsernsMode}} lab-old": (True, ""),
+        "docker inspect --format {{.HostConfig.UsernsMode}} lab-remapped": (True, "default"),
+        "docker inspect --format {{.HostConfig.UsernsMode}} lab-current": (True, "host"),
+    }))
+    assert system._stale_lab_userns_containers() == ["lab-old", "lab-remapped"]

--- a/agent/tests/test_users.py
+++ b/agent/tests/test_users.py
@@ -23,6 +23,9 @@ def test_add_user_exact_ids_sudo_and_flat_links(monkeypatch):
     assert "groupadd -g 10042" in script
     assert 'useradd -M -d /home/"$u" -u 10042 -g 10042' in script
     assert "usermod -aG sudo" in script
+    assert "PASSWD: ALL" in script
+    assert "NOPASSWD" not in script
+    assert "chmod 0440 /etc/sudoers.d/zz-lab-agent" in script
     assert '/cold-storage/"$u"' in script
     assert '/fast/"$u"' not in script and '/cold/"$u"' not in script
     assert "docker" not in script


### PR DESCRIPTION
## Summary
- run managed lab containers with the per-container `--userns=host` override so nested Bubblewrap can change mount propagation
- use native stable UID/GID ownership for persistent student storage
- enforce password-authenticated real sudo with an explicit late sudoers rule
- make doctor inspect the actual container user namespace and require reinstall of stale labs
- extend real-lab acceptance coverage for host userns and non-passwordless sudo

## Root cause
After removing Docker system-path overmounts, Bubblewrap advanced to `Failed to make / slave: Permission denied`. There was no AppArmor/seccomp denial. Docker daemon userns-remap caused the student child namespace to inherit locked mounts, so it could not change `/` propagation.

## Validation
- `agent/.venv/bin/ruff check agent/src agent/tests`
- `agent/.venv/bin/pytest -q agent/tests` (221 passed, 4 skipped)
- `git diff --check`

This changes persistent ownership from remapped IDs to native student IDs and therefore intentionally requires a clean lab reinstall.