### PR TITLE
Fix setuid bubblewrap capability failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ lab, no host engine socket, and no privileged mode. Students retain full passwor
 daemon-remapped parent namespace locks the inherited mounts that nested bubblewrap must modify.
 
 Codex is a required workload. The lab image includes a pinned Codex CLI and distribution
-`/usr/bin/bwrap`; the outer container uses a dedicated seccomp profile and deliberately runs with
-`apparmor=unconfined` for setuid bubblewrap setup without granting outer `CAP_SYS_ADMIN`. Doctor
-validates Codex's supported sandbox command directly.
+`/usr/bin/bwrap`; the outer container uses a dedicated seccomp profile, deliberately runs with
+`apparmor=unconfined`, and adds the three capabilities required by bubblewrap's setuid setup path:
+`SYS_ADMIN`, `NET_ADMIN`, and `SYS_PTRACE`. Doctor validates Codex's supported sandbox command
+directly.
 
 ## Persistent layout
 
@@ -124,9 +125,10 @@ profile digest differs from the installed profile.
 Managed labs also use Docker's `systempaths=unconfined` creation option. Docker's default masked
 and read-only submounts below `/proc` make Linux reject the fresh procfs mount required by an
 unprivileged bubblewrap PID namespace. Managed containers pair this with `apparmor=unconfined`;
-the dedicated seccomp profile, restricted mounts, and lack of outer `CAP_SYS_ADMIN` remain active.
-Existing containers must be recreated after this contract changes; doctor reports them as
-`container_systempaths_stale`.
+the dedicated seccomp profile and restricted mounts remain active. Existing containers must be
+recreated after this contract changes; doctor reports stale system paths as
+`container_systempaths_stale` and missing setuid-bubblewrap capabilities as
+`container_bwrap_caps_stale`.
 
 Managed labs run with `--userns=host` (the initial user namespace). Bubblewrap needs it: under a
 remapped namespace Linux locks the inherited root mount and bubblewrap fails at `make / slave`
@@ -190,16 +192,22 @@ the real namespace and Codex smoke tests as that ordinary user. A lab is not hea
 commands pass inside its outer container:
 
 ```bash
-unshare --user --map-root-user true
+bwrap --unshare-user --uid 0 --gid 0 --ro-bind / / --proc /proc --dev /dev --unshare-pid true
 codex --version
 codex sandbox -- true
 ```
 
+A plain `unshare --user` may remain blocked by Ubuntu's AppArmor restriction. That is expected in
+the enforced Fix 3 model: the setuid-root distribution bwrap obtains its required setup
+capabilities, constructs the sandbox, and drops them before starting the payload.
+
 Doctor still records whether the distribution `bwrap` binary can create a raw nested sandbox, but
 Codex's own sandbox smoke test is the supported pass/fail gate. Managed labs enforce root ownership
 and setuid mode (`4755`) on `/usr/bin/bwrap`, and run the outer container with
-`--security-opt apparmor=unconfined` for the most reliable nested sandbox setup. The dedicated
-seccomp profile remains enabled. `host-prepare` and `Repair` re-assert this bwrap mode.
+`--security-opt apparmor=unconfined` plus `SYS_ADMIN`, `NET_ADMIN`, and `SYS_PTRACE`, which the
+setuid bubblewrap code requires while constructing the nested sandbox. The dedicated seccomp
+profile remains enabled. `host-prepare` and `Repair` re-assert this bwrap mode; capability changes
+require container recreation.
 
 Also verify `nvidia-smi`, Codex workspace writes under the student's home, network namespace
 isolation, and that container root cannot modify a host sentinel outside `/home` and

