### PR TITLE
Allow bwrap remount propagation in AppArmor profile

### DIFF
--- a/agent/src/lab_agent/assets/lab-codex.apparmor
+++ b/agent/src/lab_agent/assets/lab-codex.apparmor
@@ -69,6 +69,7 @@ profile lab-codex//lab-codex-bwrap flags=(attach_disconnected,mediate_deleted) {
   deny /sys/devices/system/cpu/**/thermal_throttle/** rwklx,
   deny /sys/kernel/security/** rwklx,
   mount,
+  remount,
   umount,
   pivot_root,
   /** ix,

--- a/agent/tests/test_hostprep.py
+++ b/agent/tests/test_hostprep.py
@@ -210,6 +210,7 @@ def test_security_assets_include_required_runtime_syscalls():
     apparmor = root.joinpath("lab-codex.apparmor").read_text()
     assert "/usr/bin/bwrap Px -> lab-codex//lab-codex-bwrap" in apparmor
     assert "profile lab-codex//lab-codex-bwrap" in apparmor and "userns," in apparmor
+    assert "  remount,\n" in apparmor
 
 
 def test_running_labs_get_home_owned_npm_prefix(monkeypatch):


### PR DESCRIPTION
## Summary
- allow `remount,` in the bwrap AppArmor child profile so the `/` propagation change used by bubblewrap is permitted
- assert the profile keeps the remount permission in the hostprep asset test

## Tests
- `./.venv/bin/pytest tests/test_system.py tests/test_docker.py tests/test_hostprep.py`