### PR TITLE
fix: update container naming to include node name for uniqueness

### DIFF
--- a/agent/src/lab_agent/containerops.py
+++ b/agent/src/lab_agent/containerops.py
@@ -58,7 +58,7 @@ def assert_node_ready(cfg: AgentConfig) -> Any:
 
 def ensure_container(cfg: AgentConfig, lab: str, params: dict[str, Any]) -> str:
     """Create the lab container fresh and verify that sshd becomes ready."""
-    name = docker.container_name(lab)
+    name = docker.container_name(lab, cfg.node_name)
     opts = ContainerOptions.from_params(params)
     mounts = _mounts(cfg, lab)
     caps = assert_node_ready(cfg)
@@ -73,6 +73,7 @@ def ensure_container(cfg: AgentConfig, lab: str, params: dict[str, Any]) -> str:
         mounts,
         gpus=caps.nvidia_gpu and caps.nvidia_cdi,
         labels=_labels(cfg, lab),
+        hostname=docker.container_hostname(lab, cfg.node_name),
     )
     if not docker.wait_ssh_ready(name):
         logs = docker.container_logs(name)
@@ -88,13 +89,13 @@ def recreate_container(cfg: AgentConfig, params: dict[str, Any]) -> tuple[Any, s
 
     Flow that never leaves the lab without a working container on failure:
       1. Validate + ensure the proposed image is available BEFORE stopping the running container.
-      2. Stop the old container and rename it aside (lab-<lab>-old) — preserved for rollback.
+      2. Stop the old container and rename it aside (<lab>-<node>-old) — preserved for rollback.
       3. Create the candidate under the real name and wait for sshd readiness.
       4. On success, delete the preserved old container (promote). On any failure, remove the
          candidate and restore + restart the old container, then surface the error.
     """
     lab = params["lab"]
-    name = docker.container_name(lab)
+    name = docker.container_name(lab, cfg.node_name)
     old = f"{name}-old"
     opts = ContainerOptions.from_params(params)
     mounts = _mounts(cfg, lab)
@@ -114,7 +115,8 @@ def recreate_container(cfg: AgentConfig, params: dict[str, Any]) -> tuple[Any, s
     try:
         # 3. Bring up the candidate under the real name and verify it actually started.
         container_id = docker.create_container(
-            name, opts, mounts, gpus=gpus, labels=_labels(cfg, lab)
+            name, opts, mounts, gpus=gpus, labels=_labels(cfg, lab),
+            hostname=docker.container_hostname(lab, cfg.node_name),
         )
         if not docker.wait_ssh_ready(name):
             logs = docker.container_logs(name)

--- a/agent/src/lab_agent/executors/docker.py
+++ b/agent/src/lab_agent/executors/docker.py
@@ -1,6 +1,6 @@
 """Docker executor for the single, non-nested lab container.
 
-One shared container per lab (name + hostname ``<lab>-<node>``). Creation-time options (cpu/ram/shm/image-quota/
+One container per lab (name+hostname ``<lab>-<node>``). Creation options (cpu/ram/shm/image-quota/
 port/restart) are baked into ``docker run`` and frozen for the container's life; changing them means
 ``recreate`` (which preserves the ZFS data, since data lives in bind-mounted datasets, not the
 container layer). All NVIDIA GPUs are always passed.

--- a/agent/src/lab_agent/executors/docker.py
+++ b/agent/src/lab_agent/executors/docker.py
@@ -1,6 +1,6 @@
 """Docker executor for the single, non-nested lab container.
 
-One shared container per lab (name ``lab-<lab>``). Creation-time options (cpu/ram/shm/image-quota/
+One shared container per lab (name + hostname ``<lab>-<node>``). Creation-time options (cpu/ram/shm/image-quota/
 port/restart) are baked into ``docker run`` and frozen for the container's life; changing them means
 ``recreate`` (which preserves the ZFS data, since data lives in bind-mounted datasets, not the
 container layer). All NVIDIA GPUs are always passed.
@@ -58,8 +58,23 @@ def sanitize_env(env: dict) -> dict[str, str]:
     return out
 
 
-def container_name(lab: str) -> str:
-    return f"lab-{lab}"
+def container_name(lab: str, node: str) -> str:
+    """The container's Docker ``--name``: ``<lab>-<node>``. One shared container per lab per node,
+    so the name is unique on the node and legible in ``docker ps`` / the controller UI."""
+    return f"{lab}-{node}"
+
+
+# Everything outside the RFC 1123 hostname set (letters, digits, '-', '.') folded to '-'. Lab names
+# may contain '_' (valid in a container --name, invalid in a hostname), so the hostname is sanitized
+# separately from container_name.
+_HOSTNAME_INVALID_RE = re.compile(r"[^A-Za-z0-9.-]+")
+
+
+def container_hostname(lab: str, node: str) -> str:
+    """DNS-safe hostname (the ``<lab>-<node>`` a student sees in their shell prompt). Without this,
+    the container hostname defaults to the random truncated container ID."""
+    cleaned = _HOSTNAME_INVALID_RE.sub("-", f"{lab}-{node}").strip("-.")
+    return cleaned[:63] or "lab"
 
 
 @dataclass
@@ -106,9 +121,12 @@ def build_run_args(
     gpus: bool,
     storage_quota_supported: bool = True,
     labels: dict[str, str] | None = None,
+    hostname: str | None = None,
 ) -> list[str]:
     """Pure function building the `docker run` argv (unit-tested without Docker)."""
     args = ["docker", "run", "-d", "--name", name]
+    if hostname:
+        args += ["--hostname", hostname]
     if opts.ssh_port:
         args += ["-p", f"{opts.ssh_port}:22"]
     args += ["--cpus", opts.cpus, "--memory", opts.memory, "--shm-size", opts.shm_size]
@@ -177,8 +195,12 @@ def create_container(
     *,
     gpus: bool,
     labels: dict[str, str] | None = None,
+    hostname: str | None = None,
 ) -> str:
-    res = run(build_run_args(name, opts, mounts, gpus=gpus, labels=labels), timeout=180)
+    res = run(
+        build_run_args(name, opts, mounts, gpus=gpus, labels=labels, hostname=hostname),
+        timeout=180,
+    )
     if not res.ok:
         raise DockerError(res.logs)
     return res.stdout.strip()

--- a/agent/src/lab_agent/labops.py
+++ b/agent/src/lab_agent/labops.py
@@ -83,7 +83,7 @@ def destroy_lab(cfg: AgentConfig, params: dict[str, Any]) -> tuple[Any, str]:
     # the teardown isn't already destroying.
     from .executors import docker
 
-    docker.remove_container(docker.container_name(lab))
+    docker.remove_container(docker.container_name(lab, cfg.node_name))
     zfs.destroy_dataset(lab_fast(cfg, lab), recursive=True)
     coldstore.destroy_lab(cfg, lab)
     return {"lab": lab, "destroyed": True}, f"destroyed container + datasets for lab '{lab}'"

--- a/agent/src/lab_agent/maintenance.py
+++ b/agent/src/lab_agent/maintenance.py
@@ -82,7 +82,7 @@ def run_apt_upgrade(cfg: AgentConfig, lab: str, *, timeout: float = 1800.0) -> t
     Returns ``(ok, note)`` and never raises, so the caller's weekly loop survives one bad lab. A
     non-interactive frontend + ``--force-confold`` keep dpkg from blocking on config prompts.
     """
-    name = docker.container_name(lab)
+    name = docker.container_name(lab, cfg.node_name)
     if not docker.container_exists(name):
         return False, f"lab '{lab}' container not running; apt upgrade skipped"
     env = ["env", "DEBIAN_FRONTEND=noninteractive"]

--- a/agent/src/lab_agent/studentops.py
+++ b/agent/src/lab_agent/studentops.py
@@ -29,7 +29,7 @@ def add_student(cfg: AgentConfig, params: dict[str, Any]) -> tuple[Any, str]:
 
     # The directories already have the student's stable IDs; account creation populates the home
     # and creates its cold-storage symlink.
-    users.add_user(docker.container_name(lab), username, password, uid, gid)
+    users.add_user(docker.container_name(lab, cfg.node_name), username, password, uid, gid)
     return {"lab": lab, "username": username, "uid": uid}, (
         f"added student '{username}' (uid={uid}) to lab '{lab}'"
     )
@@ -39,7 +39,7 @@ def remove_student(cfg: AgentConfig, params: dict[str, Any]) -> tuple[Any, str]:
     lab = params["lab"]
     username = params["username"]
     delete_data = bool(params.get("delete_data", False))
-    users.remove_user(docker.container_name(lab), username)
+    users.remove_user(docker.container_name(lab, cfg.node_name), username)
     if delete_data:
         coldfs.remove_child(zfs.get_mountpoint(lab_fast(cfg, lab)), username)
     msg = f"removed student '{username}' from lab '{lab}'"

--- a/agent/src/lab_agent/usagereport.py
+++ b/agent/src/lab_agent/usagereport.py
@@ -250,7 +250,7 @@ def build_snapshot(
     }
 
 
-def live_container_storage(lab: str) -> dict[str, Any] | None:
+def live_container_storage(cfg: AgentConfig, lab: str) -> dict[str, Any] | None:
     """The lab-level outer-container writable-layer (``SizeRw``) telemetry row.
 
     This is the rootfs number, measured with one ``docker inspect --size``.
@@ -259,7 +259,7 @@ def live_container_storage(lab: str) -> dict[str, Any] | None:
     ``lab_level_for``). Returns None when the container is absent or the measurement fails, in which
     case the row is omitted and the controller keeps the last known value.
     """
-    container = docker.container_name(lab)
+    container = docker.container_name(lab, cfg.node_name)
     if not docker.container_exists(container):
         return None
     total = docker.writable_layer_size(container)
@@ -300,7 +300,7 @@ def lab_level_for(
         rows.append(_zfs_row(lab, "fast", lab_usage.fast))
     if lab_usage.slow is not None:
         rows.append(_zfs_row(lab, "cold", lab_usage.slow))
-    image = live_container_storage(lab)
+    image = live_container_storage(cfg, lab)
     if image is not None:
         rows.append(image)
     return LabLevelUsage(computed_at=now, storage=rows)
@@ -469,7 +469,7 @@ def run_container_scan(
     never breaks the loop.
     """
     now = now if now is not None else now_ms()
-    container = docker.container_name(lab)
+    container = docker.container_name(lab, cfg.node_name)
     if not docker.container_exists(container):
         return ContainerUsage(scanned_at=now, status="idle")
     total = docker.writable_layer_size(container)

--- a/agent/tests/test_containerops.py
+++ b/agent/tests/test_containerops.py
@@ -85,4 +85,4 @@ def test_creation_removes_container_and_reports_logs_when_ssh_fails(monkeypatch)
     with pytest.raises(containerops.docker.DockerError, match="sshd failed"):
         containerops.ensure_container(cfg(), "bio", {})
 
-    assert removed == ["lab-bio", "lab-bio"]
+    assert removed == ["bio-n", "bio-n"]

--- a/agent/tests/test_docker.py
+++ b/agent/tests/test_docker.py
@@ -10,6 +10,22 @@ def mounts():
                   "/etc/lab-agent/security/lab-codex-seccomp.json", "lab-codex")
 
 
+def test_container_name_and_hostname_scheme():
+    assert docker.container_name("bio", "node1") == "bio-node1"
+    assert docker.container_hostname("bio", "node1") == "bio-node1"
+    # Underscores are legal in a container --name but not in a hostname: only the hostname folds them.
+    assert docker.container_name("my_lab", "gpu_1") == "my_lab-gpu_1"
+    assert docker.container_hostname("my_lab", "gpu_1") == "my-lab-gpu-1"
+
+
+def test_hostname_is_set_on_run():
+    args = build_run_args("bio-node1", ContainerOptions(), mounts(), gpus=False,
+                          hostname="bio-node1")
+    assert "--hostname bio-node1" in " ".join(args)
+    # Omitted hostname leaves docker to its default (no flag emitted).
+    assert "--hostname" not in build_run_args("bio-node1", ContainerOptions(), mounts(), gpus=False)
+
+
 def test_runc_host_userns_outer_container_contract():
     opts = ContainerOptions(image="custom-ssh", cpus="8", memory="16g", shm_size="2g",
                             rootfs_quota="100g", ssh_port=50012)

--- a/agent/tests/test_labops.py
+++ b/agent/tests/test_labops.py
@@ -4,7 +4,8 @@ from lab_agent.executors import zfs
 
 
 def _cfg():
-    return AgentConfig(controller_url="ws://x", token="t", fast_pool="fast", slow_pool="slow")
+    return AgentConfig(controller_url="ws://x", token="t", fast_pool="fast", slow_pool="slow",
+                       node_name="n1")
 
 
 def _patch_zfs(monkeypatch):
@@ -79,5 +80,5 @@ def test_destroy_lab_removes_container_before_datasets(monkeypatch):
     monkeypatch.setattr(labops.zfs, "destroy_dataset",
                         lambda name, *, recursive=True: order.append(f"destroy:{name}"))
     labops.destroy_lab(_cfg(), {"lab": "bio"})
-    assert order[0] == "rm:lab-bio"
+    assert order[0] == "rm:bio-n1"
     assert any(o.startswith("destroy:") for o in order[1:])

--- a/agent/tests/test_maintenance.py
+++ b/agent/tests/test_maintenance.py
@@ -9,7 +9,7 @@ def _ok_status(pool):
 
 
 def _cfg():
-    return AgentConfig(controller_url="ws://x", token="t")
+    return AgentConfig(controller_url="ws://x", token="t", node_name="n1")
 
 
 def test_run_apt_upgrade_runs_update_then_upgrade(monkeypatch):
@@ -24,7 +24,7 @@ def test_run_apt_upgrade_runs_update_then_upgrade(monkeypatch):
     ok, note = maintenance.run_apt_upgrade(_cfg(), "bio", timeout=1800)
     assert ok is True
     assert "patched lab 'bio'" in note
-    assert calls[0][0] == "lab-bio"
+    assert calls[0][0] == "bio-n1"
     # update first, then a non-interactive upgrade, both with the long timeout.
     assert calls[0][1] == ["env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "update"]
     assert calls[1][1] == ["env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "-y",

--- a/agent/tests/test_studentops.py
+++ b/agent/tests/test_studentops.py
@@ -6,7 +6,7 @@ from lab_agent.executors.coldfs import ColdFsError
 
 
 def cfg():
-    return AgentConfig(controller_url="ws://x", token="t", userns_start=231072)
+    return AgentConfig(controller_url="ws://x", token="t", userns_start=231072, node_name="n1")
 
 
 def patch_storage(monkeypatch):
@@ -35,7 +35,7 @@ def test_add_student_uses_native_host_ownership(monkeypatch):
     assert result["uid"] == 10042
     assert dirs == [("/fast/bio/alice", 10042, 10042),
                     ("/cold/bio/alice", 10042, 10042)]
-    assert calls == [("add", "lab-bio", "alice", 10042, 10042)]
+    assert calls == [("add", "bio-n1", "alice", 10042, 10042)]
 
 
 def test_remove_data_is_host_side_and_cold_is_independent(monkeypatch):
@@ -43,7 +43,7 @@ def test_remove_data_is_host_side_and_cold_is_independent(monkeypatch):
     studentops.remove_student(cfg(), {
         "lab": "bio", "username": "alice", "delete_data": True, "delete_cold": False,
     })
-    assert calls == [("remove", "lab-bio", "alice")]
+    assert calls == [("remove", "bio-n1", "alice")]
     assert removed == [("/fast/bio", "alice")]
 
 

--- a/agent/tests/test_usagereport.py
+++ b/agent/tests/test_usagereport.py
@@ -31,7 +31,7 @@ def test_snapshot_uses_container_oriented_names():
 def test_explicit_storage_telemetry(monkeypatch):
     monkeypatch.setattr(usagereport.docker, "container_exists", lambda name: True)
     monkeypatch.setattr(usagereport.docker, "writable_layer_size", lambda name: 42)
-    assert usagereport.live_container_storage("bio") == {
+    assert usagereport.live_container_storage(cfg(), "bio") == {
         "lab": "bio", "user": None, "tier": "rootfs", "used_bytes": 42,
         "quota_bytes": None, "available_bytes": None,
     }

--- a/controller/src/lib/placements.ts
+++ b/controller/src/lib/placements.ts
@@ -367,6 +367,7 @@ interface PendingCredential {
   student_id: string | null;
   lab_name: string;
   node_name: string;
+  node_alias: string | null;
   ssh_port: number;
 }
 
@@ -375,7 +376,7 @@ function pendingCredential(labName: string, nodeName: string, username: string):
     .prepare(
       `SELECT pm.id AS member_id, pm.state, pm.credential_secret,
               students.email, students.name, students.username, students.student_id,
-              labs.name AS lab_name, nodes.name AS node_name, p.ssh_port
+              labs.name AS lab_name, nodes.name AS node_name, nodes.alias AS node_alias, p.ssh_port
        FROM placement_members pm
        JOIN students ON students.id = pm.student_id
        JOIN lab_placements p ON p.id = pm.placement_id
@@ -407,7 +408,7 @@ export async function deliverPlacementCredential(
     host,
     port: pending.ssh_port,
     lab: pending.lab_name,
-    node: pending.node_name,
+    node: pending.node_alias?.trim() || pending.node_name,
     studentId: pending.student_id,
   });
   if (!result.sent) return false;


### PR DESCRIPTION
This pull request updates the naming and hostname scheme for lab containers to ensure that containers are uniquely and consistently identified by both lab and node, improving clarity and correctness across the agent and controller codebases. The changes affect container creation, management, telemetry, and student operations, and update all relevant tests to match the new `<lab>-<node>` naming convention.

**Container Naming and Hostname Scheme Updates:**

* Updated all usages of `docker.container_name` to require both lab and node names, producing container names in the format `<lab>-<node>`, instead of the previous `lab-<lab>` format. This ensures uniqueness and clarity for containers across nodes. [[1]](diffhunk://#diff-def94eeb45b3c04e78daeeef564bbcadbca559bca486fcb935710bf19e38f940L61-R77) [[2]](diffhunk://#diff-1bc50d3cb868eeff6c9cccd110b78f1c91f6e86f300c4bac516e5a00732b1196L61-R61) [[3]](diffhunk://#diff-1bc50d3cb868eeff6c9cccd110b78f1c91f6e86f300c4bac516e5a00732b1196L91-R98) [[4]](diffhunk://#diff-4fb066b29f0e276260a229b758441eac86bcf1f72a2918e9965cfe19dfb1b024L86-R86) [[5]](diffhunk://#diff-a112e04bee9322d099c9b63508150a36159a6f50be3c0820e7d265ecb3a6f8caL85-R85) [[6]](diffhunk://#diff-de110ecd3e823e89979bed22091956743a1a1973c10a921050e8d2925c4e62eaL32-R32) [[7]](diffhunk://#diff-de110ecd3e823e89979bed22091956743a1a1973c10a921050e8d2925c4e62eaL42-R42) [[8]](diffhunk://#diff-dc5a3f7068193419a4eb72b4a1819b6165d2d21a78ae619ba619573eb0cb9da8L262-R262) [[9]](diffhunk://#diff-dc5a3f7068193419a4eb72b4a1819b6165d2d21a78ae619ba619573eb0cb9da8L303-R303) [[10]](diffhunk://#diff-dc5a3f7068193419a4eb72b4a1819b6165d2d21a78ae619ba619573eb0cb9da8L472-R472)
* Introduced a new `docker.container_hostname` function to generate DNS-safe hostnames for containers, sanitizing invalid characters and enforcing RFC 1123 compliance. Hostnames are now explicitly set on container creation. [[1]](diffhunk://#diff-def94eeb45b3c04e78daeeef564bbcadbca559bca486fcb935710bf19e38f940L61-R77) [[2]](diffhunk://#diff-def94eeb45b3c04e78daeeef564bbcadbca559bca486fcb935710bf19e38f940R124-R129) [[3]](diffhunk://#diff-def94eeb45b3c04e78daeeef564bbcadbca559bca486fcb935710bf19e38f940R198-R203) [[4]](diffhunk://#diff-1bc50d3cb868eeff6c9cccd110b78f1c91f6e86f300c4bac516e5a00732b1196R76) [[5]](diffhunk://#diff-1bc50d3cb868eeff6c9cccd110b78f1c91f6e86f300c4bac516e5a00732b1196L117-R119)

**Container Lifecycle and Operations:**

* Updated container creation, recreation, and destruction logic to use the new naming scheme and set hostnames appropriately, ensuring all operations target the correct containers. [[1]](diffhunk://#diff-1bc50d3cb868eeff6c9cccd110b78f1c91f6e86f300c4bac516e5a00732b1196L61-R61) [[2]](diffhunk://#diff-1bc50d3cb868eeff6c9cccd110b78f1c91f6e86f300c4bac516e5a00732b1196R76) [[3]](diffhunk://#diff-1bc50d3cb868eeff6c9cccd110b78f1c91f6e86f300c4bac516e5a00732b1196L91-R98) [[4]](diffhunk://#diff-1bc50d3cb868eeff6c9cccd110b78f1c91f6e86f300c4bac516e5a00732b1196L117-R119) [[5]](diffhunk://#diff-4fb066b29f0e276260a229b758441eac86bcf1f72a2918e9965cfe19dfb1b024L86-R86)

**Student and Maintenance Operations:**

* Modified student add/remove and maintenance operations to use the updated container naming, ensuring user management and upgrades operate on the correct containers. [[1]](diffhunk://#diff-de110ecd3e823e89979bed22091956743a1a1973c10a921050e8d2925c4e62eaL32-R32) [[2]](diffhunk://#diff-de110ecd3e823e89979bed22091956743a1a1973c10a921050e8d2925c4e62eaL42-R42) [[3]](diffhunk://#diff-a112e04bee9322d099c9b63508150a36159a6f50be3c0820e7d265ecb3a6f8caL85-R85)

**Telemetry and Usage Reporting:**

* Updated telemetry functions to use the new container naming and accept the agent config for node name resolution, ensuring accurate reporting per container. [[1]](diffhunk://#diff-dc5a3f7068193419a4eb72b4a1819b6165d2d21a78ae619ba619573eb0cb9da8L253-R253) [[2]](diffhunk://#diff-dc5a3f7068193419a4eb72b4a1819b6165d2d21a78ae619ba619573eb0cb9da8L262-R262) [[3]](diffhunk://#diff-dc5a3f7068193419a4eb72b4a1819b6165d2d21a78ae619ba619573eb0cb9da8L303-R303) [[4]](diffhunk://#diff-dc5a3f7068193419a4eb72b4a1819b6165d2d21a78ae619ba619573eb0cb9da8L472-R472)

**Test Suite Updates:**

* Refactored all affected tests to use the new naming convention and verify correct hostname handling, including new tests for container name/hostname generation and argument passing. [[1]](diffhunk://#diff-b06681983e1e7681d8e861f9702302942cf75cc1a514a623da1c99d2e9360ba0L88-R88) [[2]](diffhunk://#diff-3e109d63bdc934c251b34692011a2d60f9feb767cfba8274a9d221d5c5b7e110R13-R28) [[3]](diffhunk://#diff-f34c6a479cd5f23b3ba7bff8612f45dea3416fc0f32571981fbc32dd01f66a98L7-R8) [[4]](diffhunk://#diff-f34c6a479cd5f23b3ba7bff8612f45dea3416fc0f32571981fbc32dd01f66a98L82-R83) [[5]](diffhunk://#diff-399ce0a87d09b02b3054d5b9e4740039492492a74b2cb87d90a1e1639e0ef31dL12-R12) [[6]](diffhunk://#diff-399ce0a87d09b02b3054d5b9e4740039492492a74b2cb87d90a1e1639e0ef31dL27-R27) [[7]](diffhunk://#diff-24e0db2b0280c07d28974402b2bb242d210e732edddac9b493bbf483d4d0c8d2L9-R9) [[8]](diffhunk://#diff-24e0db2b0280c07d28974402b2bb242d210e732edddac9b493bbf483d4d0c8d2L38-R46) [[9]](diffhunk://#diff-4017041e738ac114a37c05527d1e851b7c91f7685e144c920c6b9977f024b5e4L34-R34)

**Controller Placement Credential Update:**

* The controller now includes both `node_name` and `node_alias` in placement credentials and uses the alias (if present) when delivering credentials, improving clarity for users connecting to their assigned node. (F306aab9L29R29, [[1]](diffhunk://#diff-4274f727de91786c6b40c3419b72dec10067f79d2bc0988449451c575cd95b4bL378-R379) [[2]](diffhunk://#diff-4274f727de91786c6b40c3419b72dec10067f79d2bc0988449451c575cd95b4bL410-R411)