### PR TITLE
fix(agent): provision Codex Landlock sandbox config

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ lab, no host engine socket, and no privileged mode. Students retain full passwor
 daemon-remapped parent namespace locks the inherited mounts that nested bubblewrap must modify.
 
 Codex is a required workload. The lab image includes a pinned Codex CLI and distribution
-`/usr/bin/bwrap`; the outer container uses dedicated seccomp and AppArmor profiles that allow
-bubblewrap to create nested unprivileged namespaces without granting outer `CAP_SYS_ADMIN`.
+`/usr/bin/bwrap`; the outer container uses dedicated seccomp and AppArmor profiles for sandbox
+setup without granting outer `CAP_SYS_ADMIN`. `host-prepare` also enables Codex's legacy Landlock
+sandbox path for student homes, which avoids requiring setuid bubblewrap inside Docker.
 
 ## Persistent layout
 
@@ -105,6 +106,9 @@ sudo lab-agent host-prepare
   `kernel.apparmor_restrict_unprivileged_userns=1`;
 - installs and loads `lab-codex-seccomp.json`, `lab-codex`, and the distribution
   `bwrap-userns-restrict` profile when available;
+- restores non-setuid mode on `/usr/bin/bwrap` in running managed labs;
+- configures existing student homes with `~/.codex/config.toml` so Codex uses its legacy Landlock
+  sandbox path instead of requiring setuid bubblewrap inside Docker;
 - regenerates NVIDIA CDI at `/etc/cdi/nvidia.yaml` when `nvidia-ctk` is installed.
 
 Seccomp policy is fixed when Docker creates a container. If an agent upgrade changes
@@ -167,21 +171,19 @@ sudo lab-agent doctor
 ```
 
 The final doctor check needs a running lab with at least one provisioned student because it executes
-the real bubblewrap and Codex smoke tests as that ordinary user. A lab is not healthy until these
+the real namespace and Codex smoke tests as that ordinary user. A lab is not healthy until these
 commands pass inside its outer container:
 
 ```bash
-bwrap --unshare-user --uid 0 --gid 0 --ro-bind / / --proc /proc --dev /dev \
-  --unshare-pid --new-session true
 unshare --user --map-root-user true
 codex --version
 codex sandbox -- true
