### PR TITLE
fix(agent): remove deprecated Codex sandbox setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ daemon-remapped parent namespace locks the inherited mounts that nested bubblewr
 
 Codex is a required workload. The lab image includes a pinned Codex CLI and distribution
 `/usr/bin/bwrap`; the outer container uses dedicated seccomp and AppArmor profiles for sandbox
-setup without granting outer `CAP_SYS_ADMIN`. `host-prepare` also enables Codex's legacy Landlock
-sandbox path for student homes, which avoids requiring setuid bubblewrap inside Docker.
+setup without granting outer `CAP_SYS_ADMIN`. The doctor validates Codex's supported sandbox command
+directly; raw bubblewrap procfs setup may remain unavailable at the outer container boundary.
 
 ## Persistent layout
 
@@ -107,8 +107,8 @@ sudo lab-agent host-prepare
 - installs and loads `lab-codex-seccomp.json`, `lab-codex`, and the distribution
   `bwrap-userns-restrict` profile when available;
 - restores non-setuid mode on `/usr/bin/bwrap` in running managed labs;
-- configures existing student homes with `~/.codex/config.toml` so Codex uses its legacy Landlock
-  sandbox path instead of requiring setuid bubblewrap inside Docker;
+- removes the deprecated `features.use_legacy_landlock` opt-in from existing student Codex configs
+  while preserving all unrelated settings;
 - regenerates NVIDIA CDI at `/etc/cdi/nvidia.yaml` when `nvidia-ctk` is installed.
 
 Seccomp policy is fixed when Docker creates a container. If an agent upgrade changes

--- a/agent/src/lab_agent/executors/users.py
+++ b/agent/src/lab_agent/executors/users.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import re
 
-from ..student_config import codex_config_patch_shell
 from .base import CommandResult
 from .docker import DockerError, exec_in
 
@@ -83,10 +82,6 @@ sed -i '/^[[:space:]]*prefix[[:space:]]*=/d' /home/"$u"/.npmrc
 printf 'prefix=/home/%s/.local\n' "$u" >> /home/"$u"/.npmrc
 chown {uid}:{gid} /home/"$u"/.npmrc
 chmod 0644 /home/"$u"/.npmrc
-install -d -m 0755 -o {uid} -g {gid} /home/"$u"/.codex
-{codex_config_patch_shell('/home/"$u"/.codex/config.toml').rstrip()}
-chown {uid}:{gid} /home/"$u"/.codex/config.toml
-chmod 0644 /home/"$u"/.codex/config.toml
 printf '%s:%s' "$u" {_shell_quote(password)} | chpasswd
 """
     return _run_script(container, script)

--- a/agent/src/lab_agent/hostprep.py
+++ b/agent/src/lab_agent/hostprep.py
@@ -22,7 +22,7 @@ from typing import Any
 
 from .config import AgentConfig
 from .executors.base import run
-from .student_config import codex_config_patch_shell
+from .student_config import codex_config_cleanup_shell
 from .system import _nvidia_hardware_count, _pool_exists
 
 DAEMON_JSON = Path("/etc/docker/daemon.json")
@@ -309,10 +309,11 @@ def _lab_npm_config_script() -> str:
         "    printf 'prefix=%s/.local\\n' \"$home\" >> \"$home/.npmrc\"\n"
         "    chown \"$uid:$gid\" \"$home/.npmrc\"\n"
         "    chmod 0644 \"$home/.npmrc\"\n"
-        "    install -d -m 0755 -o \"$uid\" -g \"$gid\" \"$home/.codex\"\n"
-        + codex_config_patch_shell('"$home/.codex/config.toml"')
-        + "    chown \"$uid:$gid\" \"$home/.codex/config.toml\"\n"
-        "    chmod 0644 \"$home/.codex/config.toml\"\n"
+        "    if [ -f \"$home/.codex/config.toml\" ]; then\n"
+        + codex_config_cleanup_shell('"$home/.codex/config.toml"')
+        + "      chown \"$uid:$gid\" \"$home/.codex/config.toml\"\n"
+        "      chmod 0644 \"$home/.codex/config.toml\"\n"
+        "    fi\n"
         "  fi\n"
         "done\n"
     )

--- a/agent/src/lab_agent/student_config.py
+++ b/agent/src/lab_agent/student_config.py
@@ -1,51 +1,39 @@
-"""Student-owned tool configuration snippets shared by provisioning paths."""
+"""Student-owned tool configuration migrations used by host preparation."""
 
 from __future__ import annotations
 
-CODEX_CONFIG_PATCH = r"""
+CODEX_CONFIG_CLEANUP = r"""
 import pathlib
+import re
 import sys
 
 path = pathlib.Path(sys.argv[1])
-path.parent.mkdir(parents=True, exist_ok=True)
-text = path.read_text(encoding="utf-8") if path.exists() else ""
+if not path.exists():
+    raise SystemExit(0)
+
+text = path.read_text(encoding="utf-8")
 lines = text.splitlines()
 out = []
 in_features = False
-features_seen = False
-key_seen = False
-inserted = False
 
 for line in lines:
     stripped = line.strip()
     if stripped.startswith("[") and stripped.endswith("]"):
-        if in_features and not key_seen:
-            out.append("use_legacy_landlock = true")
-            inserted = True
         in_features = stripped == "[features]"
-        features_seen = features_seen or in_features
-        key_seen = False if in_features else key_seen
-    if in_features and stripped.startswith("use_legacy_landlock"):
-        out.append("use_legacy_landlock = true")
-        key_seen = True
+    if in_features and re.match(r"^use_legacy_landlock\s*=", stripped):
         continue
     out.append(line)
 
-if in_features and not key_seen and not inserted:
-    out.append("use_legacy_landlock = true")
-elif not features_seen:
-    if out and out[-1].strip():
-        out.append("")
-    out.extend(["[features]", "use_legacy_landlock = true"])
-
-path.write_text("\n".join(out) + "\n", encoding="utf-8")
+updated = "\n".join(out) + ("\n" if text.endswith("\n") else "")
+if updated != text:
+    path.write_text(updated, encoding="utf-8")
 """
 
 
