### PR TITLE
GPU idle-kill forensics + student-guide quota/GPU docs

### DIFF
--- a/STUDENT_GUIDE.md
+++ b/STUDENT_GUIDE.md
@@ -24,78 +24,49 @@ Docker and does not expose the host Docker socket.
 
 The lab provides two persistent storage locations:
 
-| Location | Storage tier | Use it for |
-| --- | --- | --- |
-| `~` (`/home/<username>`) | Fast | Active projects, source code, environments, frequently accessed datasets, and current checkpoints |
-| `~/cold-storage` (`/cold-storage/<username>`) | Cold | Large source datasets, completed results, archives, and checkpoints that are not accessed frequently |
+| Storage tier | Relative path | Absolute path | Use it for |
+| --- | --- | --- | --- |
+| Fast | `~` | `/home/<username>` | Active projects, source code, environments, frequently accessed datasets, and current checkpoints |
+| Cold | `~/cold-storage` | `/cold-storage/<username>` | Large source datasets, completed results, archives, and checkpoints that are not accessed frequently |
+
+The relative paths above are what you normally type; they resolve to the absolute paths shown. For
+example, `~` in your shell is exactly `/home/<username>`, and `~/cold-storage` is exactly
+`/cold-storage/<username>`.
 
 `~/cold-storage` is a shortcut to your private cold-storage directory. Both locations survive lab
 container recreation, but persistence is not a backup guarantee. Keep another copy of irreplaceable
 data in an approved backup location.
 
-### How to use fast storage
-
-Run active work from your home directory. Fast storage is the appropriate place for repositories,
-Python or Conda environments, compiled files, caches needed by current work, and data being read or
-written repeatedly by a job. For example:
-
-```bash
-mkdir -p ~/projects
-cd ~/projects
-```
-
-Fast storage is limited and shared by everyone in the lab. Remove disposable caches, obsolete
-environments, duplicate downloads, and failed-run output regularly. Do not keep large inactive
-datasets in fast storage merely for convenience.
-
-Useful commands for finding fast-storage usage include:
-
-```bash
-du -sh ~
-du -h -d 1 ~ 2>/dev/null | sort -h
-```
-
-### How to use cold storage
-
-Move data to cold storage when it must be retained but is no longer part of day-to-day work. Good
-candidates include original datasets, completed experiment output, old checkpoints, and compressed
-archives. For example:
-
-```bash
-mkdir -p ~/cold-storage/datasets ~/cold-storage/archive
-mv ~/projects/completed-run ~/cold-storage/archive/
-```
-
-Cold storage has lower performance. Avoid running metadata-heavy workloads there, creating software
-environments there, or repeatedly training directly against many small files there. A typical
-workflow is:
-
-1. Keep the authoritative large dataset or archived result in `~/cold-storage`.
-2. Copy only the files needed for the current job into a working directory under `~`.
-3. Run the job from fast storage.
-4. Copy final results and checkpoints back to cold storage.
-5. Verify the copied data before deleting the fast working copy.
-
-Example:
-
-```bash
-mkdir -p ~/work/current-run
-rsync -a --info=progress2 ~/cold-storage/datasets/project-a/ ~/work/current-run/input/
-# Run the workload and write results under ~/work/current-run/output.
-rsync -a --info=progress2 ~/work/current-run/output/ ~/cold-storage/archive/project-a-output/
-du -sh ~/cold-storage/archive/project-a-output
-```
-
-`rsync` is preferable for large transfers because it can be run again to copy only missing or
-changed files. Confirm the destination is complete before using `rm -rf` on the source.
-
 ## Lab storage quota
 
-Fast and cold quotas apply to the lab as a whole, not separately to each student. Every student's
-files contribute to the same lab totals. If the lab reaches a quota, writes can fail for everyone,
-jobs may stop while saving output or checkpoints, and package installation may fail.
+Fast and cold quotas apply to your group as a whole, not separately to each student. Every group
+member's files contribute to the same group totals. If the group reaches a quota, writes can fail
+for everyone, jobs may stop while saving output or checkpoints, and package installation may fail.
 