--- a/agent/src/lab_agent/executors/docker.py
+++ b/agent/src/lab_agent/executors/docker.py
@@ -118,6 +118,11 @@ def build_run_args(
     args += [
         "--runtime=runc", "--userns=host", "--cgroupns=private", "--stop-signal", "SIGTERM"
     ]
+    # A setuid bubblewrap drops to the caller while retaining this minimal setup set. Docker's
+    # default bounding set omits all three, which makes bwrap's capset(2) fail with EPERM before it
+    # can create the sandbox. These capabilities remain confined to the outer lab container.
+    for capability in ("SYS_ADMIN", "NET_ADMIN", "SYS_PTRACE"):
+        args += ["--cap-add", capability]
     args += ["--tmpfs", "/run:rw,nosuid,nodev", "--tmpfs", "/run/lock:rw,nosuid,nodev"]
     args += ["--security-opt", f"seccomp={mounts.seccomp_profile}"]
     # The setuid-root bubblewrap image contract is paired with an unconfined outer AppArmor policy.

--- a/agent/src/lab_agent/system.py
+++ b/agent/src/lab_agent/system.py
@@ -266,6 +266,35 @@ def _stale_lab_userns_containers() -> list[str]:
     return stale
 
 
+def _stale_bwrap_capability_containers() -> list[str]:
+    """Return managed containers missing capabilities required by setuid bubblewrap."""
+    required = {"SYS_ADMIN", "NET_ADMIN", "SYS_PTRACE"}
+    listed = run([
+        "docker", "ps", "--filter", "label=lab-agent.managed=true", "--format", "{{.Names}}",
+    ], timeout=20)
+    if not listed.ok:
+        return []
+    stale: list[str] = []
+    for container in listed.stdout.splitlines():
+        result = run([
+            "docker", "inspect", "--format", "{{json .HostConfig.CapAdd}}", container,
+        ], timeout=20)
+        if not result.ok:
+            stale.append(container)
+            continue
+        try:
+            cap_add = json.loads(result.stdout.strip() or "null") or []
+        except json.JSONDecodeError:
+            stale.append(container)
+            continue
+        normalized = {
+            str(cap).upper().removeprefix("CAP_") for cap in cap_add
+        } if isinstance(cap_add, list) else set()
+        if not required.issubset(normalized):
+            stale.append(container)
+    return stale
+
+
 def _first_student_container() -> tuple[str, str] | None:
     listed = run([
         "docker", "ps", "--filter", "label=lab-agent.managed=true", "--format", "{{.Names}}"
@@ -402,6 +431,15 @@ def detect_capabilities(cfg: AgentConfig, *, deep: bool = True) -> Capabilities:
                 "Managed containers require reinstall for bubblewrap-compatible user namespaces: "
                 + ", ".join(stale_lab_userns),
             )
+        stale_bwrap_caps = _stale_bwrap_capability_containers()
+        if stale_bwrap_caps:
+            _issue(
+                issues,
+                "container_bwrap_caps_stale",
+                "critical",
+                "Managed containers require recreation with the setuid bubblewrap capability "
+                "contract: " + ", ".join(stale_bwrap_caps),
+            )
         target = _first_student_container()
         if target:
             if not docker.wait_ssh_ready(target[0], timeout=10, interval=1):
@@ -420,13 +458,14 @@ def detect_capabilities(cfg: AgentConfig, *, deep: bool = True) -> Capabilities:
                 "--unshare-pid", "--new-session", "true",
             ]
             raw_bwrap_ok = mode_ok and _student_command(target, bwrap_smoke)
-            nested_userns_ok = nested_userns_ok and _student_command(
-                target, ["unshare", "--user", "--map-root-user", "true"]
-            )
             codex_ok = (
                 _student_command(target, ["codex", "--version"])
                 and _student_command(target, ["codex", "sandbox", "--", "true"])
             )
+            # Fix 3 relies on setuid bwrap's narrowly scoped setup capabilities. Ubuntu may reject
+            # a plain unprivileged `unshare --user` under its global AppArmor restriction; that is
+            # expected and is not the sandbox contract deployed here.
+            nested_userns_ok = nested_userns_ok and (raw_bwrap_ok or codex_ok)
             bwrap_ok = mode_ok and (raw_bwrap_ok or codex_ok)
             npm_prefix_ok = _student_command(
                 target, ["sh", "-c", 'test "$(npm config get prefix)" = "$HOME/.local"']

--- a/agent/tests/integration/test_real_lab.py
+++ b/agent/tests/integration/test_real_lab.py
@@ -35,7 +35,8 @@ def test_outer_boundary_and_mounts():
     config = json.loads(docker("inspect", CONTAINER).stdout)[0]
     host = config["HostConfig"]
     assert host["Privileged"] is False
-    assert "SYS_ADMIN" not in (host.get("CapAdd") or [])
+    cap_add = set(host.get("CapAdd") or [])
+    assert {"SYS_ADMIN", "NET_ADMIN", "SYS_PTRACE"}.issubset(cap_add)
     security = host.get("SecurityOpt") or []
     assert "systempaths=unconfined" in security
     assert host["UsernsMode"] == "host"
@@ -60,7 +61,6 @@ def test_setuid_bubblewrap_and_codex():
              "--ro-bind", "/", "/", "--proc", "/proc", "--dev", "/dev",
              "--unshare-pid", "--new-session", "true")
     student_exec(*bwrap)
-    student_exec("unshare", "--user", "--map-root-user", "true")
     student_exec("codex", "--version")
     student_exec("codex", "sandbox", "--", "true")
     student_exec("codex", "sandbox", "--", *bwrap)

--- a/agent/tests/test_docker.py
+++ b/agent/tests/test_docker.py
@@ -21,14 +21,16 @@ def test_runc_host_userns_outer_container_contract():
     assert "seccomp=/etc/lab-agent/security/lab-codex-seccomp.json" in joined
     assert "apparmor=unconfined" in joined
     assert "systempaths=unconfined" in joined
+    for capability in ("SYS_ADMIN", "NET_ADMIN", "SYS_PTRACE"):
+        assert f"--cap-add {capability}" in joined
     assert "source=/fast/bio,target=/home" in joined
     assert "source=/cold/bio,target=/cold-storage" in joined
     assert "target=/run/labquota,readonly" in joined
     assert "--storage-opt size=100g" in joined
     assert "--stop-signal SIGTERM" in joined
     assert "SIGRTMIN+3" not in joined
-    for forbidden in ("--privileged", "--cap-add", "SYS_ADMIN", "/var/run/docker.sock",
-                      "no-new-privileges", "seccomp=unconfined"):
+    for forbidden in ("--privileged", "/var/run/docker.sock", "no-new-privileges",
+                      "seccomp=unconfined"):
         assert forbidden not in joined
 
 

--- a/agent/tests/test_system.py
+++ b/agent/tests/test_system.py
@@ -165,6 +165,18 @@ def test_stale_lab_userns_containers_detects_remapped_contract(monkeypatch):
     assert system._stale_lab_userns_containers() == ["lab-old", "lab-remapped"]
 
 
+def test_stale_bwrap_capability_containers_detects_missing_contract(monkeypatch):
+    monkeypatch.setattr(system, "run", Runner({
+        "docker ps": (True, "lab-old\nlab-partial\nlab-current\n"),
+        "docker inspect --format {{json .HostConfig.CapAdd}} lab-old": (True, "null"),
+        "docker inspect --format {{json .HostConfig.CapAdd}} lab-partial":
+            (True, '["CAP_SYS_ADMIN"]'),
+        "docker inspect --format {{json .HostConfig.CapAdd}} lab-current":
+            (True, '["CAP_SYS_ADMIN","CAP_NET_ADMIN","CAP_SYS_PTRACE"]'),
+    }))
+    assert system._stale_bwrap_capability_containers() == ["lab-old", "lab-partial"]
+
+
 def test_deep_doctor_accepts_codex_sandbox_when_raw_bwrap_fails(monkeypatch):
     runner = healthy_runner()
     runner.responses.update({
@@ -174,12 +186,12 @@ def test_deep_doctor_accepts_codex_sandbox_when_raw_bwrap_fails(monkeypatch):
         "docker inspect --format {{json .HostConfig.MaskedPaths}}\t{{json .HostConfig.ReadonlyPaths}} lab-test":
             (True, "[]\t[]"),
         "docker inspect --format {{.HostConfig.UsernsMode}} lab-test": (True, "host"),
+        "docker inspect --format {{json .HostConfig.CapAdd}} lab-test":
+            (True, '["CAP_SYS_ADMIN","CAP_NET_ADMIN","CAP_SYS_PTRACE"]'),
         "docker exec lab-test getent passwd": (True, "alice:x:10042:10042::/home/alice:/bin/bash\n"),
         "docker exec lab-test stat -c %a /usr/bin/bwrap": (True, "4755"),
         "docker exec -u alice -e HOME=/home/alice -e USER=alice -e LOGNAME=alice lab-test bwrap":
             (False, ""),
-        "docker exec -u alice -e HOME=/home/alice -e USER=alice -e LOGNAME=alice lab-test unshare":
-            (True, ""),
         "docker exec -u alice -e HOME=/home/alice -e USER=alice -e LOGNAME=alice lab-test codex --version":
             (True, "codex 1.2.3"),
         "docker exec -u alice -e HOME=/home/alice -e USER=alice -e LOGNAME=alice lab-test codex sandbox -- true":


### PR DESCRIPTION
## Summary
- grant the three setup capabilities required by setuid bubblewrap
- detect managed containers that require recreation with the corrected runtime contract
- align Doctor with the enforced Fix 3 model instead of requiring plain unprivileged unshare
- update runtime, integration, and documentation contracts

## Validation
- `uv run pytest -q` (226 passed, 4 skipped)
- `uv run ruff check src tests`
- `git diff --check`