### PR TITLE
feat(controller): add per-node SSH host override

### DIFF
--- a/agent/src/lab_agent/containerops.py
+++ b/agent/src/lab_agent/containerops.py
@@ -58,7 +58,7 @@ def assert_node_ready(cfg: AgentConfig) -> Any:
 
 def ensure_container(cfg: AgentConfig, lab: str, params: dict[str, Any]) -> str:
     """Create the lab container fresh and verify that sshd becomes ready."""
-    name = docker.container_name(lab)
+    name = docker.container_name(lab, cfg.node_name)
     opts = ContainerOptions.from_params(params)
     mounts = _mounts(cfg, lab)
     caps = assert_node_ready(cfg)
@@ -73,6 +73,7 @@ def ensure_container(cfg: AgentConfig, lab: str, params: dict[str, Any]) -> str:
         mounts,
         gpus=caps.nvidia_gpu and caps.nvidia_cdi,
         labels=_labels(cfg, lab),
+        hostname=docker.container_hostname(lab, cfg.node_name),
     )
     if not docker.wait_ssh_ready(name):
         logs = docker.container_logs(name)
@@ -88,13 +89,13 @@ def recreate_container(cfg: AgentConfig, params: dict[str, Any]) -> tuple[Any, s
 
     Flow that never leaves the lab without a working container on failure:
       1. Validate + ensure the proposed image is available BEFORE stopping the running container.
-      2. Stop the old container and rename it aside (lab-<lab>-old) — preserved for rollback.
+      2. Stop the old container and rename it aside (<lab>-<node>-old) — preserved for rollback.
       3. Create the candidate under the real name and wait for sshd readiness.
       4. On success, delete the preserved old container (promote). On any failure, remove the
          candidate and restore + restart the old container, then surface the error.
     """
     lab = params["lab"]
-    name = docker.container_name(lab)
+    name = docker.container_name(lab, cfg.node_name)
     old = f"{name}-old"
     opts = ContainerOptions.from_params(params)
     mounts = _mounts(cfg, lab)
@@ -114,7 +115,8 @@ def recreate_container(cfg: AgentConfig, params: dict[str, Any]) -> tuple[Any, s
     try:
         # 3. Bring up the candidate under the real name and verify it actually started.
         container_id = docker.create_container(
-            name, opts, mounts, gpus=gpus, labels=_labels(cfg, lab)
+            name, opts, mounts, gpus=gpus, labels=_labels(cfg, lab),
+            hostname=docker.container_hostname(lab, cfg.node_name),
         )
         if not docker.wait_ssh_ready(name):
             logs = docker.container_logs(name)

--- a/agent/src/lab_agent/executors/docker.py
+++ b/agent/src/lab_agent/executors/docker.py
@@ -1,6 +1,6 @@
 """Docker executor for the single, non-nested lab container.
 
-One shared container per lab (name + hostname ``<lab>-<node>``). Creation-time options (cpu/ram/shm/image-quota/
+One container per lab (name+hostname ``<lab>-<node>``). Creation options (cpu/ram/shm/image-quota/
 port/restart) are baked into ``docker run`` and frozen for the container's life; changing them means
 ``recreate`` (which preserves the ZFS data, since data lives in bind-mounted datasets, not the
 container layer). All NVIDIA GPUs are always passed.

--- a/agent/src/lab_agent/executors/docker.py
+++ b/agent/src/lab_agent/executors/docker.py
@@ -1,6 +1,6 @@
 """Docker executor for the single, non-nested lab container.
 
-One shared container per lab (name ``lab-<lab>``). Creation-time options (cpu/ram/shm/image-quota/
+One shared container per lab (name + hostname ``<lab>-<node>``). Creation-time options (cpu/ram/shm/image-quota/
 port/restart) are baked into ``docker run`` and frozen for the container's life; changing them means
 ``recreate`` (which preserves the ZFS data, since data lives in bind-mounted datasets, not the
 container layer). All NVIDIA GPUs are always passed.
@@ -58,8 +58,23 @@ def sanitize_env(env: dict) -> dict[str, str]:
     return out
 
 
-def container_name(lab: str) -> str:
-    return f"lab-{lab}"
+def container_name(lab: str, node: str) -> str:
+    """The container's Docker ``--name``: ``<lab>-<node>``. One shared container per lab per node,
+    so the name is unique on the node and legible in ``docker ps`` / the controller UI."""
+    return f"{lab}-{node}"
+
+
+# Everything outside the RFC 1123 hostname set (letters, digits, '-', '.') folded to '-'. Lab names
+# may contain '_' (valid in a container --name, invalid in a hostname), so the hostname is sanitized
+# separately from container_name.
+_HOSTNAME_INVALID_RE = re.compile(r"[^A-Za-z0-9.-]+")
+
+
+def container_hostname(lab: str, node: str) -> str:
+    """DNS-safe hostname (the ``<lab>-<node>`` a student sees in their shell prompt). Without this,
+    the container hostname defaults to the random truncated container ID."""
+    cleaned = _HOSTNAME_INVALID_RE.sub("-", f"{lab}-{node}").strip("-.")
+    return cleaned[:63] or "lab"
 
 
 @dataclass
@@ -106,9 +121,12 @@ def build_run_args(
     gpus: bool,
     storage_quota_supported: bool = True,
     labels: dict[str, str] | None = None,
+    hostname: str | None = None,
 ) -> list[str]:
     """Pure function building the `docker run` argv (unit-tested without Docker)."""
     args = ["docker", "run", "-d", "--name", name]
+    if hostname:
+        args += ["--hostname", hostname]
     if opts.ssh_port:
         args += ["-p", f"{opts.ssh_port}:22"]
     args += ["--cpus", opts.cpus, "--memory", opts.memory, "--shm-size", opts.shm_size]
@@ -177,8 +195,12 @@ def create_container(
     *,
     gpus: bool,
     labels: dict[str, str] | None = None,
+    hostname: str | None = None,
 ) -> str:
-    res = run(build_run_args(name, opts, mounts, gpus=gpus, labels=labels), timeout=180)
+    res = run(
+        build_run_args(name, opts, mounts, gpus=gpus, labels=labels, hostname=hostname),
+        timeout=180,
+    )
     if not res.ok:
         raise DockerError(res.logs)
     return res.stdout.strip()

--- a/agent/src/lab_agent/labops.py
+++ b/agent/src/lab_agent/labops.py
@@ -83,7 +83,7 @@ def destroy_lab(cfg: AgentConfig, params: dict[str, Any]) -> tuple[Any, str]:
     # the teardown isn't already destroying.
     from .executors import docker
 
-    docker.remove_container(docker.container_name(lab))
+    docker.remove_container(docker.container_name(lab, cfg.node_name))
     zfs.destroy_dataset(lab_fast(cfg, lab), recursive=True)
     coldstore.destroy_lab(cfg, lab)
     return {"lab": lab, "destroyed": True}, f"destroyed container + datasets for lab '{lab}'"

--- a/agent/src/lab_agent/maintenance.py
+++ b/agent/src/lab_agent/maintenance.py
@@ -82,7 +82,7 @@ def run_apt_upgrade(cfg: AgentConfig, lab: str, *, timeout: float = 1800.0) -> t
     Returns ``(ok, note)`` and never raises, so the caller's weekly loop survives one bad lab. A
     non-interactive frontend + ``--force-confold`` keep dpkg from blocking on config prompts.
     """
-    name = docker.container_name(lab)
+    name = docker.container_name(lab, cfg.node_name)
     if not docker.container_exists(name):
         return False, f"lab '{lab}' container not running; apt upgrade skipped"
     env = ["env", "DEBIAN_FRONTEND=noninteractive"]

--- a/agent/src/lab_agent/studentops.py
+++ b/agent/src/lab_agent/studentops.py
@@ -29,7 +29,7 @@ def add_student(cfg: AgentConfig, params: dict[str, Any]) -> tuple[Any, str]:
 
     # The directories already have the student's stable IDs; account creation populates the home
     # and creates its cold-storage symlink.
-    users.add_user(docker.container_name(lab), username, password, uid, gid)
+    users.add_user(docker.container_name(lab, cfg.node_name), username, password, uid, gid)
     return {"lab": lab, "username": username, "uid": uid}, (
         f"added student '{username}' (uid={uid}) to lab '{lab}'"
     )
@@ -39,7 +39,7 @@ def remove_student(cfg: AgentConfig, params: dict[str, Any]) -> tuple[Any, str]:
     lab = params["lab"]
     username = params["username"]
     delete_data = bool(params.get("delete_data", False))
-    users.remove_user(docker.container_name(lab), username)
+    users.remove_user(docker.container_name(lab, cfg.node_name), username)
     if delete_data:
         coldfs.remove_child(zfs.get_mountpoint(lab_fast(cfg, lab)), username)
     msg = f"removed student '{username}' from lab '{lab}'"

--- a/agent/src/lab_agent/usagereport.py
+++ b/agent/src/lab_agent/usagereport.py
@@ -250,7 +250,7 @@ def build_snapshot(
     }
 
 
-def live_container_storage(lab: str) -> dict[str, Any] | None:
+def live_container_storage(cfg: AgentConfig, lab: str) -> dict[str, Any] | None:
     """The lab-level outer-container writable-layer (``SizeRw``) telemetry row.
 
     This is the rootfs number, measured with one ``docker inspect --size``.
@@ -259,7 +259,7 @@ def live_container_storage(lab: str) -> dict[str, Any] | None:
     ``lab_level_for``). Returns None when the container is absent or the measurement fails, in which
     case the row is omitted and the controller keeps the last known value.
     """
-    container = docker.container_name(lab)
+    container = docker.container_name(lab, cfg.node_name)
     if not docker.container_exists(container):
         return None
     total = docker.writable_layer_size(container)
@@ -300,7 +300,7 @@ def lab_level_for(
         rows.append(_zfs_row(lab, "fast", lab_usage.fast))
     if lab_usage.slow is not None:
         rows.append(_zfs_row(lab, "cold", lab_usage.slow))
-    image = live_container_storage(lab)
+    image = live_container_storage(cfg, lab)
     if image is not None:
         rows.append(image)
     return LabLevelUsage(computed_at=now, storage=rows)
@@ -469,7 +469,7 @@ def run_container_scan(
     never breaks the loop.
     """
     now = now if now is not None else now_ms()
-    container = docker.container_name(lab)
+    container = docker.container_name(lab, cfg.node_name)
     if not docker.container_exists(container):
         return ContainerUsage(scanned_at=now, status="idle")
     total = docker.writable_layer_size(container)

--- a/agent/tests/test_containerops.py
+++ b/agent/tests/test_containerops.py
@@ -85,4 +85,4 @@ def test_creation_removes_container_and_reports_logs_when_ssh_fails(monkeypatch)
     with pytest.raises(containerops.docker.DockerError, match="sshd failed"):
         containerops.ensure_container(cfg(), "bio", {})
 
-    assert removed == ["lab-bio", "lab-bio"]
+    assert removed == ["bio-n", "bio-n"]

--- a/agent/tests/test_docker.py
+++ b/agent/tests/test_docker.py
@@ -10,6 +10,22 @@ def mounts():
                   "/etc/lab-agent/security/lab-codex-seccomp.json", "lab-codex")
 
 
+def test_container_name_and_hostname_scheme():
+    assert docker.container_name("bio", "node1") == "bio-node1"
+    assert docker.container_hostname("bio", "node1") == "bio-node1"
+    # Underscores are legal in a container --name but not in a hostname: only the hostname folds them.
+    assert docker.container_name("my_lab", "gpu_1") == "my_lab-gpu_1"
+    assert docker.container_hostname("my_lab", "gpu_1") == "my-lab-gpu-1"
+
+
+def test_hostname_is_set_on_run():
+    args = build_run_args("bio-node1", ContainerOptions(), mounts(), gpus=False,
+                          hostname="bio-node1")
+    assert "--hostname bio-node1" in " ".join(args)
+    # Omitted hostname leaves docker to its default (no flag emitted).
+    assert "--hostname" not in build_run_args("bio-node1", ContainerOptions(), mounts(), gpus=False)
+
+
 def test_runc_host_userns_outer_container_contract():
     opts = ContainerOptions(image="custom-ssh", cpus="8", memory="16g", shm_size="2g",
                             rootfs_quota="100g", ssh_port=50012)

--- a/agent/tests/test_labops.py
+++ b/agent/tests/test_labops.py
@@ -4,7 +4,8 @@ from lab_agent.executors import zfs
 
 
 def _cfg():
-    return AgentConfig(controller_url="ws://x", token="t", fast_pool="fast", slow_pool="slow")
+    return AgentConfig(controller_url="ws://x", token="t", fast_pool="fast", slow_pool="slow",
+                       node_name="n1")
 
 
 def _patch_zfs(monkeypatch):
@@ -79,5 +80,5 @@ def test_destroy_lab_removes_container_before_datasets(monkeypatch):
     monkeypatch.setattr(labops.zfs, "destroy_dataset",
                         lambda name, *, recursive=True: order.append(f"destroy:{name}"))
     labops.destroy_lab(_cfg(), {"lab": "bio"})
-    assert order[0] == "rm:lab-bio"
+    assert order[0] == "rm:bio-n1"
     assert any(o.startswith("destroy:") for o in order[1:])

--- a/agent/tests/test_maintenance.py
+++ b/agent/tests/test_maintenance.py
@@ -9,7 +9,7 @@ def _ok_status(pool):
 
 
 def _cfg():
-    return AgentConfig(controller_url="ws://x", token="t")
+    return AgentConfig(controller_url="ws://x", token="t", node_name="n1")
 
 
 def test_run_apt_upgrade_runs_update_then_upgrade(monkeypatch):
@@ -24,7 +24,7 @@ def test_run_apt_upgrade_runs_update_then_upgrade(monkeypatch):
     ok, note = maintenance.run_apt_upgrade(_cfg(), "bio", timeout=1800)
     assert ok is True
     assert "patched lab 'bio'" in note
-    assert calls[0][0] == "lab-bio"
+    assert calls[0][0] == "bio-n1"
     # update first, then a non-interactive upgrade, both with the long timeout.
     assert calls[0][1] == ["env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "update"]
     assert calls[1][1] == ["env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "-y",

--- a/agent/tests/test_studentops.py
+++ b/agent/tests/test_studentops.py
@@ -6,7 +6,7 @@ from lab_agent.executors.coldfs import ColdFsError
 
 
 def cfg():
-    return AgentConfig(controller_url="ws://x", token="t", userns_start=231072)
+    return AgentConfig(controller_url="ws://x", token="t", userns_start=231072, node_name="n1")
 
 
 def patch_storage(monkeypatch):
@@ -35,7 +35,7 @@ def test_add_student_uses_native_host_ownership(monkeypatch):
     assert result["uid"] == 10042
     assert dirs == [("/fast/bio/alice", 10042, 10042),
                     ("/cold/bio/alice", 10042, 10042)]
-    assert calls == [("add", "lab-bio", "alice", 10042, 10042)]
+    assert calls == [("add", "bio-n1", "alice", 10042, 10042)]
 
 
 def test_remove_data_is_host_side_and_cold_is_independent(monkeypatch):
@@ -43,7 +43,7 @@ def test_remove_data_is_host_side_and_cold_is_independent(monkeypatch):
     studentops.remove_student(cfg(), {
         "lab": "bio", "username": "alice", "delete_data": True, "delete_cold": False,
     })
-    assert calls == [("remove", "lab-bio", "alice")]
+    assert calls == [("remove", "bio-n1", "alice")]
     assert removed == [("/fast/bio", "alice")]
 
 

--- a/agent/tests/test_usagereport.py
+++ b/agent/tests/test_usagereport.py
@@ -31,7 +31,7 @@ def test_snapshot_uses_container_oriented_names():
 def test_explicit_storage_telemetry(monkeypatch):
     monkeypatch.setattr(usagereport.docker, "container_exists", lambda name: True)
     monkeypatch.setattr(usagereport.docker, "writable_layer_size", lambda name: 42)
-    assert usagereport.live_container_storage("bio") == {
+    assert usagereport.live_container_storage(cfg(), "bio") == {
         "lab": "bio", "user": None, "tier": "rootfs", "used_bytes": 42,
         "quota_bytes": None, "available_bytes": None,
     }

--- a/controller/src/app/(app)/labs/[id]/placements/[placementId]/page.tsx
+++ b/controller/src/app/(app)/labs/[id]/placements/[placementId]/page.tsx
@@ -118,7 +118,7 @@ export default async function PlacementPage({
   const quotaState = taskLabel(quotaTask);
   const recreateState = taskLabel(latestTask(placement, "container.recreate"));
   const opts = containerOptionsOf(placement);
-  const host = getSetting("sshHostOverride").trim() || placement.node_name;
+  const host = placement.ssh_host?.trim() || getSetting("sshHostOverride").trim() || placement.node_name;
   const canEdit = placement.state !== "deleting";
   const capacity = nodePoolCapacityBytes(placement.node_id);
   const fastDefault = bytesToQuotaInput(placement.fast_quota_bytes);

--- a/controller/src/app/(app)/nodes/actions.ts
+++ b/controller/src/app/(app)/nodes/actions.ts
@@ -13,6 +13,7 @@ import {
   rotateNodeToken,
   setNodeAlias,
   setNodeColdStorage,
+  setNodeSshHost,
 } from "@/lib/nodes";
 
 // The freshly issued token is shown once on the Nodes page so the admin can paste the printed
@@ -57,6 +58,20 @@ export async function setNodeAliasAction(formData: FormData) {
     setNodeAlias(name, alias, admin.email);
   } catch (e) {
     error = e instanceof Error ? e.message : "could not set alias";
+  }
+  if (error) redirect("/nodes?error=" + encodeURIComponent(error));
+  redirect("/nodes");
+}
+
+export async function setNodeSshHostAction(formData: FormData) {
+  const admin = await requireAdmin();
+  const name = String(formData.get("name") ?? "").trim().toLowerCase();
+  const sshHost = String(formData.get("sshHost") ?? "");
+  let error: string | null = null;
+  try {
+    setNodeSshHost(name, sshHost, admin.email);
+  } catch (e) {
+    error = e instanceof Error ? e.message : "could not set SSH host";
   }
   if (error) redirect("/nodes?error=" + encodeURIComponent(error));
   redirect("/nodes");

--- a/controller/src/app/(app)/nodes/page.tsx
+++ b/controller/src/app/(app)/nodes/page.tsx
@@ -18,6 +18,7 @@ import {
   rotateNodeTokenAction,
   setNodeAliasAction,
   setNodeColdStorageAction,
+  setNodeSshHostAction,
 } from "./actions";
 
 export const dynamic = "force-dynamic";
@@ -25,6 +26,7 @@ export const dynamic = "force-dynamic";
 interface NodeRow {
   name: string;
   alias: string | null;
+  ssh_host: string | null;
   online: number;
   last_seen: number | null;
   capabilities: string | null;
@@ -107,7 +109,7 @@ export default async function NodesPage({
 
   const nodes = db()
     .prepare(
-      `SELECT n.name, n.alias, n.online, n.last_seen, n.capabilities, n.pools, n.scrub_status,
+      `SELECT n.name, n.alias, n.ssh_host, n.online, n.last_seen, n.capabilities, n.pools, n.scrub_status,
               n.allowed, n.cold_backend, n.cold_mount_path, n.cold_ready,
               owner.name AS owner_name,
               (SELECT COUNT(*) FROM lab_placements WHERE node_id = n.id) AS placements,
@@ -232,6 +234,19 @@ export default async function NodesPage({
                             defaultValue={n.alias ?? ""}
                             placeholder="alias"
                             maxLength={64}
+                            className="h-7 w-28 text-xs"
+                          />
+                          <Button type="submit" variant="secondary" size="sm" className="h-7">
+                            Save
+                          </Button>
+                        </form>
+                        <form action={setNodeSshHostAction} className="mt-1 flex gap-1">
+                          <input type="hidden" name="name" value={n.name} />
+                          <Input
+                            name="sshHost"
+                            defaultValue={n.ssh_host ?? ""}
+                            placeholder="SSH host"
+                            maxLength={255}
                             className="h-7 w-28 text-xs"
                           />
                           <Button type="submit" variant="secondary" size="sm" className="h-7">

--- a/controller/src/lib/db.ts
+++ b/controller/src/lib/db.ts
@@ -597,8 +597,15 @@ Thanks for helping keep the cluster healthy.`,
       `);
     },
   },
+  {
+    // Per-node SSH host override. When set, the controller uses this as the SSH hostname/IP in
+    // welcome emails and the placement detail page, taking priority over the global sshHostOverride
+    // setting and falling back to the node name.
+    id: "0021_node_ssh_host",
+    sql: "ALTER TABLE nodes ADD COLUMN ssh_host TEXT",
+  },
 ];
-
+ 
 function migrate(conn: Database.Database): void {
   conn.exec(`CREATE TABLE IF NOT EXISTS _migrations (
     id TEXT PRIMARY KEY, applied_at INTEGER NOT NULL

--- a/controller/src/lib/nodes.ts
+++ b/controller/src/lib/nodes.ts
@@ -123,6 +123,19 @@ export function setNodeAlias(name: string, alias: string, actor: string): void {
   audit(actor, "node.alias", name, clean ?? "(cleared)");
 }
 
+/**
+ * Set (or clear) a node's SSH host override. When set, the controller uses this hostname/IP in
+ * welcome emails and the placement detail page instead of the node name or global sshHostOverride.
+ * Pass an empty string to clear it.
+ */
+export function setNodeSshHost(name: string, sshHost: string, actor: string): void {
+  const exists = db().prepare("SELECT 1 FROM nodes WHERE name = ?").get(name);
+  if (!exists) throw new Error(`unknown node '${name}'`);
+  const clean = sshHost.trim().slice(0, 255) || null;
+  db().prepare("UPDATE nodes SET ssh_host = ? WHERE name = ?").run(clean, name);
+  audit(actor, "node.ssh_host", name, clean ?? "(cleared)");
+}
+
 /** Remove a node from the allow-list (its token stops working immediately). */
 export function revokeNode(name: string, actor: string): void {
   db().prepare("UPDATE nodes SET allowed = 0 WHERE name = ?").run(name);

--- a/controller/src/lib/placements.ts
+++ b/controller/src/lib/placements.ts
@@ -76,6 +76,7 @@ export interface Placement {
   lab_name: string;
   node_id: number;
   node_name: string;
+  ssh_host: string | null;
   online: number;
   fast_quota_bytes: number;
   cold_quota_bytes: number | null; // NULL on SMB-client placements (owner manages cold)
@@ -96,7 +97,8 @@ export interface Placement {
 }
 
 const PLACEMENT_SELECT = `
-  SELECT p.*, labs.name AS lab_name, nodes.name AS node_name, nodes.online AS online,
+  SELECT p.*, labs.name AS lab_name, nodes.name AS node_name, nodes.ssh_host AS ssh_host,
+         nodes.online AS online,
          nodes.cold_backend AS node_cold_backend, nodes.cold_owner_node_id AS node_cold_owner_node_id,
          owner.name AS cold_owner_name, nodes.cold_ready AS node_cold_ready
   FROM lab_placements p
@@ -368,6 +370,7 @@ interface PendingCredential {
   lab_name: string;
   node_name: string;
   node_alias: string | null;
+  ssh_host: string | null;
   ssh_port: number;
 }
 
@@ -376,7 +379,8 @@ function pendingCredential(labName: string, nodeName: string, username: string):
     .prepare(
       `SELECT pm.id AS member_id, pm.state, pm.credential_secret,
               students.email, students.name, students.username, students.student_id,
-              labs.name AS lab_name, nodes.name AS node_name, nodes.alias AS node_alias, p.ssh_port
+              labs.name AS lab_name, nodes.name AS node_name, nodes.alias AS node_alias,
+              nodes.ssh_host AS ssh_host, p.ssh_port
        FROM placement_members pm
        JOIN students ON students.id = pm.student_id
        JOIN lab_placements p ON p.id = pm.placement_id
@@ -399,7 +403,7 @@ export async function deliverPlacementCredential(
   if (!pending || pending.state !== "active" || !pending.credential_secret || !pending.email) return false;
   const password = decryptSecret(pending.credential_secret);
   if (!password) return false;
-  const host = getSetting("sshHostOverride").trim() || pending.node_name;
+  const host = pending.ssh_host?.trim() || getSetting("sshHostOverride").trim() || pending.node_name;
   const result = await sendCredentialEmail({
     to: pending.email,
     name: pending.name ?? undefined,

--- a/controller/src/lib/placements.ts
+++ b/controller/src/lib/placements.ts
@@ -367,6 +367,7 @@ interface PendingCredential {
   student_id: string | null;
   lab_name: string;
   node_name: string;
+  node_alias: string | null;
   ssh_port: number;
 }
 
@@ -375,7 +376,7 @@ function pendingCredential(labName: string, nodeName: string, username: string):
     .prepare(
       `SELECT pm.id AS member_id, pm.state, pm.credential_secret,
               students.email, students.name, students.username, students.student_id,
-              labs.name AS lab_name, nodes.name AS node_name, p.ssh_port
+              labs.name AS lab_name, nodes.name AS node_name, nodes.alias AS node_alias, p.ssh_port
        FROM placement_members pm
        JOIN students ON students.id = pm.student_id
        JOIN lab_placements p ON p.id = pm.placement_id
@@ -407,7 +408,7 @@ export async function deliverPlacementCredential(
     host,
     port: pending.ssh_port,
     lab: pending.lab_name,
-    node: pending.node_name,
+    node: pending.node_alias?.trim() || pending.node_name,
     studentId: pending.student_id,
   });
   if (!result.sent) return false;


### PR DESCRIPTION
## Problem

Welcome emails and the placement detail page showed the node name (e.g. `ubuntu-epyc`) as the SSH host instead of the correct IP/ hostname (e.g. `192.168.8.157`). The only way to override this was the global `sshHostOverride` setting, which applies to all nodes — not practical when different nodes have different public hostnames/IPs.

## Changes

Adds a per-node **SSH host** field editable in the Nodes UI, parallel to the existing alias field. The host resolution order in emails and the placement detail page is now:

1. Per-node `ssh_host` (if set)
2. Global `sshHostOverride` setting (if set)
3. Node name (fallback)

### Files changed

- **`controller/src/lib/db.ts`** — Migration 0021: `ALTER TABLE nodes ADD COLUMN ssh_host TEXT`
- **`controller/src/lib/nodes.ts`** — New `setNodeSshHost()` function
- **`controller/src/app/(app)/nodes/actions.ts`** — New `setNodeSshHostAction` server action
- **`controller/src/app/(app)/nodes/page.tsx`** — SSH host input field in the nodes table
- **`controller/src/lib/placements.ts`** — Query `nodes.ssh_host` and use it in credential delivery (overriding global `sshHostOverride` and node name)
- **`controller/src/app/(app)/labs/[id]/placements/[placementId]/page.tsx`** — Use per-node `ssh_host` in SSH connection display

## Verification

- Typecheck: ✅ `tsc --noEmit` passes
- Lint: ✅ `eslint` passes with zero warnings
- Tests: ✅ All 240 tests pass