### PR TITLE
fix: every deletion redirects back to its page with a confirmation

### DIFF
--- a/controller/src/app/(app)/email-templates/actions.ts
+++ b/controller/src/app/(app)/email-templates/actions.ts
@@ -100,4 +100,6 @@ export async function updateAnnouncementTemplateAction(formData: FormData) {
 export async function deleteAnnouncementTemplateAction(formData: FormData) {
   const id = Number(formData.get("id"));
   await withTemplateFlash(() => deleteAnnouncementTemplate(id));
+  const fid = putFlash("Announcement template deleted.");
+  redirect(`/email-templates?saved=${fid}`);
 }

--- a/controller/src/app/(app)/email-templates/page.tsx
+++ b/controller/src/app/(app)/email-templates/page.tsx
@@ -140,10 +140,11 @@ function AnnouncementTemplateCard({ tpl }: { tpl: AnnouncementTemplate }) {
 export default async function EmailTemplatesPage({
   searchParams,
 }: {
-  searchParams: Promise<{ error?: string }>;
+  searchParams: Promise<{ error?: string; saved?: string }>;
 }) {
-  const { error } = await searchParams;
+  const { error, saved } = await searchParams;
   const errorMsg = error ? takeFlash(error) : null;
+  const savedMsg = saved ? takeFlash(saved) : null;
   const s = getSettings();
   const gpuKillVars = GPU_EMAIL_VARS.filter((v) => v.key !== "grace_minutes");
   const announcementTemplates = listAnnouncementTemplates();
@@ -251,6 +252,7 @@ export default async function EmailTemplatesPage({
           </div>
 
           {errorMsg && <p className="text-sm text-destructive">{errorMsg}</p>}
+          {savedMsg && <p className="text-sm text-primary">{savedMsg}</p>}
 
           {announcementTemplates.length === 0 ? (
             <p className="text-sm text-muted-foreground">No templates yet — add one below.</p>

--- a/controller/src/app/(app)/gpu/actions.ts
+++ b/controller/src/app/(app)/gpu/actions.ts
@@ -1,11 +1,13 @@
 "use server";
 
+import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
 import { requireAdmin } from "@/lib/auth";
 import { clearGpuEvents } from "@/lib/gpu";
 
 export async function clearGpuEventsAction() {
   const actor = (await requireAdmin()).email;
-  clearGpuEvents(actor);
+  const cleared = clearGpuEvents(actor);
   revalidatePath("/gpu");
+  redirect(`/gpu?cleared=${encodeURIComponent(`Cleared ${cleared} event${cleared === 1 ? "" : "s"}`)}`);
 }

--- a/controller/src/app/(app)/gpu/page.tsx
+++ b/controller/src/app/(app)/gpu/page.tsx
@@ -27,7 +27,12 @@ interface EventRow {
   ts: number;
 }
 
-export default function GpuPage() {
+export default async function GpuPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ cleared?: string }>;
+}) {
+  const { cleared } = await searchParams;
   const snapshot = db()
     .prepare("SELECT * FROM gpu_snapshot ORDER BY node, vram_bytes DESC")
     .all() as SnapRow[];
@@ -79,6 +84,7 @@ export default function GpuPage() {
         <CardContent className="space-y-3">
           <div className="flex flex-wrap items-center justify-between gap-2">
             <h3 className="text-base font-semibold">Recent idle-kill events</h3>
+            {cleared && <p className="text-sm text-primary">{cleared}</p>}
             {events.length > 0 ? (
               <form action={clearGpuEventsAction}>
                 <ConfirmButton

--- a/controller/src/app/(app)/labs/actions.ts
+++ b/controller/src/app/(app)/labs/actions.ts
@@ -251,7 +251,9 @@ export async function removePlacementAction(formData: FormData) {
   const who = await actor();
   const placementId = Number(formData.get("placementId"));
   const placement = getPlacement(placementId);
-  if (!placement) return;
+  // Already gone (e.g. the node confirmed teardown while the page was open): land on the labs list
+  // instead of re-rendering a placement page that no longer exists.
+  if (!placement) redirect("/labs");
   try {
     destroyPlacement(placementId, who);
   } catch (e) {
@@ -313,7 +315,18 @@ export async function removeMemberAction(formData: FormData) {
   const labId = Number(formData.get("labId"));
   const studentId = Number(formData.get("studentId"));
   const deleteData = formData.get("deleteData") === "on";
-  removeStudentFromLab(labId, studentId, deleteData, who);
+  try {
+    removeStudentFromLab(labId, studentId, deleteData, who);
+  } catch (e) {
+    const fid = putFlash(e instanceof Error ? e.message : "Could not remove student");
+    redirect(`/labs/${labId}?error=${fid}`);
+  }
   revalidatePath(`/labs/${labId}`);
   revalidatePath("/students");
+  const fid = putFlash(
+    deleteData
+      ? "Student removed from the roster; their account and data are being deleted on every node."
+      : "Student removed from the roster; their account is being deprovisioned on every node (data kept).",
+  );
+  redirect(`/labs/${labId}?saved=${fid}`);
 }

--- a/controller/src/app/(app)/settings/actions.ts
+++ b/controller/src/app/(app)/settings/actions.ts
@@ -108,8 +108,11 @@ export async function saveSmtpSettingsAction(formData: FormData) {
 export async function deleteSmtpSettingsAction(formData: FormData) {
   await requireAdmin();
   const id = String(formData.get("smtpId") ?? "");
-  setSetting("smtpConfigs", getSmtpConfigs().filter((config) => config.id !== id));
+  const configs = getSmtpConfigs();
+  const removed = configs.find((config) => config.id === id);
+  setSetting("smtpConfigs", configs.filter((config) => config.id !== id));
   revalidatePath("/settings");
+  redirect(`/settings?smtp=${encodeURIComponent(removed ? `Deleted ${removed.name}` : "SMTP server deleted")}`);
 }
 
 export async function saveSshHostOverrideAction(formData: FormData) {

--- a/controller/src/app/(app)/stats/actions.ts
+++ b/controller/src/app/(app)/stats/actions.ts
@@ -83,6 +83,8 @@ export async function renameNodeGroupAction(formData: FormData) {
 export async function deleteNodeGroupAction(formData: FormData) {
   const groupId = Number(formData.get("groupId"));
   await withGroupFlash((who) => deleteNodeGroup(groupId, who));
+  const fid = putFlash("Node group deleted. The nodes and their data are untouched.");
+  redirect(`/stats?saved=${fid}`);
 }
 
 export async function setNodeGroupMembersAction(formData: FormData) {

--- a/controller/src/app/(app)/stats/page.tsx
+++ b/controller/src/app/(app)/stats/page.tsx
@@ -282,10 +282,12 @@ function PerNodeUsageSection({
   usage,
   groups,
   flash,
+  saved,
 }: {
   usage: NodeUsage[];
   groups: NodeGroup[];
   flash: string | null;
+  saved: string | null;
 }) {
   const grouped = new Set(groups.flatMap((g) => g.nodeIds));
   const ungrouped = usage.filter((n) => !grouped.has(n.nodeId));
@@ -303,6 +305,7 @@ function PerNodeUsageSection({
         </div>
 
         {flash && <p className="text-sm text-destructive">{flash}</p>}
+        {saved && <p className="text-sm text-primary">{saved}</p>}
 
         {usage.length === 0 ? (
           <p className="text-sm text-muted-foreground">No nodes yet.</p>
@@ -334,10 +337,11 @@ function PerNodeUsageSection({
 export default async function StatsPage({
   searchParams,
 }: {
-  searchParams: Promise<{ error?: string }>;
+  searchParams: Promise<{ error?: string; saved?: string }>;
 }) {
-  const { error } = await searchParams;
+  const { error, saved } = await searchParams;
   const errorMsg = error ? takeFlash(error) : null;
+  const savedMsg = saved ? takeFlash(saved) : null;
   const nodes = buildStats();
   const nodeUsage = buildNodeUsage();
   const groups = listNodeGroups();
@@ -367,7 +371,7 @@ export default async function StatsPage({
         </form>
       </div>
 
-      <PerNodeUsageSection usage={nodeUsage} groups={groups} flash={errorMsg} />
+      <PerNodeUsageSection usage={nodeUsage} groups={groups} flash={errorMsg} saved={savedMsg} />
 
       <h2 className="pt-2 text-lg font-semibold tracking-tight">Per-lab breakdown</h2>
 


### PR DESCRIPTION
## Summary

Audited every destructive Server Action in the controller and fixed the ones that finished without redirecting (or without any visible confirmation), so each deletion now lands the admin on the right page with feedback.

| Deletion | Before | After |
|---|---|---|
| Remove node access (placement) | Silently returned when the placement was already gone, re-rendering a page that 404s | Redirects to `/labs` in that case (success path already redirected to the lab page) |
| Remove lab member | Revalidate only — no redirect, no feedback | Redirects to `/labs/[id]?saved=` with a flash; errors surface as an `?error=` flash |
| Delete SMTP server | Revalidate only | Redirects to `/settings?smtp=Deleted <name>` |
| Delete announcement template | Revalidate only | Redirects to `/email-templates?saved=` flash (page now renders `saved=` alongside `error=`) |
| Delete node group | Revalidate only | Redirects to `/stats?saved=` flash (page now renders `saved=` alongside `error=`) |
| Clear GPU events | Revalidate only | Redirects to `/gpu?cleared=Cleared N events` |

Already correct and left unchanged: destroy lab (`/labs` or lab page while teardown pending), remove student (`/students`), delete/revoke node (`/nodes?deleted=`/`?revoked=`), clear logs (`/settings?logs=`).

## Testing

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — 32 files, 240 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)