### PR TITLE
Add {host_alias} email template variable

### DIFF
--- a/controller/src/app/(app)/labs/[id]/placements/[placementId]/page.tsx
+++ b/controller/src/app/(app)/labs/[id]/placements/[placementId]/page.tsx
@@ -19,7 +19,6 @@ import {
   nodePoolCapacityBytes,
   type Placement,
 } from "@/lib/placements";
-import { getSetting } from "@/lib/settings";
 import {
   removePlacementAction,
   revealPlacementCredentialAction,
@@ -118,7 +117,7 @@ export default async function PlacementPage({
   const quotaState = taskLabel(quotaTask);
   const recreateState = taskLabel(latestTask(placement, "container.recreate"));
   const opts = containerOptionsOf(placement);
-  const host = getSetting("sshHostOverride").trim() || placement.node_name;
+  const host = placement.node_name;
   const canEdit = placement.state !== "deleting";
   const capacity = nodePoolCapacityBytes(placement.node_id);
   const fastDefault = bytesToQuotaInput(placement.fast_quota_bytes);

--- a/controller/src/app/(app)/settings/actions.ts
+++ b/controller/src/app/(app)/settings/actions.ts
@@ -115,12 +115,6 @@ export async function deleteSmtpSettingsAction(formData: FormData) {
   redirect(`/settings?smtp=${encodeURIComponent(removed ? `Deleted ${removed.name}` : "SMTP server deleted")}`);
 }
 
-export async function saveSshHostOverrideAction(formData: FormData) {
-  await requireAdmin();
-  setSetting("sshHostOverride", String(formData.get("sshHostOverride") ?? "").trim());
-  revalidatePath("/settings");
-}
-
 export async function saveAlertSettingsAction(formData: FormData) {
   await requireAdmin();
   setSetting("alertsEnabled", formData.get("alertsEnabled") === "on");

--- a/controller/src/app/(app)/settings/page.tsx
+++ b/controller/src/app/(app)/settings/page.tsx
@@ -16,7 +16,6 @@ import {
   saveGpuPolicyAction,
   saveScrubSettingsAction,
   saveSmtpSettingsAction,
-  saveSshHostOverrideAction,
   saveStorageSettingsAction,
   saveUsageScanSettingsAction,
   scrubNowAction,
@@ -201,13 +200,6 @@ export default async function SettingsPage({
             <div className="flex items-end">
               <Button type="submit" variant="secondary">Add SMTP config</Button>
             </div>
-          </form>
-          <form action={saveSshHostOverrideAction} className="flex max-w-xl flex-wrap items-end gap-3">
-            <div>
-              <Label>SSH host override (optional)</Label>
-              <Input name="sshHostOverride" defaultValue={s.sshHostOverride} placeholder="gpu.uga.edu" />
-            </div>
-            <Button type="submit" variant="secondary">Save SSH host</Button>
           </form>
           <form action={testEmailAction} className="flex flex-wrap items-end gap-3">
             <div>

--- a/controller/src/lib/mailer.ts
+++ b/controller/src/lib/mailer.ts
@@ -104,6 +104,7 @@ export interface CredentialEmail {
   port: number;
   lab: string;
   node?: string;
+  hostAlias?: string;
   studentId?: string | null;
 }
 
@@ -197,6 +198,7 @@ export function welcomeEmailVars(info: CredentialEmail): Record<string, string |
     username: info.username,
     password: info.password,
     host: info.host,
+    host_alias: info.hostAlias || info.host,
     port: info.port,
     lab: info.lab,
     node: info.node ?? info.host,

--- a/controller/src/lib/placements.ts
+++ b/controller/src/lib/placements.ts
@@ -399,7 +399,7 @@ export async function deliverPlacementCredential(
   if (!pending || pending.state !== "active" || !pending.credential_secret || !pending.email) return false;
   const password = decryptSecret(pending.credential_secret);
   if (!password) return false;
-  const host = getSetting("sshHostOverride").trim() || pending.node_name;
+  const host = pending.node_name;
   const result = await sendCredentialEmail({
     to: pending.email,
     name: pending.name ?? undefined,
@@ -409,6 +409,7 @@ export async function deliverPlacementCredential(
     port: pending.ssh_port,
     lab: pending.lab_name,
     node: pending.node_alias?.trim() || pending.node_name,
+    hostAlias: pending.node_alias?.trim() || "",
     studentId: pending.student_id,
   });
   if (!result.sent) return false;

--- a/controller/src/lib/settings.ts
+++ b/controller/src/lib/settings.ts
@@ -50,8 +50,6 @@ export interface Settings {
   smtpConfigs: SmtpConfig[];
   // Plain-text signature appended by the mailer to every outbound email.
   emailSignatureText: string;
-  // Optional public hostname students SSH to (falls back to the node name).
-  sshHostOverride: string;
   // Welcome email sent to a student when added to a lab. Both fields support {placeholder}
   // substitution (see WELCOME_EMAIL_VARS / renderTemplate in lib/mailer.ts). Empty falls back to
   // the built-in default.
@@ -131,7 +129,8 @@ export const WELCOME_EMAIL_VARS: { key: string; desc: string }[] = [
   { key: "name", desc: "student's full name (falls back to username)" },
   { key: "username", desc: "login username" },
   { key: "password", desc: "generated initial password" },
-  { key: "host", desc: "SSH host (override or node name)" },
+  { key: "host", desc: "SSH host (node name)" },
+  { key: "host_alias", desc: "node alias (may be blank)" },
   { key: "port", desc: "SSH port" },
   { key: "lab", desc: "lab name" },
   { key: "node", desc: "node name the lab runs on" },
@@ -241,7 +240,6 @@ export const DEFAULT_SETTINGS: Settings = {
   smtpSecure: false,
   smtpConfigs: [],
   emailSignatureText: DEFAULT_EMAIL_SIGNATURE_TEXT,
-  sshHostOverride: "",
   welcomeEmailSubject: DEFAULT_WELCOME_SUBJECT,
   welcomeEmailBody: DEFAULT_WELCOME_BODY,
   gpuEnabled: false,

--- a/controller/src/lib/settings.ts
+++ b/controller/src/lib/settings.ts
@@ -130,7 +130,7 @@ export const WELCOME_EMAIL_VARS: { key: string; desc: string }[] = [
   { key: "username", desc: "login username" },
   { key: "password", desc: "generated initial password" },
   { key: "host", desc: "SSH host (node name)" },
-  { key: "host_alias", desc: "node alias (may be blank)" },
+  { key: "host_alias", desc: "node alias (falls back to node name)" },
   { key: "port", desc: "SSH port" },
   { key: "lab", desc: "lab name" },
   { key: "node", desc: "node name the lab runs on" },


### PR DESCRIPTION
- Add `{host_alias}` variable that resolves to the node's alias (falls back to node name if empty)
- Remove global `sshHostOverride` setting (unused)

Changes email template variables available for credential emails.