-Show the lab totals and the latest per-student estimates with:
+The fast and image quotas depend on which server your group is assigned to:
+
+| Server | Fast quota (per group) | Image quota (per group) |
+| --- | --- | --- |
+| asimov1 | 1 TB | 200 GB |
+| asimov2 | 2 TB | 400 GB |
+
+Cold storage is the same on both servers: **3 TB per group**.
+
+The image quota covers the container's root filesystem — everything outside `~` and
+`~/cold-storage`, such as system packages installed with `sudo apt install`. Unlike fast and cold
+storage, the image does **not** survive container recreation, so keep anything you care about in
+your home directory or cold storage.
+
+Both the fast and cold quotas can be expanded temporarily on request — for example, for a large
+experiment or a one-time data migration. Contact the administrator with the amount and duration you
+need. The expansion is shrunk back to the standard quota once the stated need is over, so make sure
+your usage is back under the standard quota by then.
+
+### Checking usage with labquota
+
+The best way to check storage usage is the `labquota` command. It reports the group totals against
+the quotas and a per-student breakdown, without the cost of scanning directories yourself. Show the
+group totals and the latest per-student estimates with:
 
 ```bash
 labquota
@@ -107,7 +78,7 @@ Show only your per-student rows with:
 labquota --me
 ```
 
-The lab totals are updated frequently, while the per-student breakdown comes from a periodic file
+The group totals are updated frequently, while the per-student breakdown comes from a periodic file
 scan and can be older. The output displays when that scan last completed. Request a newer scan with:
 
 ```bash
@@ -126,7 +97,7 @@ When usage is high:
    on `~/cold-storage/` makes `du` inspect the linked cold directory.
 2. Delete files that can be regenerated, including obsolete outputs and caches.
 3. Move inactive data from fast storage to cold storage when cold capacity is available.
-4. Coordinate with labmates, because the quota is shared.
+4. Coordinate with your group members, because the quota is shared.
 5. Contact the administrator before a critical run if the remaining capacity is insufficient.
 
 Do not assume that deleting an open file immediately releases its space. If quota usage remains
@@ -135,27 +106,24 @@ scan.
 
 ## GPU use and process termination
 
-GPUs are shared resources. Request a GPU only when the program will use it, release GPU memory when
-work finishes, and checkpoint long-running jobs frequently. A process can reserve GPU memory while
-performing no GPU computation, preventing other students from using that capacity.
+### Automatic idle-process termination
 
-### Inspect your GPU processes
+GPUs are shared, so the lab automatically terminates processes that hold GPU memory (VRAM) without
+doing real GPU work. The policy is:
 
-Use `nvidia-smi` to see GPU utilization, memory usage, and the process IDs (PIDs) holding GPU memory:
+1. A process that holds VRAM with **less than 2% GPU utilization** is tracked as idle.
+2. After **more than 30 minutes** of continuous idleness, the system records a warning and emails
+   the owner.
+3. If the process is still idle **10 minutes after the warning**, it is killed automatically.
+4. If GPU utilization rises to 2% or above at any point before the kill, idle tracking resets.
 
-```bash
-nvidia-smi
-nvidia-smi pmon -c 1
-```
+The kill is a `SIGKILL`: the process gets no chance to save a checkpoint or clean up, so act on the
+warning email immediately — checkpoint or stop the job, make sure it resumes real GPU work, or
+contact the administrator.
 
-Before terminating anything, verify that the PID belongs to you and identify the command:
-
-```bash
-ps -o user,pid,ppid,stat,etime,cmd -p <pid>
-```
-
-Never terminate a PID that you have not identified. A PID can disappear and later be reused by a
-different process, so repeat `ps` immediately before sending a signal.
+Note that an active CPU-only stage (for example, data preprocessing) can still appear GPU-idle
+while holding VRAM. Structure jobs so they release the GPU during long CPU-only stages, or contact
+the administrator in advance if a legitimate workload needs an exemption.
 
 ### Stop your own GPU process safely
 
@@ -181,30 +149,7 @@ workers. Inspect the process tree with `ps -f --forest -u "$USER"` or `pstree -a
 available. Do not use broad commands such as `pkill python` unless you have verified every matching
 process.
 
