### PR TITLE
feat: slim CUDA lab image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,13 @@ jobs:
         run: docker build --tag custom-ssh:ci image
       - name: Verify CUDA toolkit and bubblewrap
         run: |
+          image_size=$(docker image inspect custom-ssh:ci --format '{{.Size}}')
+          echo "Lab image size: $image_size bytes"
+          test "$image_size" -lt $((4 * 1024 * 1024 * 1024))
           docker run --rm --entrypoint sh custom-ssh:ci -c '
             nvcc --version
+            python --version
+            test "$(command -v python)" = /usr/bin/python
             ! command -v node
             ! command -v npm
             ! command -v codex

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ lab, no host engine socket, and no privileged mode. Students retain full passwor
 `sudo` inside the lab. Managed labs use Docker's per-container host user namespace because a
 daemon-remapped parent namespace locks the inherited mounts that nested bubblewrap must modify.
 
-The lab image is based on NVIDIA's Ubuntu 24.04 CUDA development image. It includes `nvcc`, CUDA
-headers and libraries, NCCL, standard C/C++ build tooling, and distribution `/usr/bin/bwrap`; it
-does not install Node.js, npm, or Codex. The outer container uses a dedicated seccomp profile,
+The lab image starts from Ubuntu 24.04 and installs NVIDIA's minimal CUDA 13.3 build packages. It
+includes `nvcc`, the CUDA runtime and headers needed for basic CUDA applications, standard C/C++
+build tooling, Python, and distribution `/usr/bin/bwrap`; it does not install the full CUDA library
+suite, Node.js, npm, or Codex. The outer container uses a dedicated seccomp profile,
 `apparmor=unconfined`, and the three capabilities required by bubblewrap's setuid setup path:
 `SYS_ADMIN`, `NET_ADMIN`, and `SYS_PTRACE`.
 
