### PR TITLE
chore(dependabot): ignore ubuntu major bumps for lab image base

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,3 +59,10 @@ updates:
       - /image
     schedule:
       interval: weekly
+    # The lab image base (ubuntu) is deliberately pinned to the 24.04 LTS line;
+    # test_image_contract asserts ubuntu:24.04@sha256:. Do not offer major LTS
+    # bumps (e.g. 26.04) — they break the pinned-base contract. Digest/patch
+    # updates within 24.04 are still allowed.
+    ignore:
+      - dependency-name: "ubuntu"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
The lab image base is deliberately pinned to the 24.04 LTS line and `test_image_contract` asserts `ubuntu:24.04@sha256:`. The 24.04 → 26.04 bump (#93, now closed) broke that contract and failed the Agent CI job.

This ignores semver-major `ubuntu` updates for the docker ecosystem so Dependabot won't reopen the 26.04 bump. Digest/patch updates within the 24.04 line are still allowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)