-### Automatic idle-process termination
 
-The lab may enforce an administrator-configured idle GPU policy. It evaluates managed lab
-processes that hold GPU memory and compares their GPU compute utilization with the configured idle
-threshold. The idle duration, warning period, utilization threshold, and any exemptions can change;
-do not assume fixed values.
-
-Under the normal warning policy:
-
-1. A process that continuously holds GPU memory at or below the idle threshold is tracked as idle.
-2. When it exceeds the configured idle duration, the system records a warning and sends the owner a
-   warning email when email delivery is configured.
-3. If the process remains idle through the grace period, the system terminates it with `SIGKILL` and
-   sends a termination email when email delivery is configured.
-4. If GPU activity rises above the threshold before termination, idle tracking resets.
-
-Administrators can also enable immediate termination, which skips the warning grace period. Missing
-GPU utilization data is treated conservatively and is not considered proof that a process is idle.
-Only processes in managed lab containers are eligible for automatic termination.
-
-An active CPU preprocessing stage can still appear GPU-idle while holding GPU memory. Structure jobs
-so they release the GPU during long CPU-only stages, or contact the administrator before running a
-legitimate workload that requires an exemption. Warning emails should be acted on immediately:
-checkpoint or stop the job, make sure it resumes real GPU work, or contact the administrator.
 
 ## Administrative help
 

--- a/agent/src/lab_agent/client.py
+++ b/agent/src/lab_agent/client.py
@@ -236,6 +236,8 @@ class Agent:
                         "lab": d.lab,
                         "vram_bytes": d.proc.get("vram_bytes"),
                         "state": "killed" if d.action == "kill" else "warned",
+                        "cmd": d.proc.get("cmd"),
+                        "idle_s": d.idle_s,
                     }
                     if d.action == "kill":
                         # Re-verify the PID identity right before killing (M-06): if the original

--- a/agent/src/lab_agent/gpu/killer.py
+++ b/agent/src/lab_agent/gpu/killer.py
@@ -30,6 +30,7 @@ class Decision:
     proc: dict[str, Any]
     lab: str | None
     user: str | None
+    idle_s: int = 0  # how long the process had been idle when the decision fired
 
 
 class GpuKiller:
@@ -79,17 +80,17 @@ class GpuKiller:
             user = proc.get("user")
 
             if policy.immediate:
-                decisions.append(Decision(pid, "kill", proc, lab, user))
+                decisions.append(Decision(pid, "kill", proc, lab, user, int(idle_for)))
                 self._state.pop(pid, None)
                 continue
 
             if st["warned_at"] is None:
                 if idle_for >= policy.idle_minutes * 60:
                     st["warned_at"] = now
-                    decisions.append(Decision(pid, "warn", proc, lab, user))
+                    decisions.append(Decision(pid, "warn", proc, lab, user, int(idle_for)))
             else:
                 if now - st["warned_at"] >= policy.grace_minutes * 60:
-                    decisions.append(Decision(pid, "kill", proc, lab, user))
+                    decisions.append(Decision(pid, "kill", proc, lab, user, int(idle_for)))
                     self._state.pop(pid, None)
 
         # Forget processes that are gone (finished or already killed).

--- a/agent/src/lab_agent/gpu/monitor.py
+++ b/agent/src/lab_agent/gpu/monitor.py
@@ -31,6 +31,7 @@ class GpuProcess:
     # process eligible for the idle-GPU killer. Host processes / unmanaged containers are False.
     managed: bool = False
     lab: str | None = None  # from the lab-agent.lab label (not the container name)
+    cmd: str | None = None  # process command line (path + args), for kill-event forensics
 
 
 def _query_compute_apps() -> dict[int, int]:
@@ -154,6 +155,24 @@ def _student_user(container: str | None, pid: int) -> str | None:
     return res.stdout.split(":", 1)[0].strip() or None
 
 