-def codex_config_patch_shell(path_expr: str) -> str:
-    """Return shell that patches a Codex config path expression.
+def codex_config_cleanup_shell(path_expr: str) -> str:
+    """Return shell that removes deprecated Codex settings from a config path expression.
 
     ``path_expr`` is intentionally a shell expression so callers can pass paths containing their own
     variables, e.g. ``"$home/.codex/config.toml"``.
     """
-    return "python3 - " + path_expr + " <<'PY'\n" + CODEX_CONFIG_PATCH + "PY\n"
+    return "python3 - " + path_expr + " <<'PY'\n" + CODEX_CONFIG_CLEANUP + "PY\n"

--- a/agent/tests/test_hostprep.py
+++ b/agent/tests/test_hostprep.py
@@ -228,7 +228,8 @@ def test_running_labs_get_home_owned_npm_prefix(monkeypatch):
     assert all("chmod 0755 /usr/bin/bwrap" in call for call in exec_calls)
     assert all('"$home/.npmrc"' in call for call in exec_calls)
     assert all('"$home/.codex/config.toml"' in call for call in exec_calls)
-    assert all("use_legacy_landlock = true" in call for call in exec_calls)
+    assert all("use_legacy_landlock" in call for call in exec_calls)
+    assert all("if [ -f" in call for call in exec_calls)
     assert all("10000" in call and "59999" in call for call in exec_calls)
 
 

--- a/agent/tests/test_student_config.py
+++ b/agent/tests/test_student_config.py
@@ -1,0 +1,26 @@
+import subprocess
+import sys
+
+from lab_agent.student_config import CODEX_CONFIG_CLEANUP
+
+
+def test_codex_config_cleanup_removes_only_deprecated_feature(tmp_path):
+    config = tmp_path / "config.toml"
+    config.write_text(
+        'model = "gpt-5.5"\n\n[features]\nuse_legacy_landlock = true\nweb_search = true\n'
+        '\n[projects."/work"]\ntrust_level = "trusted"\n',
+        encoding="utf-8",
+    )
+
+    for _ in range(2):
+        subprocess.run(
+            [sys.executable, "-", str(config)],
+            input=CODEX_CONFIG_CLEANUP,
+            text=True,
+            check=True,
+        )
+
+    assert config.read_text(encoding="utf-8") == (
+        'model = "gpt-5.5"\n\n[features]\nweb_search = true\n'
+        '\n[projects."/work"]\ntrust_level = "trusted"\n'
+    )

--- a/agent/tests/test_users.py
+++ b/agent/tests/test_users.py
@@ -32,8 +32,8 @@ def test_add_user_exact_ids_sudo_and_flat_links(monkeypatch):
     assert '/home/"$u"/.npmrc' in script
     assert "prefix=/home/%s/.local" in script
     assert '/home/"$u"/.local/bin' in script
-    assert '/home/"$u"/.codex/config.toml' in script
-    assert "use_legacy_landlock = true" in script
+    assert '/home/"$u"/.codex' not in script
+    assert "use_legacy_landlock" not in script
 
 
 def test_uid_and_username_validation(monkeypatch):


### PR DESCRIPTION
## Summary
- stop provisioning deprecated `features.use_legacy_landlock` for new students
- remove the deprecated key from existing student configs during `host-prepare` while preserving other settings
- document that Codex sandbox health is authoritative when standalone bwrap procfs mounting is restricted

## Verification
- `cd agent && ./.venv/bin/ruff check .`
- `cd agent && ./.venv/bin/pytest` (223 passed, 4 skipped)