@@ -169,11 +170,12 @@ placements at it (or override the image per-placement in the controller UI):
 docker build -t ghcr.io/ec061/custom-ssh:latest image
 ```
 
-The image runs OpenSSH directly as PID 1 and uses NVIDIA's pinned CUDA 13.3 development base. It
-contains `nvcc`, CUDA headers/runtime/math libraries, NCCL, GCC/G++, CMake, Ninja, pkg-config,
-Python, sudo, bubblewrap, Git, ripgrep, curl, and proc tools. It intentionally contains no Node.js,
-npm, Codex, systemd, Docker packages, daemon configuration, socket, or inner NVIDIA container
-runtime.
+The image runs OpenSSH directly as PID 1 and uses a pinned Ubuntu 24.04 base plus NVIDIA's
+`cuda-minimal-build-13-3` package. It contains `nvcc`, the basic CUDA headers/runtime, GCC/G++,
+CMake, Ninja, pkg-config, Python (as both `python` and `python3`), sudo, bubblewrap, Git, ripgrep,
+curl, and proc tools. Large optional CUDA math libraries, profilers, documentation, and samples are
+excluded. It intentionally contains no Node.js, npm, Codex, systemd, Docker packages, daemon
+configuration, socket, or inner NVIDIA container runtime.
 
 ## 3. Start and validate the node
 

--- a/agent/tests/test_image_contract.py
+++ b/agent/tests/test_image_contract.py
@@ -7,6 +7,8 @@ def test_lab_image_has_cuda_bubblewrap_and_no_nested_engine():
     assert "ubuntu:24.04@sha256:" in dockerfile
     assert "cuda-minimal-build-13-3=13.3.1-1" in dockerfile
     assert "CUDA_KEYRING_SHA256=" in dockerfile
+    assert "ENV PATH=/usr/local/cuda/bin:${PATH}" in dockerfile
+    assert "ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64" in dockerfile
     assert "bubblewrap" in dockerfile
     assert "python-is-python3" in dockerfile
     assert "build-essential cmake ninja-build pkg-config" in dockerfile

--- a/agent/tests/test_image_contract.py
+++ b/agent/tests/test_image_contract.py
@@ -4,8 +4,11 @@ from pathlib import Path
 def test_lab_image_has_cuda_bubblewrap_and_no_nested_engine():
     dockerfile = (Path(__file__).parents[2] / "image" / "Dockerfile").read_text()
     entrypoint = (Path(__file__).parents[2] / "image" / "entrypoint").read_text()
-    assert "nvidia/cuda:13.3.0-devel-ubuntu24.04@sha256:" in dockerfile
+    assert "ubuntu:24.04@sha256:" in dockerfile
+    assert "cuda-minimal-build-13-3=13.3.1-1" in dockerfile
+    assert "CUDA_KEYRING_SHA256=" in dockerfile
     assert "bubblewrap" in dockerfile
+    assert "python-is-python3" in dockerfile
     assert "build-essential cmake ninja-build pkg-config" in dockerfile
     assert "nvcc --version" in dockerfile
     assert "nvcc -c /tmp/cuda-smoke.cu" in dockerfile
@@ -15,7 +18,8 @@ def test_lab_image_has_cuda_bubblewrap_and_no_nested_engine():
     assert "chown root:root /usr/bin/bwrap" in dockerfile
     assert "chmod 4755 /usr/bin/bwrap" in dockerfile
     assert "test -u /usr/bin/bwrap" in dockerfile
-    for forbidden in ("nodejs", "npm install", "@openai/codex", "CODEX_VERSION"):
+    for forbidden in ("nvidia/cuda:", "cuda-toolkit-13-3", "cuda-libraries-dev-13-3",
+                      "nodejs", "npm install", "@openai/codex", "CODEX_VERSION"):
         assert forbidden not in dockerfile
     assert "systemd" not in dockerfile
     assert "/sbin/init" not in dockerfile

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,22 +1,36 @@
-# SSH-accessible CUDA development lab. Docker/NVIDIA device integration lives on the host; this
-# image contains the CUDA toolkit and libraries, but no Docker daemon, CLI, socket, or inner NVIDIA
-# container runtime. Students retain password-authenticated sudo. Bubblewrap is setuid-root.
+# SSH-accessible CUDA development lab. Docker/NVIDIA device integration lives on the host. This
+# image installs NVIDIA's minimal CUDA build package rather than inheriting the much larger devel
+# image. Students retain password-authenticated sudo. Bubblewrap is setuid-root.
 
-FROM nvidia/cuda:13.3.0-devel-ubuntu24.04@sha256:ef2203909e80b8b976cfc672f7e2ae2b00bc0e25c404ee86d89e10a3802f1c52
+FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV CUDA_HOME=/usr/local/cuda
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
+
+ARG CUDA_KEYRING_SHA256=d2a6b11c096396d868758b86dab1823b25e14d70333f1dfa74da5ddaf6a06dba
 
 RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && curl -fsSL \
+        https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb \
+        -o /tmp/cuda-keyring.deb \
+    && echo "$CUDA_KEYRING_SHA256  /tmp/cuda-keyring.deb" | sha256sum -c - \
+    && dpkg -i /tmp/cuda-keyring.deb \
+    && rm -f /tmp/cuda-keyring.deb \
+    && apt-get update \
     && apt-get install -y --no-install-recommends \
+        cuda-minimal-build-13-3=13.3.1-1 \
         openssh-server sudo \
-        python3-pip python3-venv \
+        python3-pip python3-venv python-is-python3 \
         bubblewrap \
         build-essential cmake ninja-build pkg-config \
-        git ripgrep curl ca-certificates procps util-linux nano gnupg \
+        git ripgrep procps util-linux nano gnupg \
     && chown root:root /usr/bin/bwrap \
     && chmod 4755 /usr/bin/bwrap \
     && test -u /usr/bin/bwrap \
+    && test "$(readlink -f /usr/bin/python)" = "$(readlink -f /usr/bin/python3)" \
     && nvcc --version \
     && printf '%s\n' '__global__ void kernel() {}' 'int main() { return 0; }' \
         > /tmp/cuda-smoke.cu \

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -6,6 +6,8 @@ FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV CUDA_HOME=/usr/local/cuda
+ENV PATH=/usr/local/cuda/bin:${PATH}
+ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
 


### PR DESCRIPTION
## Summary
- build from pinned Ubuntu 24.04 instead of the full NVIDIA CUDA devel image
- install NVIDIA CUDA 13.3 minimal build packages only
- expose Python 3 through both `python` and `python3`
- enforce a 4 GiB maximum image size in CI

## Validation
- image contract test passes
- Ruff passes
- workflow YAML parses
- full image build, CUDA compilation, runtime checks, and size measurement run in GitHub CI