-codex sandbox -- bwrap --unshare-user --uid 0 --gid 0 --ro-bind / / --proc /proc \
-  --dev /dev --unshare-pid --new-session true
 ```
 
-The last command verifies the required nested case: a student command can create another complete
-bubblewrap user/PID/proc sandbox while already running inside Codex's bubblewrap sandbox.
+Doctor still records whether the distribution `bwrap` binary can create a raw nested sandbox, but
+Codex's own sandbox smoke test is the supported pass/fail gate. Do not mark `/usr/bin/bwrap`
+setuid in managed labs; with Docker userns-remap it can appear owned by the remapped host ID or
+fail capability setup inside the outer container.
 
 Also verify `nvidia-smi`, Codex workspace writes under the student's home, network namespace
 isolation, and that container root cannot modify a host sentinel outside `/home` and

--- a/agent/src/lab_agent/executors/users.py
+++ b/agent/src/lab_agent/executors/users.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import re
 
+from ..student_config import codex_config_patch_shell
 from .base import CommandResult
 from .docker import DockerError, exec_in
 
@@ -82,6 +83,10 @@ sed -i '/^[[:space:]]*prefix[[:space:]]*=/d' /home/"$u"/.npmrc
 printf 'prefix=/home/%s/.local\n' "$u" >> /home/"$u"/.npmrc
 chown {uid}:{gid} /home/"$u"/.npmrc
 chmod 0644 /home/"$u"/.npmrc
+install -d -m 0755 -o {uid} -g {gid} /home/"$u"/.codex
+{codex_config_patch_shell('/home/"$u"/.codex/config.toml').rstrip()}
+chown {uid}:{gid} /home/"$u"/.codex/config.toml
+chmod 0644 /home/"$u"/.codex/config.toml
 printf '%s:%s' "$u" {_shell_quote(password)} | chpasswd
 """
     return _run_script(container, script)

--- a/agent/src/lab_agent/hostprep.py
+++ b/agent/src/lab_agent/hostprep.py
@@ -22,6 +22,7 @@ from typing import Any
 
 from .config import AgentConfig
 from .executors.base import run
+from .student_config import codex_config_patch_shell
 from .system import _nvidia_hardware_count, _pool_exists
 
 DAEMON_JSON = Path("/etc/docker/daemon.json")
@@ -299,6 +300,7 @@ def _lab_npm_config_script() -> str:
         "grep -qxF '. /etc/profile.d/lab-npm-user-prefix.sh' /etc/bash.bashrc || "
         "printf '%s\\n' '. /etc/profile.d/lab-npm-user-prefix.sh' >> /etc/bash.bashrc\n"
         "chmod 0644 /etc/npmrc /etc/profile.d/lab-npm-user-prefix.sh\n"
+        "if [ -e /usr/bin/bwrap ]; then chmod 0755 /usr/bin/bwrap; fi\n"
         "getent passwd | while IFS=: read -r user _ uid gid _ home _; do\n"
         "  if [ \"$uid\" -ge 10000 ] 2>/dev/null && [ \"$uid\" -le 59999 ]; then\n"
         "    install -d -m 0755 -o \"$uid\" -g \"$gid\" \"$home/.local\" \"$home/.local/bin\"\n"
@@ -307,6 +309,10 @@ def _lab_npm_config_script() -> str:
         "    printf 'prefix=%s/.local\\n' \"$home\" >> \"$home/.npmrc\"\n"
         "    chown \"$uid:$gid\" \"$home/.npmrc\"\n"
         "    chmod 0644 \"$home/.npmrc\"\n"
+        "    install -d -m 0755 -o \"$uid\" -g \"$gid\" \"$home/.codex\"\n"
+        + codex_config_patch_shell('"$home/.codex/config.toml"')
+        + "    chown \"$uid:$gid\" \"$home/.codex/config.toml\"\n"
+        "    chmod 0644 \"$home/.codex/config.toml\"\n"
         "  fi\n"
         "done\n"
     )

--- a/agent/src/lab_agent/student_config.py
+++ b/agent/src/lab_agent/student_config.py
@@ -1,0 +1,51 @@
+"""Student-owned tool configuration snippets shared by provisioning paths."""
+
+from __future__ import annotations
+
+CODEX_CONFIG_PATCH = r"""
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+path.parent.mkdir(parents=True, exist_ok=True)
+text = path.read_text(encoding="utf-8") if path.exists() else ""
+lines = text.splitlines()
+out = []
+in_features = False
+features_seen = False
+key_seen = False
+inserted = False
+
+for line in lines:
+    stripped = line.strip()
+    if stripped.startswith("[") and stripped.endswith("]"):
+        if in_features and not key_seen:
+            out.append("use_legacy_landlock = true")
+            inserted = True
+        in_features = stripped == "[features]"
+        features_seen = features_seen or in_features
+        key_seen = False if in_features else key_seen
+    if in_features and stripped.startswith("use_legacy_landlock"):
+        out.append("use_legacy_landlock = true")
+        key_seen = True
+        continue
+    out.append(line)
+
+if in_features and not key_seen and not inserted:
+    out.append("use_legacy_landlock = true")
+elif not features_seen:
+    if out and out[-1].strip():
+        out.append("")
+    out.extend(["[features]", "use_legacy_landlock = true"])
+
+path.write_text("\n".join(out) + "\n", encoding="utf-8")
+"""
+
+
+def codex_config_patch_shell(path_expr: str) -> str:
+    """Return shell that patches a Codex config path expression.
+
+    ``path_expr`` is intentionally a shell expression so callers can pass paths containing their own
+    variables, e.g. ``"$home/.codex/config.toml"``.
+    """
+    return "python3 - " + path_expr + " <<'PY'\n" + CODEX_CONFIG_PATCH + "PY\n"

--- a/agent/src/lab_agent/system.py
+++ b/agent/src/lab_agent/system.py
@@ -1,4 +1,4 @@
-"""Structured host health checks for runc/userns, Codex bubblewrap, storage, and NVIDIA CDI."""
+"""Structured host health checks for runc/userns, Codex sandboxing, storage, and NVIDIA CDI."""
 
 from __future__ import annotations
 
@@ -417,15 +417,15 @@ def detect_capabilities(cfg: AgentConfig, *, deep: bool = True) -> Capabilities:
                 "--ro-bind", "/", "/", "--proc", "/proc", "--dev", "/dev",
                 "--unshare-pid", "--new-session", "true",
             ]
-            bwrap_ok = mode_ok and _student_command(target, bwrap_smoke)
+            raw_bwrap_ok = mode_ok and _student_command(target, bwrap_smoke)
             nested_userns_ok = nested_userns_ok and _student_command(
                 target, ["unshare", "--user", "--map-root-user", "true"]
             )
             codex_ok = (
                 _student_command(target, ["codex", "--version"])
                 and _student_command(target, ["codex", "sandbox", "--", "true"])
-                and _student_command(target, ["codex", "sandbox", "--", *bwrap_smoke])
             )
+            bwrap_ok = mode_ok and (raw_bwrap_ok or codex_ok)
             npm_prefix_ok = _student_command(
                 target, ["sh", "-c", 'test "$(npm config get prefix)" = "$HOME/.local"']
             )

--- a/agent/tests/test_hostprep.py
+++ b/agent/tests/test_hostprep.py
@@ -225,7 +225,10 @@ def test_running_labs_get_home_owned_npm_prefix(monkeypatch):
     assert len(exec_calls) == 2
     assert all("prefix=${HOME}/.local" in call for call in exec_calls)
     assert all("/etc/profile.d/lab-npm-user-prefix.sh" in call for call in exec_calls)
+    assert all("chmod 0755 /usr/bin/bwrap" in call for call in exec_calls)
     assert all('"$home/.npmrc"' in call for call in exec_calls)
+    assert all('"$home/.codex/config.toml"' in call for call in exec_calls)
+    assert all("use_legacy_landlock = true" in call for call in exec_calls)
     assert all("10000" in call and "59999" in call for call in exec_calls)
 
 

--- a/agent/tests/test_system.py
+++ b/agent/tests/test_system.py
@@ -160,3 +160,40 @@ def test_stale_lab_userns_containers_detects_remapped_contract(monkeypatch):
         "docker inspect --format {{.HostConfig.UsernsMode}} lab-current": (True, "host"),
     }))
     assert system._stale_lab_userns_containers() == ["lab-old", "lab-remapped"]
+
+
+def test_deep_doctor_accepts_codex_sandbox_when_raw_bwrap_fails(monkeypatch):
+    runner = healthy_runner()
+    runner.responses.update({
+        'docker ps --filter label=lab-agent.managed=true --format {{.Names}}\t{{.Label "lab-agent.seccomp-sha256"}}':
+            (True, "lab-test\tcurrent\n"),
+        "docker ps --filter label=lab-agent.managed=true --format {{.Names}}": (True, "lab-test\n"),
+        "docker inspect --format {{json .HostConfig.MaskedPaths}}\t{{json .HostConfig.ReadonlyPaths}} lab-test":
+            (True, "[]\t[]"),
+        "docker inspect --format {{.HostConfig.UsernsMode}} lab-test": (True, "host"),
+        "docker exec lab-test getent passwd": (True, "alice:x:10042:10042::/home/alice:/bin/bash\n"),
+        "docker exec lab-test stat -c %a /usr/bin/bwrap": (True, "755"),
+        "docker exec -u alice -e HOME=/home/alice -e USER=alice -e LOGNAME=alice lab-test bwrap":
+            (False, ""),
+        "docker exec -u alice -e HOME=/home/alice -e USER=alice -e LOGNAME=alice lab-test unshare":
+            (True, ""),
+        "docker exec -u alice -e HOME=/home/alice -e USER=alice -e LOGNAME=alice lab-test codex --version":
+            (True, "codex 1.2.3"),
+        "docker exec -u alice -e HOME=/home/alice -e USER=alice -e LOGNAME=alice lab-test codex sandbox -- true":
+            (True, ""),
+        "docker exec -u alice -e HOME=/home/alice -e USER=alice -e LOGNAME=alice lab-test sh -c test":
+            (True, ""),
+    })
+    monkeypatch.setattr(system, "run", runner)
+    monkeypatch.setattr(system.docker, "security_profile_digest", lambda path: "current")
+    monkeypatch.setattr(system.docker, "wait_ssh_ready", lambda container, **kwargs: True)
+    monkeypatch.setattr(system, "_security_profiles_ok", lambda cfg: True)
+    monkeypatch.setattr(system, "_subid_ok", lambda cfg: True)
+    monkeypatch.setattr(system, "_loaded_driver_version", lambda: "570.1")
+
+    caps = system.detect_capabilities(cfg(), deep=True)
+
+    assert caps.runtime.bwrap_ok
+    assert caps.runtime.codex_sandbox_ok
+    assert caps.health.status == "healthy"
+    assert not any(i.code == "bubblewrap_failed" for i in caps.issues)

--- a/agent/tests/test_users.py
+++ b/agent/tests/test_users.py
@@ -32,6 +32,8 @@ def test_add_user_exact_ids_sudo_and_flat_links(monkeypatch):
     assert '/home/"$u"/.npmrc' in script
     assert "prefix=/home/%s/.local" in script
     assert '/home/"$u"/.local/bin' in script
+    assert '/home/"$u"/.codex/config.toml' in script
+    assert "use_legacy_landlock = true" in script
 
 
 def test_uid_and_username_validation(monkeypatch):


### PR DESCRIPTION
## Summary
- provision student ~/.codex/config.toml with use_legacy_landlock=true during host-prepare and user creation
- restore non-setuid bwrap mode during host-prepare for running managed labs
- make doctor treat codex sandbox -- true as the supported sandbox smoke test when raw nested bwrap fails inside Docker

## Tests
- cd agent && ./.venv/bin/ruff check .
- cd agent && ./.venv/bin/pytest