### PR TITLE
Publish student guide via GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,72 @@
+name: Publish student guide
+
+# Renders STUDENT_GUIDE.md into a themed GitHub Pages site. The Markdown file at
+# the repo root stays the single source of truth; this workflow wraps it in a
+# minimal Jekyll site at build time so edits publish automatically.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - STUDENT_GUIDE.md
+      - .github/workflows/pages.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; don't cancel an in-progress publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Assemble Jekyll site from STUDENT_GUIDE.md
+        run: |
+          mkdir -p site
+          cat > site/_config.yml <<'YAML'
+          title: Student Lab Guide
+          description: Connecting to and using your lab environment
+          theme: jekyll-theme-cayman
+          YAML
+          # Front matter drives the themed banner; the leading H1 is dropped so
+          # the title isn't rendered twice.
+          {
+            echo '---'
+            echo 'title: Student Lab Guide'
+            echo 'description: Connecting to and using your lab environment'
+            echo '---'
+            echo
+            sed '1{/^# /d}' STUDENT_GUIDE.md
+          } > site/index.md
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./site
+          destination: ./_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Renders [STUDENT_GUIDE.md](../blob/main/STUDENT_GUIDE.md) as a GitHub Pages site.

## What this does
- Adds `.github/workflows/pages.yml`, which wraps the root `STUDENT_GUIDE.md` in a minimal Jekyll site (`jekyll-theme-cayman`) and deploys it to Pages.
- The Markdown stays the single source of truth — the workflow injects front matter and drops the duplicate leading H1 at build time, so editing `STUDENT_GUIDE.md` republishes automatically.
- Triggers on push to `main` (when the guide or the workflow changes) and via manual `workflow_dispatch`.

## Setup already done
- GitHub Pages is enabled with **build type: GitHub Actions**.
- Site URL: **https://ec061.github.io/docker-mass-deployment/**

## To go live
Merge this PR. The workflow runs on `main` and the first deploy publishes the site. (Pages deploys from the default branch, so it won't publish from this PR branch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)