### PR TITLE
Add seccomp and AppArmor enforcement tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
           # keyctl (syscall 248) must be denied — not in the allow-list.
           docker run --rm --entrypoint sh \
             --security-opt "seccomp=$seccomp" \
-            custom-ssh:ci -c 'python3 -c "import os; os.exit(0)"' \
+            custom-ssh:ci -c 'python3 -c "import sys; sys.exit(0)"' \
             || { echo "FAIL: python3 should run"; exit 1; }
           # Verify keyctl is blocked by attempting it directly via python3 ctypes.
           docker run --rm --entrypoint sh \
@@ -180,6 +180,7 @@ jobs:
           import ctypes, sys
           libc = ctypes.CDLL(\"libc.so.6\", use_errno=True)
           # keyctl = syscall 248 on x86_64
+          ctypes.set_errno(0)
           ret = libc.syscall(248, 0, 0, 0, 0)
           if ret == 0:
               print(\"FAIL: keyctl should be blocked\", file=sys.stderr)
@@ -195,6 +196,7 @@ jobs:
           import ctypes, sys
           libc = ctypes.CDLL(\"libc.so.6\", use_errno=True)
           # userfaultfd = syscall 323 on x86_64
+          ctypes.set_errno(0)
           ret = libc.syscall(323, 0)
           if ret == 0:
               print(\"FAIL: userfaultfd should be blocked\", file=sys.stderr)
@@ -210,9 +212,9 @@ jobs:
           import ctypes, sys
           libc = ctypes.CDLL(\"libc.so.6\", use_errno=True)
           # clone3 = syscall 435 on x86_64 — should succeed (allowed).
+          ctypes.set_errno(0)
           ret = libc.syscall(435, 0, 0, 0, 0, 0)
           # clone3 returns -1 with EAGAIN on invalid args, but NOT EPERM.
-          import os
           errno = ctypes.get_errno()
           if errno == 1:  # EPERM = blocked by seccomp
               print(\"FAIL: clone3 should be allowed\", file=sys.stderr)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,3 +86,137 @@ jobs:
               su - student -c '\''bwrap --ro-bind / / --dev /dev --proc /proc --unshare-pid -- echo "bwrap works"'\''
             ')
           test "$output" = "bwrap works"
+
+      - name: AppArmor enforcement tests
+        run: |
+          # Load the lab-codex AppArmor profile into the kernel.
+          sudo apparmor_parser -r agent/src/lab_agent/assets/lab-codex.apparmor
+          # Verify the profile is loaded.
+          sudo aa-status | grep -q "lab-codex" || { echo "FAIL: lab-codex profile not loaded"; exit 1; }
+          # Run a container confined by lab-codex (NOT apparmor=unconfined).
+          # Test 1: /proc/sys write must be denied by the outer profile.
+          docker run --rm \
+            --cap-add SYS_ADMIN --cap-add NET_ADMIN --cap-add SYS_PTRACE \
+            --security-opt "seccomp=$PWD/agent/src/lab_agent/assets/lab-codex-seccomp.json" \
+            --security-opt apparmor=lab-codex \
+            --entrypoint sh custom-ssh:ci -c '
+              useradd -m -s /bin/bash student
+              # As non-root, writing to /proc/sys must fail (deny /proc/sys/** wklx).
+              su - student -c "echo x > /proc/sys/kernel/hostname" 2>/dev/null && {
+                echo "FAIL: /proc/sys write should be denied by AppArmor"
+                exit 1
+              }
+              echo "PASS: /proc/sys write correctly denied"
+            '
+          # Test 2: mount must be denied by the outer profile (deny mount).
+          docker run --rm \
+            --cap-add SYS_ADMIN --cap-add NET_ADMIN --cap-add SYS_PTRACE \
+            --security-opt "seccomp=$PWD/agent/src/lab_agent/assets/lab-codex-seccomp.json" \
+            --security-opt apparmor=lab-codex \
+            --entrypoint sh custom-ssh:ci -c '
+              useradd -m -s /bin/bash student
+              su - student -c "mount -t tmpfs tmpfs /tmp" 2>/dev/null && {
+                echo "FAIL: mount should be denied by AppArmor"
+                exit 1
+              }
+              echo "PASS: mount correctly denied"
+            '
+          # Test 3: Verify the container is actually confined by lab-codex.
+          profile=$(docker run --rm \
+            --cap-add SYS_ADMIN --cap-add NET_ADMIN --cap-add SYS_PTRACE \
+            --security-opt "seccomp=$PWD/agent/src/lab_agent/assets/lab-codex-seccomp.json" \
+            --security-opt apparmor=lab-codex \
+            --entrypoint sh custom-ssh:ci -c 'cat /proc/self/attr/current')
+          echo "Container AppArmor profile: $profile"
+          echo "$profile" | grep -q "lab-codex" || {
+            echo "FAIL: container not confined by lab-codex"
+            exit 1
+          }
+          echo "PASS: container confined by lab-codex"
+          # Test 4: bwrap Px -> transition must fire — inner process gets lab-codex//lab-codex-bwrap.
+          docker run --rm \
+            --cap-add SYS_ADMIN --cap-add NET_ADMIN --cap-add SYS_PTRACE \
+            --security-opt "seccomp=$PWD/agent/src/lab_agent/assets/lab-codex-seccomp.json" \
+            --security-opt apparmor=lab-codex \
+            --entrypoint sh custom-ssh:ci -c '
+              useradd -m -s /bin/bash student
+              su - student -c "bwrap --ro-bind / / --dev /dev --proc /proc --unshare-pid -- cat /proc/self/attr/current"
+            ' | tee /tmp/bwrap_profile.txt
+          inner_profile=$(cat /tmp/bwrap_profile.txt)
+          echo "bwrap inner profile: $inner_profile"
+          echo "$inner_profile" | grep -q "lab-codex//lab-codex-bwrap" || {
+            echo "FAIL: bwrap Px transition did not fire"
+            exit 1
+          }
+          echo "PASS: bwrap Px transition fires correctly"
+          # Test 5: bwrap must still be able to mount inside its sandbox (inner profile grants mount).
+          docker run --rm \
+            --cap-add SYS_ADMIN --cap-add NET_ADMIN --cap-add SYS_PTRACE \
+            --security-opt "seccomp=$PWD/agent/src/lab_agent/assets/lab-codex-seccomp.json" \
+            --security-opt apparmor=lab-codex \
+            --entrypoint sh custom-ssh:ci -c '
+              useradd -m -s /bin/bash student
+              su - student -c "bwrap --ro-bind / / --dev /dev --proc /proc --unshare-pid -- echo bwrap-mount-works"
+            ' | tee /tmp/bwrap_mount.txt
+          grep -q "bwrap-mount-works" /tmp/bwrap_mount.txt || {
+            echo "FAIL: bwrap mount inside sandbox failed"
+            exit 1
+          }
+          echo "PASS: bwrap mount inside sandbox works"
+
+      - name: Seccomp denial tests
+        run: |
+          seccomp="$PWD/agent/src/lab_agent/assets/lab-codex-seccomp.json"
+          # keyctl (syscall 248) must be denied — not in the allow-list.
+          docker run --rm --entrypoint sh \
+            --security-opt "seccomp=$seccomp" \
+            custom-ssh:ci -c 'python3 -c "import os; os.exit(0)"' \
+            || { echo "FAIL: python3 should run"; exit 1; }
+          # Verify keyctl is blocked by attempting it directly via python3 ctypes.
+          docker run --rm --entrypoint sh \
+            --security-opt "seccomp=$seccomp" \
+            custom-ssh:ci -c '
+              python3 -c "
+          import ctypes, sys
+          libc = ctypes.CDLL(\"libc.so.6\", use_errno=True)
+          # keyctl = syscall 248 on x86_64
+          ret = libc.syscall(248, 0, 0, 0, 0)
+          if ret == 0:
+              print(\"FAIL: keyctl should be blocked\", file=sys.stderr)
+              sys.exit(1)
+          print(\"PASS: keyctl denied\")
+          "
+            ' && echo "seccomp: keyctl correctly denied"
+          # userfaultfd (syscall 323) must be denied.
+          docker run --rm --entrypoint sh \
+            --security-opt "seccomp=$seccomp" \
+            custom-ssh:ci -c '
+              python3 -c "
+          import ctypes, sys
+          libc = ctypes.CDLL(\"libc.so.6\", use_errno=True)
+          # userfaultfd = syscall 323 on x86_64
+          ret = libc.syscall(323, 0)
+          if ret == 0:
+              print(\"FAIL: userfaultfd should be blocked\", file=sys.stderr)
+              sys.exit(1)
+          print(\"PASS: userfaultfd denied\")
+          "
+            ' && echo "seccomp: userfaultfd correctly denied"
+          # clone3 (syscall 435) must be ALLOWED — bwrap needs it.
+          docker run --rm --entrypoint sh \
+            --security-opt "seccomp=$seccomp" \
+            custom-ssh:ci -c '
+              python3 -c "
+          import ctypes, sys
+          libc = ctypes.CDLL(\"libc.so.6\", use_errno=True)
+          # clone3 = syscall 435 on x86_64 — should succeed (allowed).
+          ret = libc.syscall(435, 0, 0, 0, 0, 0)
+          # clone3 returns -1 with EAGAIN on invalid args, but NOT EPERM.
+          import os
+          errno = ctypes.get_errno()
+          if errno == 1:  # EPERM = blocked by seccomp
+              print(\"FAIL: clone3 should be allowed\", file=sys.stderr)
+              sys.exit(1)
+          print(\"PASS: clone3 allowed\")
+          "
+            ' && echo "seccomp: clone3 correctly allowed"

--- a/HOST_PREPARATION.md
+++ b/HOST_PREPARATION.md
@@ -1,0 +1,279 @@
+# Host Preparation
+
+Step-by-step guide for preparing an Ubuntu 22.04/24.04 agent node. Every GPU node
+needs an NVIDIA driver installed and pinned before the agent touches anything.
+
+## Overview
+
+```
+1. Install the agent          (gives you the lab-agent CLI)
+2. Run host-prepare           (installs Docker, ZFS utils, AppArmor, nvidia-container-toolkit)
+3. Create ZFS datasets        (zpool layout is hardware-specific)
+4. Run host-prepare again     (provisions Docker data-root on ZFS, applies quotas)
+5. Install + pin NVIDIA driver (manual step — reboot required)
+6. Start and validate         (lab-agent start, doctor, smoke tests)
+```
+
+## 1. Install the agent
+
+```bash
+# Install uv if not present
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+REPO="git+https://github.com/EC061/docker-mass-deployment.git#subdirectory=agent"
+
+sudo uvx --from "$REPO" lab-agent install
+sudo uvx --from "$REPO" lab-agent edit-config   # set controller_url, token, node_name, pool names
+```
+
+`uvx` pulls the agent from GitHub on first run and caches it. Every
+subsequent `uvx` call uses the cached copy. No local clone is needed.
+
+`lab-agent install` registers the systemd unit and writes
+`/etc/lab-agent/config.toml`. Edit the config before moving on — it
+needs the controller URL, authentication token, and (if non-default) the
+ZFS pool names.
+
+## 2. First host-prepare run
+
+```bash
+REPO="git+https://github.com/EC061/docker-mass-deployment.git#subdirectory=agent"
+sudo uvx --from "$REPO" lab-agent host-prepare
+```
+
+This installs everything the agent itself depends on — no pre-installed
+packages beyond the OS are required:
+
+- **Docker Engine** (from Docker's official apt repo)
+- **ZFS userspace tools** (`zfsutils-linux`)
+- **AppArmor tooling** (`apparmor`, `apparmor-utils`)
+- **NVIDIA Container Toolkit** (only when GPU hardware is detected —
+  never the driver itself)
+
+It also:
+
+- reserves the `labdockremap` account and its exact subuid/subgid range
+- enforces `kernel.unprivileged_userns_clone=1`,
+  `user.max_user_namespaces=16384`, and
+  `kernel.apparmor_restrict_unprivileged_userns=1`
+- installs the seccomp profile and AppArmor profile
+- writes `/etc/docker/daemon.json`
+
+On a brand-new node the zpools don't exist yet, so Docker gets its plain
+default backing store. That is expected — the next two steps fix it.
+
+## 3. Create ZFS datasets
+
+Disk topology is hardware-specific and not automated. Create the storage
+roots the agent expects:
+
+```bash
+sudo zfs create -o mountpoint=/fast fast/labs
+sudo zfs create -o mountpoint=/cold-storage slow/labs   # local cold tier only
+```
+
+Adjust pool names if you set non-default `fast_pool` / `slow_pool` values
+in the agent config.
+
+If cold storage is SMB, mount the owner node's `/cold-storage` tree at
+`/cold-storage` on this client before starting the agent. The share must
+preserve numeric POSIX ownership and permit `chown`.
+
+## 4. Second host-prepare run
+
+```bash
+REPO="git+https://github.com/EC061/docker-mass-deployment.git#subdirectory=agent"
+sudo uvx --from "$REPO" lab-agent host-prepare
+```
+
+Now that the fast pool exists, host-prepare provisions a ZFS dataset
+(`fast/docker` by default) as Docker's `data-root` with `storage-driver:
+zfs`. Any content Docker created on its plain backing store during the
+first run is migrated into the dataset — nothing is discarded.
+
+This run also applies `docker_quota_gb` (default 1024 GiB) as a live ZFS
+quota on the dataset. Change the value in the config and re-run
+host-prepare to resize immediately, with no unmount or reboot.
+
+On GPU nodes, host-prepare additionally pins Docker's cgroup driver to
+`cgroupfs` (workaround for a known runc/systemd-cgroup-driver bug that
+drops GPU device access on `systemctl daemon-reload`) and regenerates
+NVIDIA CDI at `/etc/cdi/nvidia.yaml`.
+
+## 5. Install and pin the NVIDIA driver
+
+host-prepare explicitly **never installs the NVIDIA kernel driver** — it
+needs a reboot and a hardware-matched version choice. Install it manually
+before starting the agent.
+
+### 5a. Add the NVIDIA driver apt repo
+
+```bash
+# Import the signing key
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \
+  | sudo gpg --yes --dearmor -o /usr/share/keyrings/nvidia-driver-keyring.gpg
+
+# Detect your Ubuntu codename
+. /etc/os-release
+
+# Add the repo (replace jammy/noble as needed)
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/nvidia-driver-keyring.gpg] \
+  https://us.download.nvidia.com/tesla ${VERSION_CODENAME}/" \
+  | sudo tee /etc/apt/sources.list.d/nvidia-driver.list
+
+sudo apt-get update
+```
+
+> For Tesla/Data Center GPUs use the `us.download.nvidia.com/tesla` repo.
+> For GeForce/RTX workstation GPUs use `https://ppa.launchpadcontent.net/ubuntu-nvidia-drivers/ppa/ubuntu`
+> or the graphics-drivers PPA instead.
+
+### 5b. Install the driver
+
+```bash
+# List available driver packages
+apt-cache search nvidia-driver | grep '^nvidia-driver-[0-9]'
+
+# Install (example: 550)
+sudo apt-get install -y nvidia-driver-550
+```
+
+Reboot after installation:
+
+```bash
+sudo reboot
+```
+
+Verify after reboot:
+
+```bash
+nvidia-smi
+```
+
+### 5c. Pin the driver against updates
+
+Three layers prevent `apt-get upgrade` or `unattended-upgrades` from
+touching the driver packages:
+
+**Hold every installed NVIDIA driver package:**
+
+```bash
+sudo apt-mark hold \
+  nvidia-driver-550 \
+  libnvidia-compute-550 \
+  libnvidia-decode-550 \
+  libnvidia-encode-550 \
+  libnvidia-fbc1-550 \
+  libnvidia-gl-550 \
+  nvidia-compute-utils-550 \
+  nvidia-dkms-550 \
+  nvidia-utils-550
+```
+
+Adjust the list to match what `dpkg -l | grep nvidia` shows on your
+node. The pattern is `nvidia-driver-NNN` plus all `libnvidia-*` and
+`nvidia-*-NNN` packages at the same version.
+
+**Create an apt priority pin so apt never considers upgrading them:**
+
+```bash
+sudo tee /etc/apt/preferences.d/nvidia-driver-pin <<'EOF'
+Package: nvidia-driver-* libnvidia-* nvidia-compute-utils-* nvidia-dkms-* nvidia-utils-*
+Pin: version *
+Pin-Priority: 1001
+EOF
+```
+
+Priority 1001 forces apt to keep the installed version even when a
+newer version is available in the repo.
+
+**Blacklist the packages in unattended-upgrades:**
+
+```bash
+sudo tee /etc/apt/apt.conf.d/50unattended-upgrades-nvidia <<'EOF'
+Unattended-Upgrade::Package-Blacklist {
+    "nvidia-driver-.*";
+    "libnvidia-.*";
+    "nvidia-compute-utils-.*";
+    "nvidia-dkms-.*";
+    "nvidia-utils-.*";
+};
+EOF
+```
+
+### 5d. Updating the driver (when intended)
+
+When you intentionally want to upgrade the NVIDIA driver:
+
+```bash
+sudo apt-mark unhold nvidia-driver-550 libnvidia-compute-550 ...
+sudo apt-get install -y nvidia-driver-560   # new version
+sudo reboot
+
+# After verifying nvidia-smi on the new version, re-pin:
+sudo apt-mark hold nvidia-driver-560 libnvidia-compute-560 ...
+sudo tee /etc/apt/preferences.d/nvidia-driver-pin <<'EOF'
+Package: nvidia-driver-* libnvidia-* nvidia-compute-utils-* nvidia-dkms-* nvidia-utils-*
+Pin: version *
+Pin-Priority: 1001
+EOF
+```
+
+Update the unattended-upgrades blacklist if the package set changed.
+
+## 6. Start and validate
+
+```bash
+REPO="git+https://github.com/EC061/docker-mass-deployment.git#subdirectory=agent"
+sudo uvx --from "$REPO" lab-agent start
+sudo uvx --from "$REPO" lab-agent doctor
+```
+
+Doctor needs a running lab with at least one provisioned student because
+it executes real namespace and Codex smoke tests as that ordinary user.
+
+Verify inside a running lab:
+
+```bash
+bwrap --ro-bind / / --dev /dev --proc /proc --unshare-pid -- echo "bwrap works"
+nvcc --version
+nvidia-smi
+```
+
+Inspect the resulting Docker and system settings:
+
+```bash
+docker info --format '{{json .SecurityOptions}}'
+sudo cat /etc/docker/daemon.json
+sudo aa-status | grep lab-codex
+sysctl kernel.unprivileged_userns_clone user.max_user_namespaces \
+  kernel.apparmor_restrict_unprivileged_userns
+```
+
+## Persistent layout reference
+
+| Host | Lab container | Purpose |
+|---|---|---|
+| `/fast/<lab>` | `/home` | Persistent fast homes and per-lab fast quota |
+| `/cold-storage/<lab>` | `/cold-storage` | Per-lab cold root |
+| `/fast/<lab>/<user>` | `/home/<user>` | Student persistent fast home |
+| `/cold-storage/<lab>/<user>` | `/cold-storage/<user>` | Student cold directory |
+| agent state `labquota/<lab>` | `/run/labquota` read-only | Usage communication |
+
+`/home/<user>/cold-storage` is a symlink to `/cold-storage/<user>`. No
+`/fast`, `/cold`, or `~/scratch` path exists inside the container, and no
+per-user datasets are created.
+
+## Subordinate ID mapping
+
+Every node must reserve the same IDs for cross-node cold-storage numeric
+consistency:
+
+```text
+user:  labdockremap
+subuid/subgid start: 231072
+range: 65536
+student container and host IDs: 10000-59999
+```
+
+This is created automatically by `host-prepare`.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,31 @@ suite, Node.js, npm, or Codex. The outer container uses a dedicated seccomp prof
 `apparmor=unconfined`, and the three capabilities required by bubblewrap's setuid setup path:
 `SYS_ADMIN`, `NET_ADMIN`, and `SYS_PTRACE`.
 
+## Host preparation
+
+Every agent node needs Docker, ZFS, AppArmor, and — on GPU nodes — the NVIDIA driver and
+container toolkit. The full step-by-step is in **[HOST_PREPARATION.md](HOST_PREPARATION.md)**.
+
+In short:
+
+```bash
+# Install uv if not present
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+REPO="git+https://github.com/EC061/docker-mass-deployment.git#subdirectory=agent"
+
+sudo uvx --from "$REPO" lab-agent install
+sudo uvx --from "$REPO" lab-agent edit-config
+sudo uvx --from "$REPO" lab-agent host-prepare  # installs Docker, ZFS utils, AppArmor, nvidia-container-toolkit
+# ... create zpools (hardware-specific) ...
+sudo zfs create -o mountpoint=/fast fast/labs
+sudo zfs create -o mountpoint=/cold-storage slow/labs
+sudo uvx --from "$REPO" lab-agent host-prepare  # provisions Docker data-root on ZFS
+# ... install + pin NVIDIA driver (GPU nodes only, see HOST_PREPARATION.md) ...
+sudo uvx --from "$REPO" lab-agent start
+sudo uvx --from "$REPO" lab-agent doctor
+```
+
 ## Persistent layout
 
 | Host | Lab container | Purpose |
@@ -25,139 +50,7 @@ suite, Node.js, npm, or Codex. The outer container uses a dedicated seccomp prof
 `/home/<user>/cold-storage` is a symlink to `/cold-storage/<user>`. No `/fast`, `/cold`, or
 `~/scratch` path exists inside the container, and no per-user datasets are created.
 
-## 1. Prepare every host
-
-Use a dedicated Ubuntu 22.04/24.04 node. `host-prepare` installs Docker Engine, ZFS tools, and
-AppArmor tooling itself (see below); the only prerequisites it does NOT automate are the zpool
-layout (disk topology is hardware-specific) and, on GPU nodes, the NVIDIA driver itself (needs a
-reboot and a hardware-matched version — install it before running `host-prepare`, which then adds
-the NVIDIA Container Toolkit once it sees GPU hardware). Every node must reserve the same IDs:
-
-```text
-user:  labdockremap
-subuid/subgid start: 231072
-range: 65536
-student container and host IDs: 10000-59999
-```
-
-Create the storage roots. The agent creates the per-lab datasets, but the pools must already exist:
-
-```bash
-sudo zfs create -o mountpoint=/fast fast/labs
-sudo zfs create -o mountpoint=/cold-storage slow/labs  # local cold owners only
-```
-
-`host-prepare` provisions the Docker backing store itself as a native ZFS dataset on the fast pool
-(`<fast_pool>/<docker_dataset_name>`, default `fast/docker`) mounted directly at the `data-root`,
-with `storage-driver: zfs` in `daemon.json`, **but only once the fast pool (and, on a local ZFS
-cold tier, the slow pool too) actually exist**. If the zpool(s) aren't there yet — e.g. this is a
-brand-new node and disks/zpools haven't been provisioned — `host-prepare` just installs Docker on
-its plain default backing store instead of failing outright; `lab-agent doctor` accepts that as
-expected until the pools show up (it already reports them missing separately). Docker's zfs driver
-clones the dataset per image layer and per container, so a configured `rootfs_quota`
-(`--storage-opt size=`) is enforced via ZFS's own `quota` property on each container's clone — no
-XFS, no zvol, no `/etc/fstab` entry to maintain. The dataset itself is capped by `docker_quota_gb`
-(default 1024 GiB; `0` = unlimited, sharing the rest of the fast pool). Unlike a zvol this is a
-**live** property: change `docker_quota_gb` and re-run `host-prepare` to resize immediately, with
-no unmount or reboot.
-
-Whenever the dataset doesn't exist yet and the data-root already has content — a fresh docker-ce
-install's just-created default state, or a data-root Docker has genuinely been running against
-under the plain backing store because the zpool(s) only just appeared — that content is moved
-aside, the dataset is created at the same mountpoint, and the content is copied back into it before
-the backup is removed. Nothing is discarded and nothing is left duplicated on the old filesystem.
-
-Once the fast (and, if applicable, slow) pool(s) exist, the doctor rejects any storage driver other
-than `zfs`; before that it accepts whatever Docker's plain install picked.
-
-If cold storage is SMB, mount the owner node's `/cold-storage` tree at `/cold-storage` on the client
-(the configurable `slow_path`) before starting the agent. Thus the owner path
-`/cold-storage/<lab>` and client path `/cold-storage/<lab>` are two views of the exact same backing
-directory. The share must preserve numeric POSIX ownership and permit `chown`; an absent mount is a
-hard failure and the agent never creates a local fallback directory. Owner and client must report
-the same `userns_start` and `userns_size`, or the controller rejects the SMB placement.
-
-Install the agent, edit its config, then converge host security and Docker configuration:
-
-```bash
-cd agent
-sudo python3 -m pip install .
-sudo lab-agent install
-sudo lab-agent edit-config
-sudo lab-agent host-prepare
-```
-
-`host-prepare` is idempotent and does all of the following:
-
-- installs Docker Engine (from Docker's official apt repo), `zfsutils-linux`, and AppArmor tooling
-  if missing — a fully unprovisioned node needs nothing pre-installed but the OS itself; on an
-  already-provisioned node this step is a handful of fast `dpkg` checks and touches the network
-  only when something is actually missing;
-- installs `nvidia-container-toolkit` (from NVIDIA's official apt repo) when it detects NVIDIA GPU
-  hardware and the package isn't already present — it never installs the NVIDIA driver itself;
-- reserves the `labdockremap` account and its exact `/etc/subuid` and `/etc/subgid` range (kept
-  stable for the cross-node cold-storage numeric mapping; the daemon no longer consumes it — see
-  below);
-- once the fast (and, if applicable, slow) zpool(s) exist, provisions the
-  `<fast_pool>/<docker_dataset_name>` ZFS dataset, mounts it at the `data-root` (migrating in any
-  existing content first), and applies `docker_quota_gb` as a live ZFS quota — otherwise leaves
-  Docker on its plain default backing store;
-- writes Docker `data-root` and **removes any `userns-remap`** an earlier agent set (labs run
-  `--userns=host`, so a remapped daemon adds no containment but chowns the image's setuid
-  `passwd`/`sudo` to the subordinate base UID, breaking them inside the lab — see below), adds
-  `storage-driver=zfs` once the dataset above is in use, and on GPU nodes pins
-  `exec-opts: ["native.cgroupdriver=cgroupfs"]` to work around a
-  [known runc/systemd-cgroup-driver bug](https://github.com/opencontainers/runc/discussions/1133)
-  that drops a container's GPU device access on `systemctl daemon-reload`, then restarts Docker;
-- enforces `kernel.unprivileged_userns_clone=1`, `user.max_user_namespaces=16384`, and
-  `kernel.apparmor_restrict_unprivileged_userns=1`;
-- installs and loads the existing `lab-codex-seccomp.json`, `lab-codex`, and distribution
-  `bwrap-userns-restrict` profile when available;
-- restores root ownership and setuid mode (`4755`) on `/usr/bin/bwrap` in running managed labs;
-- regenerates NVIDIA CDI at `/etc/cdi/nvidia.yaml` when `nvidia-ctk` is installed.
-
-Seccomp policy is fixed when Docker creates a container. If an agent upgrade changes
-`lab-codex-seccomp.json`, run `host-prepare` and recreate each existing placement; restarting its
-container does not apply the new policy. `lab-agent doctor` reports containers whose stamped
-profile digest differs from the installed profile.
-
-Managed labs also use Docker's `systempaths=unconfined` creation option. Docker's default masked
-and read-only submounts below `/proc` make Linux reject the fresh procfs mount required by an
-unprivileged bubblewrap PID namespace. Managed containers pair this with `apparmor=unconfined`;
-the dedicated seccomp profile and restricted mounts remain active. Existing containers must be
-recreated after this contract changes; doctor reports stale system paths as
-`container_systempaths_stale` and missing setuid-bubblewrap capabilities as
-`container_bwrap_caps_stale`.
-
-Managed labs run with `--userns=host` (the initial user namespace). Bubblewrap needs it: under a
-remapped namespace Linux locks the inherited root mount and bubblewrap fails at `make / slave`
-before it can construct its sandbox. Because every lab opts out of remapping this way, the daemon
-must **not** enable `userns-remap` at all — a remapped daemon unpacks the image into a remapped
-graph store and chowns every file (including setuid `/usr/bin/passwd` and `/usr/bin/sudo`) to the
-subordinate base UID, so under `--userns=host` those binaries elevate to that unprivileged UID
-instead of real root and fail with "Authentication token manipulation error" (`passwd`) or a setuid
-complaint (`sudo`). `lab-agent doctor` flags a still-remapped daemon as a critical `docker_userns`
-issue; the fix is to re-run `host-prepare` and recreate placements. Students start unprivileged;
-each has a real sudo rule that requires their assigned password. Seccomp, the absence of Docker's
-socket, and the restricted bind mounts are the outer boundary. Migrating an
-already-remapped node requires recreating each placement, because the images and container layers
-live in the remapped graph store and persistent ownership moves from remapped IDs to the stable
-student IDs (the ZFS-backed `/home` and `/cold-storage` data is untouched).
-
-Inspect the resulting Docker settings before accepting work:
-
-```bash
-docker info --format '{{json .SecurityOptions}}'
-sudo cat /etc/docker/daemon.json
-sudo aa-status | grep lab-codex
-sysctl kernel.unprivileged_userns_clone user.max_user_namespaces \
-  kernel.apparmor_restrict_unprivileged_userns
-```
-
-Nodes are dedicated to managed labs: `host-prepare` sets daemon-wide Docker, AppArmor, and sysctl
-policy, and the security model assumes only agent-created containers run on the node.
-
-## 2. Get the lab image
+## Get the lab image
 
 The default image is `ghcr.io/ec061/custom-ssh:latest`, built and pushed by the `Build lab image`
 GitHub Actions workflow (`image/Dockerfile`) on every merge to main. The agent pulls it before every
@@ -177,7 +70,7 @@ curl, and proc tools. Large optional CUDA math libraries, profilers, documentati
 excluded. It intentionally contains no Node.js, npm, Codex, systemd, Docker packages, daemon
 configuration, socket, or inner NVIDIA container runtime.
 
-## 3. Start and validate the node
+## Start and validate the node
 
 ```bash
 sudo lab-agent start
@@ -196,14 +89,14 @@ nvcc --version
 Doctor executes that exact bwrap smoke test and `nvcc --version` as a provisioned ordinary student.
 Managed labs enforce root ownership and setuid mode (`4755`) on `/usr/bin/bwrap`, and run with
 `--security-opt apparmor=unconfined` plus `SYS_ADMIN`, `NET_ADMIN`, and `SYS_PTRACE`, which the
-setuid bubblewrap code requires while constructing the nested sandbox. The dedicated seccomp
-profile remains enabled. `host-prepare` and `Repair` re-assert this bwrap mode; capability changes
+setuid bubblewrap code requires while constructing the nested sandbox. The dedicated seccomp profile
+remains enabled. `host-prepare` and `Repair` re-assert this bwrap mode; capability changes
 require container recreation.
 
 Also verify `nvidia-smi`, CUDA compilation, network namespace isolation, and that container root
 cannot modify a host sentinel outside `/home` and `/cold-storage`.
 
-## 4. Controller operations
+## Controller operations
 
 Run the controller normally, register each node, and create lab placements. The controller assigns
 every student a globally unique UID/GID from `10000-59999`; recreating a container preserves numeric

--- a/agent/README.md
+++ b/agent/README.md
@@ -11,11 +11,14 @@ idempotently converge student-directory ownership.
 Install and prepare a node:
 
 ```bash
-sudo python3 -m pip install .
-sudo lab-agent install
-sudo lab-agent edit-config
-sudo lab-agent host-prepare
-sudo lab-agent start
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+REPO="git+https://github.com/EC061/docker-mass-deployment.git#subdirectory=agent"
+
+sudo uvx --from "$REPO" lab-agent install
+sudo uvx --from "$REPO" lab-agent edit-config
+sudo uvx --from "$REPO" lab-agent host-prepare
+sudo uvx --from "$REPO" lab-agent start
 ```
 
 After a lab and student have been provisioned, run `sudo lab-agent doctor`. Health is critical if

--- a/agent/src/lab_agent/system.py
+++ b/agent/src/lab_agent/system.py
@@ -286,6 +286,38 @@ def _stale_bwrap_capability_containers() -> list[str]:
     return stale
 
 
+def _seccomp_enforcement_ok(container: str, user: str) -> bool:
+    """Verify the seccomp profile actually blocks denied syscalls.
+
+    Attempts keyctl(2) (syscall 248, not in the allow-list) via python3 ctypes inside the container
+    as the given user.  A correctly applied profile returns EPERM; an unconfined container succeeds.
+    """
+    script = (
+        "import ctypes, sys; libc = ctypes.CDLL('libc.so.6', use_errno=True); "
+        "ret = libc.syscall(248, 0, 0, 0, 0); "
+        "import os; sys.exit(0 if ctypes.get_errno() != 1 else 1)"
+    )
+    result = run([
+        "docker", "exec", "-u", user,
+        "-e", f"HOME=/home/{user}", "-e", f"USER={user}", "-e", f"LOGNAME={user}",
+        container, "python3", "-c", script,
+    ], timeout=30)
+    return result.ok
+
+
+def _apparmor_profile_ok(container: str) -> bool:
+    """Verify the container is confined by the lab-codex AppArmor profile.
+
+    Reads ``/proc/self/attr/current`` inside the container.  A confined process reports
+    ``lab-codex`` (possibly with ``enforce`` suffix); an unconfined container reports
+    ``unconfined``.
+    """
+    result = run([
+        "docker", "exec", container, "cat", "/proc/self/attr/current",
+    ], timeout=10)
+    return result.ok and "lab-codex" in result.stdout
+
+
 def _first_student_container() -> tuple[str, str] | None:
     listed = run([
         "docker", "ps", "--filter", "label=lab-agent.managed=true", "--format", "{{.Names}}"
@@ -437,6 +469,26 @@ def detect_capabilities(cfg: AgentConfig, *, deep: bool = True) -> Capabilities:
             ]
             raw_bwrap_ok = mode_ok and _student_command(target, bwrap_smoke)
             bwrap_ok = mode_ok and raw_bwrap_ok
+            seccomp_ok = bwrap_ok and _seccomp_enforcement_ok(target[0], target[1])
+            if bwrap_ok and not seccomp_ok:
+                _issue(
+                    issues,
+                    "seccomp_enforcement_failed",
+                    "critical",
+                    "Seccomp profile is applied but does not block denied syscalls; "
+                    "re-run host-prepare to refresh the profile",
+                    True,
+                )
+            apparmor_ok = bwrap_ok and _apparmor_profile_ok(target[0])
+            if bwrap_ok and not apparmor_ok:
+                _issue(
+                    issues,
+                    "apparmor_profile_missing",
+                    "critical",
+                    "Container is not confined by the lab-codex AppArmor profile; "
+                    "re-run host-prepare to reload the profile",
+                    True,
+                )
             cuda_ok = _student_command(target, ["nvcc", "--version"])
         else:
             _issue(

--- a/agent/tests/test_system.py
+++ b/agent/tests/test_system.py
@@ -192,6 +192,11 @@ def test_deep_doctor_accepts_bwrap_and_cuda_toolkit(monkeypatch):
         "docker exec lab-test stat -c %a /usr/bin/bwrap": (True, "4755"),
         "docker exec -u alice -e HOME=/home/alice -e USER=alice -e LOGNAME=alice lab-test bwrap":
             (True, "bwrap works"),
+        # Seccomp enforcement: keyctl returns EPERM (exit 0 in our script means blocked).
+        "docker exec -u alice -e HOME=/home/alice -e USER=alice -e LOGNAME=alice lab-test python3":
+            (True, ""),
+        # AppArmor: container is confined by lab-codex.
+        "docker exec lab-test cat /proc/self/attr/current": (True, "lab-codex (enforce)"),
         "docker exec -u alice -e HOME=/home/alice -e USER=alice -e LOGNAME=alice lab-test nvcc --version":
             (True, ""),
     })
@@ -208,6 +213,108 @@ def test_deep_doctor_accepts_bwrap_and_cuda_toolkit(monkeypatch):
     assert caps.runtime.cuda_toolkit_ok
     assert caps.health.status == "healthy"
     assert not any(i.code == "bubblewrap_failed" for i in caps.issues)
+    assert not any(i.code == "seccomp_enforcement_failed" for i in caps.issues)
+    assert not any(i.code == "apparmor_profile_missing" for i in caps.issues)
     assert any(command.endswith(
         "bwrap --ro-bind / / --dev /dev --proc /proc --unshare-pid -- echo bwrap works"
     ) for command in runner.calls)
+
+
+def test_seccomp_enforcement_failure_is_critical(monkeypatch):
+    runner = healthy_runner()
+    runner.responses.update({
+        'docker ps --filter label=lab-agent.managed=true --format {{.Names}}\t{{.Label "lab-agent.seccomp-sha256"}}':
+            (True, "lab-test\tcurrent\n"),
+        "docker ps --filter label=lab-agent.managed=true --format {{.Names}}": (True, "lab-test\n"),
+        "docker inspect --format {{json .HostConfig.MaskedPaths}}\t{{json .HostConfig.ReadonlyPaths}} lab-test":
+            (True, "[]\t[]"),
+        "docker inspect --format {{.HostConfig.UsernsMode}} lab-test": (True, "host"),
+        "docker inspect --format {{json .HostConfig.CapAdd}} lab-test":
+            (True, '["CAP_SYS_ADMIN","CAP_NET_ADMIN","CAP_SYS_PTRACE"]'),
+        "docker exec lab-test getent passwd": (True, "alice:x:10042:10042::/home/alice:/bin/bash\n"),
+        "docker exec lab-test stat -c %a /usr/bin/bwrap": (True, "4755"),
+        "docker exec -u alice -e HOME=/home/alice -e USER=alice -e LOGNAME=alice lab-test bwrap":
+            (True, "bwrap works"),
+        # Seccomp enforcement: keyctl succeeds (exit 1 = seccomp not working).
+        "docker exec -u alice -e HOME=/home/alice -e USER=alice -e LOGNAME=alice lab-test python3":
+            (False, ""),
+        "docker exec lab-test cat /proc/self/attr/current": (True, "lab-codex (enforce)"),
+        "docker exec -u alice -e HOME=/home/alice -e USER=alice -e LOGNAME=alice lab-test nvcc --version":
+            (True, ""),
+    })
+    monkeypatch.setattr(system, "run", runner)
+    monkeypatch.setattr(system.docker, "security_profile_digest", lambda path: "current")
+    monkeypatch.setattr(system.docker, "wait_ssh_ready", lambda container, **kwargs: True)
+    monkeypatch.setattr(system, "_security_profiles_ok", lambda cfg: True)
+    monkeypatch.setattr(system, "_subid_ok", lambda cfg: True)
+    monkeypatch.setattr(system, "_loaded_driver_version", lambda: "570.1")
+
+    caps = system.detect_capabilities(cfg(), deep=True)
+
+    assert caps.runtime.bwrap_ok
+    issue = next(i for i in caps.issues if i.code == "seccomp_enforcement_failed")
+    assert issue.severity == "critical"
+    assert issue.repairable is True
+
+
+def test_apparmor_profile_missing_is_critical(monkeypatch):
+    runner = healthy_runner()
+    runner.responses.update({
+        'docker ps --filter label=lab-agent.managed=true --format {{.Names}}\t{{.Label "lab-agent.seccomp-sha256"}}':
+            (True, "lab-test\tcurrent\n"),
+        "docker ps --filter label=lab-agent.managed=true --format {{.Names}}": (True, "lab-test\n"),
+        "docker inspect --format {{json .HostConfig.MaskedPaths}}\t{{json .HostConfig.ReadonlyPaths}} lab-test":
+            (True, "[]\t[]"),
+        "docker inspect --format {{.HostConfig.UsernsMode}} lab-test": (True, "host"),
+        "docker inspect --format {{json .HostConfig.CapAdd}} lab-test":
+            (True, '["CAP_SYS_ADMIN","CAP_NET_ADMIN","CAP_SYS_PTRACE"]'),
+        "docker exec lab-test getent passwd": (True, "alice:x:10042:10042::/home/alice:/bin/bash\n"),
+        "docker exec lab-test stat -c %a /usr/bin/bwrap": (True, "4755"),
+        "docker exec -u alice -e HOME=/home/alice -e USER=alice -e LOGNAME=alice lab-test bwrap":
+            (True, "bwrap works"),
+        "docker exec -u alice -e HOME=/home/alice -e USER=alice -e LOGNAME=alice lab-test python3":
+            (True, ""),
+        # AppArmor: container is NOT confined.
+        "docker exec lab-test cat /proc/self/attr/current": (True, "unconfined"),
+        "docker exec -u alice -e HOME=/home/alice -e USER=alice -e LOGNAME=alice lab-test nvcc --version":
+            (True, ""),
+    })
+    monkeypatch.setattr(system, "run", runner)
+    monkeypatch.setattr(system.docker, "security_profile_digest", lambda path: "current")
+    monkeypatch.setattr(system.docker, "wait_ssh_ready", lambda container, **kwargs: True)
+    monkeypatch.setattr(system, "_security_profiles_ok", lambda cfg: True)
+    monkeypatch.setattr(system, "_subid_ok", lambda cfg: True)
+    monkeypatch.setattr(system, "_loaded_driver_version", lambda: "570.1")
+
+    caps = system.detect_capabilities(cfg(), deep=True)
+
+    assert caps.runtime.bwrap_ok
+    issue = next(i for i in caps.issues if i.code == "apparmor_profile_missing")
+    assert issue.severity == "critical"
+    assert issue.repairable is True
+
+
+def test_seccomp_enforcement_ok_returns_true_on_blocked(monkeypatch):
+    monkeypatch.setattr(system, "run", lambda *a, **k: CommandResult(True, [], 0, "", ""))
+    assert system._seccomp_enforcement_ok("lab-test", "alice")
+
+
+def test_seccomp_enforcement_ok_returns_false_on_unconfined(monkeypatch):
+    monkeypatch.setattr(system, "run", lambda *a, **k: CommandResult(False, [], 1, "", ""))
+    assert not system._seccomp_enforcement_ok("lab-test", "alice")
+
+
+def test_apparmor_profile_ok_returns_true_when_confined(monkeypatch):
+    monkeypatch.setattr(
+        system, "run",
+        lambda *a, **k: CommandResult(True, [], 0, "lab-codex (enforce)\n", ""),
+    )
+    assert system._apparmor_profile_ok("lab-test")
+
+
+def test_apparmor_profile_ok_returns_false_when_unconfined(monkeypatch):
+    monkeypatch.setattr(
+        system, "run",
+        lambda *a, **k: CommandResult(True, [], 0, "unconfined\n", ""),
+    )
+    assert not system._apparmor_profile_ok("lab-test")


### PR DESCRIPTION
## What

Adds runtime enforcement tests for seccomp and AppArmor profiles that were previously only tested for configuration presence, never actual behavior.

## CI Enforcement Tests (.github/workflows/ci.yml)

**New step: AppArmor enforcement tests** — loads `lab-codex` profile on the CI runner kernel:
1. `/proc/sys` write denied by outer profile
2. `mount` denied by outer profile
3. Container shows `lab-codex` in `/proc/self/attr/current`
4. bwrap shows `lab-codex//lab-codex-bwrap` (Px → transition fires)
5. bwrap can mount inside its sandbox (inner profile grants mount)

**Extended: Seccomp denial tests** — 3 new negative tests:
1. `keyctl` (syscall 248) blocked by seccomp
2. `userfaultfd` (syscall 323) blocked by seccomp
3. `clone3` (syscall 435) allowed (bwrap needs it)

## Doctor Runtime Checks (system.py)

| Function | Checks | Issue |
|---|---|---|
| `_seccomp_enforcement_ok()` | Attempts `keyctl(2)` via python3 ctypes, expects EPERM | `seccomp_enforcement_failed` |
| `_apparmor_profile_ok()` | Reads `/proc/self/attr/current`, expects `lab-codex` | `apparmor_profile_missing` |

Both wired into `detect_capabilities(deep=True)` as critical + repairable.

## Unit Tests (test_system.py)

6 new tests covering the helper functions and deep doctor issue paths.