### PR TITLE
Allow bwrap mount propagation in AppArmor profile

### DIFF
--- a/agent/src/lab_agent/assets/lab-codex.apparmor
+++ b/agent/src/lab_agent/assets/lab-codex.apparmor
@@ -68,6 +68,8 @@ profile lab-codex//lab-codex-bwrap flags=(attach_disconnected,mediate_deleted) {
   deny /sys/devices/virtual/powercap/** rwklx,
   deny /sys/devices/system/cpu/**/thermal_throttle/** rwklx,
   deny /sys/kernel/security/** rwklx,
+  mount options=(rw, make-rslave) -> **,
+  mount options=(rw, make-slave) -> **,
   mount,
   remount,
   umount,

--- a/agent/tests/test_hostprep.py
+++ b/agent/tests/test_hostprep.py
@@ -210,6 +210,7 @@ def test_security_assets_include_required_runtime_syscalls():
     apparmor = root.joinpath("lab-codex.apparmor").read_text()
     assert "/usr/bin/bwrap Px -> lab-codex//lab-codex-bwrap" in apparmor
     assert "profile lab-codex//lab-codex-bwrap" in apparmor and "userns," in apparmor
+    assert "  mount options=(rw, make-rslave) -> **,\n" in apparmor
     assert "  remount,\n" in apparmor
 
 


### PR DESCRIPTION
## Summary
- allow explicit `make-rslave`/`make-slave` mount propagation in the bwrap AppArmor child profile
- keep the propagation rule covered by the hostprep asset test

## Tests
- `./.venv/bin/pytest tests/test_system.py tests/test_docker.py tests/test_hostprep.py`