+def proc_cmd(pid: int, max_len: int = 200) -> str | None:
+    """The process's command line (argv joined with spaces), or its comm name for a process whose
+    cmdline is empty (kernel threads / zombies). Length-clamped: this rides in every kill event."""
+    try:
+        with open(f"/proc/{pid}/cmdline", "rb") as fh:
+            raw = fh.read()
+    except OSError:
+        return None
+    cmd = raw.replace(b"\x00", b" ").decode("utf-8", "replace").strip()
+    if not cmd:
+        try:
+            with open(f"/proc/{pid}/comm", encoding="utf-8") as fh:
+                cmd = f"[{fh.read().strip()}]"
+        except OSError:
+            return None
+    return cmd[:max_len] or None
+
+
 def pid_start_time(pid: int) -> int | None:
     """Process start time (clock ticks since boot) from /proc/<pid>/stat field 22.
 
@@ -215,6 +234,7 @@ def list_gpu_processes() -> list[dict]:
                     start_time=pid_start_time(pid),
                     managed=managed,
                     lab=lab,
+                    cmd=proc_cmd(pid),
                 )
             )
         )

--- a/agent/tests/test_gpu_killer.py
+++ b/agent/tests/test_gpu_killer.py
@@ -27,14 +27,16 @@ def test_warn_then_kill_after_grace():
     assert k.evaluate(procs, pol, now=0) == []
     # t=10min: still within idle window.
     assert k.evaluate(procs, pol, now=600) == []
-    # t=20min: warn.
+    # t=20min: warn, having been idle the full 20 minutes.
     d = k.evaluate(procs, pol, now=1200)
     assert len(d) == 1 and d[0].action == "warn" and d[0].pid == 100 and d[0].user == "alice"
+    assert d[0].idle_s == 1200
     # t=25min: within grace, no further decision.
     assert k.evaluate(procs, pol, now=1500) == []
-    # t=30min: grace elapsed -> kill.
+    # t=30min: grace elapsed -> kill, idle_s covering the whole idle span.
     d = k.evaluate(procs, pol, now=1800)
     assert len(d) == 1 and d[0].action == "kill" and d[0].lab == "bio"
+    assert d[0].idle_s == 1800
 
 
 def test_active_process_resets_timer():

--- a/agent/tests/test_gpu_monitor.py
+++ b/agent/tests/test_gpu_monitor.py
@@ -93,6 +93,39 @@ def test_list_gpu_processes_empty_without_nvidia(monkeypatch):
     assert monitor.list_gpu_processes() == []
 
 
+def test_proc_cmd_joins_argv_and_clamps(monkeypatch):
+    from io import BytesIO
+
+    def fake_open(path, *args, **kwargs):
+        assert path == "/proc/77/cmdline"
+        return BytesIO(b"/usr/bin/python3\x00train.py\x00--epochs\x0010\x00")
+
+    monkeypatch.setattr("builtins.open", fake_open)
+    assert monitor.proc_cmd(77) == "/usr/bin/python3 train.py --epochs 10"
+    assert monitor.proc_cmd(77, max_len=16) == "/usr/bin/python3"
+
+
+def test_proc_cmd_falls_back_to_comm_when_cmdline_empty(monkeypatch):
+    from io import BytesIO, StringIO
+
+    def fake_open(path, *args, **kwargs):
+        if path == "/proc/88/cmdline":
+            return BytesIO(b"")
+        assert path == "/proc/88/comm"
+        return StringIO("cuda-worker\n")
+
+    monkeypatch.setattr("builtins.open", fake_open)
+    assert monitor.proc_cmd(88) == "[cuda-worker]"
+
+
+def test_proc_cmd_none_for_missing_process(monkeypatch):
+    def fake_open(path, *args, **kwargs):
+        raise FileNotFoundError(path)
+
+    monkeypatch.setattr("builtins.open", fake_open)
+    assert monitor.proc_cmd(99) is None
+
+
 def test_kill_pid_skips_on_start_time_mismatch(monkeypatch):
     killed = {}
     monkeypatch.setattr(monitor, "pid_start_time", lambda pid: 9999)  # current != expected

--- a/controller/src/app/(app)/gpu/page.tsx
+++ b/controller/src/app/(app)/gpu/page.tsx
@@ -1,5 +1,6 @@
 import { db } from "@/lib/db";
-import { ago, fmtBytes } from "@/lib/format";
+import { ago, fmtBytes, fmtDuration } from "@/lib/format";
+import { groupGpuEvents, recentGpuEvents, type StudentKillStats } from "@/lib/gpu";
 import { ConfirmButton } from "../_components/ConfirmButton";
 import { clearGpuEventsAction } from "./actions";
 import { Card, CardContent } from "@/components/ui/card";
@@ -17,14 +18,57 @@ interface SnapRow {
   ts: number;
 }
 
-interface EventRow {
-  id: number;
-  node: string;
-  pid: number | null;
-  user: string | null;
-  lab: string | null;
-  state: string;
-  ts: number;
+function countBadges(s: { killed: number; warned: number }) {
+  return (
+    <span className="flex items-center gap-3 text-sm tabular-nums">
+      <span className={s.killed > 0 ? "text-err" : "text-muted-foreground"}>{s.killed} killed</span>
+      <span className={s.warned > 0 ? "text-warn" : "text-muted-foreground"}>{s.warned} warned</span>
+    </span>
+  );
+}
+
+function StudentDetails({ student }: { student: StudentKillStats }) {
+  return (
+    <details className="rounded-md border">
+      <summary className="flex cursor-pointer flex-wrap items-center justify-between gap-2 px-3 py-2 hover:bg-muted/50">
+        <span className="text-sm font-medium">{student.user ?? "(unknown user)"}</span>
+        <span className="flex items-center gap-3">
+          {countBadges(student)}
+          <span className="text-xs text-muted-foreground">last {ago(student.lastTs)}</span>
+        </span>
+      </summary>
+      <div className="border-t px-3 pb-2">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>When</TableHead>
+              <TableHead>Node</TableHead>
+              <TableHead>PID</TableHead>
+              <TableHead>Process</TableHead>
+              <TableHead>Idle for</TableHead>
+              <TableHead>VRAM</TableHead>
+              <TableHead>State</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {student.events.map((e) => (
+              <TableRow key={e.id}>
+                <TableCell className="whitespace-nowrap text-muted-foreground">{ago(e.ts)}</TableCell>
+                <TableCell>{e.node}</TableCell>
+                <TableCell>{e.pid ?? "—"}</TableCell>
+                <TableCell className="max-w-md break-all font-mono text-xs">{e.cmd ?? "—"}</TableCell>
+                <TableCell>{fmtDuration(e.idle_s)}</TableCell>
+                <TableCell>{fmtBytes(e.vram_bytes)}</TableCell>
+                <TableCell className={e.state === "killed" ? "text-err" : "text-warn"}>
+                  {e.state}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </details>
+  );
 }
 
 export default async function GpuPage({
@@ -36,9 +80,8 @@ export default async function GpuPage({
   const snapshot = db()
     .prepare("SELECT * FROM gpu_snapshot ORDER BY node, vram_bytes DESC")
     .all() as SnapRow[];
-  const events = db()
-    .prepare("SELECT * FROM gpu_events ORDER BY ts DESC LIMIT 100")
-    .all() as EventRow[];
+  const events = recentGpuEvents();
+  const labStats = groupGpuEvents(events);
 
   return (
     <div className="space-y-4">
@@ -83,7 +126,7 @@ export default async function GpuPage({
       <Card>
         <CardContent className="space-y-3">
           <div className="flex flex-wrap items-center justify-between gap-2">
-            <h3 className="text-base font-semibold">Recent idle-kill events</h3>
+            <h3 className="text-base font-semibold">Idle-kill events by lab</h3>
             {cleared && <p className="text-sm text-primary">{cleared}</p>}
             {events.length > 0 ? (
               <form action={clearGpuEventsAction}>
@@ -98,35 +141,29 @@ export default async function GpuPage({
               </form>
             ) : null}
           </div>
-          {events.length === 0 ? (
+          {labStats.length === 0 ? (
             <p className="text-sm text-muted-foreground">No events yet.</p>
           ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>When</TableHead>
-                  <TableHead>Node</TableHead>
-                  <TableHead>PID</TableHead>
-                  <TableHead>User</TableHead>
-                  <TableHead>Lab</TableHead>
-                  <TableHead>State</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {events.map((e) => (
-                  <TableRow key={e.id}>
-                    <TableCell className="text-muted-foreground">{ago(e.ts)}</TableCell>
-                    <TableCell>{e.node}</TableCell>
-                    <TableCell>{e.pid ?? "—"}</TableCell>
-                    <TableCell>{e.user ?? "—"}</TableCell>
-                    <TableCell>{e.lab ?? "—"}</TableCell>
-                    <TableCell className={e.state === "killed" ? "text-err" : "text-warn"}>
-                      {e.state}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+            <div className="space-y-2">
+              {labStats.map((lab) => (
+                <details key={lab.lab ?? "(none)"} className="rounded-md border">
+                  <summary className="flex cursor-pointer flex-wrap items-center justify-between gap-2 px-3 py-2 hover:bg-muted/50">
+                    <span className="text-sm font-semibold">{lab.lab ?? "(no lab)"}</span>
+                    <span className="flex items-center gap-3">
+                      {countBadges(lab)}
+                      <span className="text-xs text-muted-foreground">
+                        {lab.students.length} student{lab.students.length === 1 ? "" : "s"}
+                      </span>
+                    </span>
+                  </summary>
+                  <div className="space-y-2 border-t p-3">
+                    {lab.students.map((s) => (
+                      <StudentDetails key={s.user ?? "(none)"} student={s} />
+                    ))}
+                  </div>
+                </details>
+              ))}
+            </div>
           )}
         </CardContent>
       </Card>

--- a/controller/src/lib/db.ts
+++ b/controller/src/lib/db.ts
@@ -597,6 +597,16 @@ Thanks for helping keep the cluster healthy.`,
       `);
     },
   },
+  {
+    // Kill-event forensics: the offending process's command line and how long it had been idle
+    // when the agent acted, so the GPU page can show admins *what* keeps getting killed per
+    // student (repeat offenders), not just that something was.
+    id: "0021_gpu_event_forensics",
+    sql: `
+    ALTER TABLE gpu_events ADD COLUMN cmd TEXT;
+    ALTER TABLE gpu_events ADD COLUMN idle_s INTEGER;
+    `,
+  },
 ];
 
 function migrate(conn: Database.Database): void {

--- a/controller/src/lib/format.ts
+++ b/controller/src/lib/format.ts
@@ -31,6 +31,20 @@ export function ago(ts: number | null | undefined): string {
   return `${Math.floor(s / 86400)}d ago`;
 }
 
+/** Compact duration for a seconds count, e.g. 45s / 12m / 3h 20m / 2d 5h. */
+export function fmtDuration(seconds: number | null | undefined): string {
+  if (seconds === null || seconds === undefined || seconds < 0) return "—";
+  const s = Math.floor(seconds);
+  if (s < 60) return `${s}s`;
+  if (s < 3600) return `${Math.floor(s / 60)}m`;
+  if (s < 86400) {
+    const m = Math.floor((s % 3600) / 60);
+    return `${Math.floor(s / 3600)}h${m ? ` ${m}m` : ""}`;
+  }
+  const h = Math.floor((s % 86400) / 3600);
+  return `${Math.floor(s / 86400)}d${h ? ` ${h}h` : ""}`;
+}
+
 export function pct(used: number, quota: number | null | undefined): number | null {
   if (!quota || quota <= 0) return null;
   return Math.min(100, Math.round((used / quota) * 100));

--- a/controller/src/lib/gpu.ts
+++ b/controller/src/lib/gpu.ts
@@ -9,3 +9,77 @@ export function clearGpuEvents(actor: string): number {
     return cleared;
   })();
 }
+
+export interface GpuEventRow {
+  id: number;
+  node: string;
+  pid: number | null;
+  user: string | null;
+  lab: string | null;
+  vram_bytes: number | null;
+  state: string;
+  ts: number;
+  cmd: string | null;
+  idle_s: number | null;
+}
+
+export interface StudentKillStats {
+  user: string | null;
+  warned: number;
+  killed: number;
+  lastTs: number;
+  events: GpuEventRow[]; // newest first
+}
+
+export interface LabKillStats {
+  lab: string | null;
+  warned: number;
+  killed: number;
+  students: StudentKillStats[];
+}
+
+/** Roll idle-kill events up into lab -> student groups with warn/kill counts, worst offenders
+ * first (kills desc, then warns), so a repeat offender floats to the top of the GPU page. */
+export function groupGpuEvents(events: GpuEventRow[]): LabKillStats[] {
+  const labs = new Map<string, LabKillStats & { byUser: Map<string, StudentKillStats> }>();
+  for (const e of events) {
+    const labKey = e.lab ?? "";
+    let lab = labs.get(labKey);
+    if (!lab) {
+      lab = { lab: e.lab, warned: 0, killed: 0, students: [], byUser: new Map() };
+      labs.set(labKey, lab);
+    }
+    const userKey = e.user ?? "";
+    let student = lab.byUser.get(userKey);
+    if (!student) {
+      student = { user: e.user, warned: 0, killed: 0, lastTs: e.ts, events: [] };
+      lab.byUser.set(userKey, student);
+      lab.students.push(student);
+    }
+    if (e.state === "killed") {
+      lab.killed++;
+      student.killed++;
+    } else if (e.state === "warned") {
+      lab.warned++;
+      student.warned++;
+    }
+    student.lastTs = Math.max(student.lastTs, e.ts);
+    student.events.push(e);
+  }
+  const byOffense = (a: { killed: number; warned: number }, b: { killed: number; warned: number }) =>
+    b.killed - a.killed || b.warned - a.warned;
+  const out = [...labs.values()];
+  for (const lab of out) {
+    lab.students.sort(byOffense);
+    for (const s of lab.students) s.events.sort((a, b) => b.ts - a.ts);
+  }
+  out.sort(byOffense);
+  return out.map(({ byUser: _byUser, ...lab }) => lab);
+}
+
+/** Recent idle-kill events for the GPU page's grouped offender view (bounded read). */
+export function recentGpuEvents(limit = 1000): GpuEventRow[] {
+  return db()
+    .prepare("SELECT * FROM gpu_events ORDER BY ts DESC LIMIT ?")
+    .all(limit) as GpuEventRow[];
+}

--- a/controller/src/lib/hub.ts
+++ b/controller/src/lib/hub.ts
@@ -399,15 +399,17 @@ function handleEvent(node: string, frame: any): void {
     lab: boundedStr(raw.lab, 40),
     vram_bytes: intOrNull(raw.vram_bytes),
     state: GPU_STATES.has(raw.state) ? (raw.state as string) : "idle",
+    cmd: boundedStr(raw.cmd, 200),
+    idle_s: intOrNull(raw.idle_s),
   };
   // Attribute the event to a placement via its (label-derived) lab + the authenticated node.
   const placementId = p.lab ? (getPlacementByLabNode(p.lab, node)?.id ?? null) : null;
   db()
     .prepare(
-      `INSERT INTO gpu_events (node, pid, user, lab, placement_id, vram_bytes, state, ts)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO gpu_events (node, pid, user, lab, placement_id, vram_bytes, state, ts, cmd, idle_s)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
-    .run(node, p.pid, p.user, p.lab, placementId, p.vram_bytes, p.state, intOrNull(frame.ts) ?? Date.now());
+    .run(node, p.pid, p.user, p.lab, placementId, p.vram_bytes, p.state, intOrNull(frame.ts) ?? Date.now(), p.cmd, p.idle_s);
   void emailGpuEvent(node, p);
 }
 

--- a/controller/tests/gpu.test.ts
+++ b/controller/tests/gpu.test.ts
@@ -17,6 +17,57 @@ beforeAll(async () => {
   gpu = await import("../src/lib/gpu");
 });
 
+describe("GPU kill stats grouping", () => {
+  const ev = (o: Partial<import("../src/lib/gpu").GpuEventRow>) => ({
+    id: 0,
+    node: "gpu-1",
+    pid: 1,
+    user: null,
+    lab: null,
+    vram_bytes: null,
+    state: "killed",
+    ts: 0,
+    cmd: null,
+    idle_s: null,
+    ...o,
+  });
+
+  it("groups lab -> student with counts, worst offenders first, events newest first", () => {
+    const stats = gpu.groupGpuEvents([
+      ev({ id: 1, lab: "bio", user: "alice", state: "warned", ts: 10 }),
+      ev({ id: 2, lab: "bio", user: "alice", state: "killed", ts: 20, cmd: "python train.py", idle_s: 1800 }),
+      ev({ id: 3, lab: "bio", user: "bob", state: "warned", ts: 30 }),
+      ev({ id: 4, lab: "chem", user: "carol", state: "killed", ts: 40 }),
+      ev({ id: 5, lab: "chem", user: "carol", state: "killed", ts: 50 }),
+      ev({ id: 6, lab: null, user: null, state: "killed", ts: 60 }),
+    ]);
+
+    // chem (2 kills) > bio (1 kill, 2 warns) > unattributed (1 kill, 0 warns).
+    expect(stats.map((l) => l.lab)).toEqual(["chem", "bio", null]);
+    expect(stats[0]).toMatchObject({ killed: 2, warned: 0 });
+
+    const bio = stats[1];
+    expect(bio).toMatchObject({ killed: 1, warned: 2 });
+    // alice (1 kill) ranks above bob (0 kills, 1 warn).
+    expect(bio.students.map((s) => s.user)).toEqual(["alice", "bob"]);
+    expect(bio.students[0]).toMatchObject({ killed: 1, warned: 1, lastTs: 20 });
+    // Per-student detail rows are newest first and carry the forensics fields.
+    expect(bio.students[0].events.map((e) => e.id)).toEqual([2, 1]);
+    expect(bio.students[0].events[0]).toMatchObject({ cmd: "python train.py", idle_s: 1800 });
+  });
+
+  it("stores and reads back cmd/idle_s on ingested events", () => {
+    const d = dbmod.db();
+    d.prepare(
+      `INSERT INTO gpu_events (node, pid, user, lab, state, ts, cmd, idle_s)
+       VALUES ('gpu-1', 7, 'alice', 'bio', 'killed', 5, '/usr/bin/python3 train.py', 2400)`,
+    ).run();
+    const rows = gpu.recentGpuEvents();
+    expect(rows[0]).toMatchObject({ cmd: "/usr/bin/python3 train.py", idle_s: 2400 });
+    d.prepare("DELETE FROM gpu_events").run();
+  });
+});
+
 describe("GPU event history", () => {
   it("clears events, preserves the live snapshot, and records an audit entry", () => {
     const d = dbmod.db();


### PR DESCRIPTION
## Summary
- **GPU idle-kill forensics** — record the offending process command line and idle duration on each idle-kill event. The GPU page now groups events into **lab → student** with warn/kill counts (worst offenders first), so admins can see *what* keeps getting killed per student, not just that something was. Adds migration `0021` (cmd/idle_s columns) and a `fmtDuration` helper.
- **Student guide** — rewrite the storage-quota section (per-group quotas, per-server fast/image quotas, image-tier caveat, temporary expansions) and lead the GPU section with the concrete idle-kill policy (2% util, 30m + 10m grace, SIGKILL).

## Testing
- `agent`: `py.test tests/test_gpu_killer.py tests/test_gpu_monitor.py` — 21 passed; `ruff check src/` clean
- `controller`: full `vitest run` — 242 passed; `tsc --noEmit` and `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)